### PR TITLE
MCFM-103 — School Tenant Isolation & UT Austin Launch

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -11,9 +11,7 @@ function isApexHost(host: string): boolean {
   const bare = host.split(":")[0].toLowerCase();
   return (
     bare === "mamuncofoundr.com" ||
-    bare === "www.mamuncofoundr.com" ||
-    bare === "localhost" ||
-    bare.endsWith(".vercel.app")
+    bare === "www.mamuncofoundr.com"
   );
 }
 
@@ -74,6 +72,20 @@ export async function GET(req: NextRequest) {
 
     const likedIds = likedProfiles?.map((like) => like.liked_id) || [];
 
+    // For any school tenant, restrict candidates to users who have completed
+    // school-specific onboarding (i.e. have a row in school_profiles for this
+    // org). Acts as the "verified school user" filter. Must be scoped by
+    // organization_id to avoid leaking cross-tenant existence.
+    const inSchoolTenant = !useGeneralPool && !!orgId;
+    let schoolUserIds: string[] | null = null;
+    if (inSchoolTenant) {
+      const { data: schoolRows } = await supabase
+        .from("school_profiles")
+        .select("user_id")
+        .eq("organization_id", orgId);
+      schoolUserIds = schoolRows?.map((r) => r.user_id) ?? [];
+    }
+
     // Fetch candidate profiles (excluding self, deleted, already liked)
     // Hard filter: candidates must belong to the same organization (or null for general pool)
     let query = supabase
@@ -86,6 +98,13 @@ export async function GET(req: NextRequest) {
       query = query.is("organization_id", null);
     } else {
       query = query.eq("organization_id", orgId);
+    }
+
+    if (schoolUserIds !== null) {
+      if (schoolUserIds.length === 0) {
+        return NextResponse.json({ profiles: [], currentUser });
+      }
+      query = query.in("user_id", schoolUserIds);
     }
 
     if (likedIds.length > 0) {
@@ -118,15 +137,50 @@ export async function GET(req: NextRequest) {
       .map((p) => p.user_id)
       .filter((id): id is string => Boolean(id));
 
-    // Fetch existing queue rows — only cycle is needed for ordering
+    // For school-tenant orgs: fetch school-specific fields from the unified
+    // school_profiles table and join them onto the profiles. Output keys stay
+    // as utStatus/utCollege/etc. so the dashboard and UT form components keep
+    // working without changes.
+    let enrichedFiltered = filtered;
+    if (inSchoolTenant && candidateIds.length > 0) {
+      const { data: schoolRows } = await supabase
+        .from("school_profiles")
+        .select("user_id, school_status, graduation_year, college, degree_type, major, sector_interests")
+        .eq("organization_id", orgId)
+        .in("user_id", candidateIds);
+
+      const schoolMap = new Map(
+        schoolRows?.map((row) => [
+          row.user_id,
+          {
+            utStatus: row.school_status,
+            gradYear: row.graduation_year,
+            utCollege: row.college,
+            utDegreeType: row.degree_type,
+            utMajor: row.major,
+            utSectorInterests: row.sector_interests,
+          },
+        ]) ?? [],
+      );
+
+      enrichedFiltered = filtered.map((profile) => {
+        const school = schoolMap.get(profile.user_id!);
+        return school ? { ...profile, ...school } : profile;
+      });
+    }
+
+    // Fetch existing queue rows — cycle, seen_at are needed for ordering and "New" badge
     const { data: queueRows } = await supabase
       .from("matching_queue")
-      .select("candidate_user_id, cycle")
+      .select("candidate_user_id, cycle, seen_at")
       .eq("viewer_user_id", userId)
       .in("candidate_user_id", candidateIds);
 
-    const queueMap = new Map<string, number>(
-      queueRows?.map((r) => [r.candidate_user_id, r.cycle as number]) ?? [],
+    const queueMap = new Map<string, { cycle: number; seenAt: string | null }>(
+      queueRows?.map((r) => [
+        r.candidate_user_id,
+        { cycle: r.cycle as number, seenAt: r.seen_at },
+      ]) ?? [],
     );
 
     // Ensure queue rows exist for any candidate not yet in the queue.
@@ -148,12 +202,15 @@ export async function GET(req: NextRequest) {
     }
 
     // Sort by: cycle asc (skipped profiles go to back) → score desc (best match first within same cycle)
-    const sorted = filtered
-      .map((profile) => ({
-        profile,
-        cycle: queueMap.get(profile.user_id!) ?? 0,
-        score: scoreCandidate(profile, currentUser),
-      }))
+    const sorted = enrichedFiltered
+      .map((profile) => {
+        const queueInfo = queueMap.get(profile.user_id!) ?? { cycle: 0, seenAt: null };
+        return {
+          profile: { ...profile, isNew: queueInfo.seenAt === null },
+          cycle: queueInfo.cycle,
+          score: scoreCandidate(profile, currentUser),
+        };
+      })
       .sort((a, b) => {
         if (a.cycle !== b.cycle) return a.cycle - b.cycle;
         return b.score - a.score;

--- a/src/app/api/profiles/seen/route.ts
+++ b/src/app/api/profiles/seen/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { candidate_user_id } = await request.json();
+
+    if (!candidate_user_id) {
+      return NextResponse.json(
+        { error: "candidate_user_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const { error } = await supabase
+      .from("matching_queue")
+      .update({ seen_at: new Date().toISOString() })
+      .eq("viewer_user_id", userId)
+      .eq("candidate_user_id", candidate_user_id)
+      .is("seen_at", null);
+
+    if (error) {
+      console.error("Error marking profile as seen:", error);
+      return NextResponse.json(
+        { error: "Failed to mark profile as seen" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in profile seen API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/ut-profile/route.ts
+++ b/src/app/api/ut-profile/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { mapOnboardingDatatoProfileDB } from "@/lib/mapProfileToFromDBFormat";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId, sessionClaims } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const orgId = sessionClaims?.metadata?.organization_id;
+    if (!orgId) {
+      return NextResponse.json(
+        { error: "organization_id missing on session — user is not associated with a school" },
+        { status: 400 },
+      );
+    }
+
+    const body: OnboardingData = await request.json();
+
+    if (!body) {
+      return NextResponse.json({ error: "Profile data is required" }, { status: 400 });
+    }
+
+    // School-tenant required field validation (server-side)
+    if (!body.utStatus) {
+      return NextResponse.json(
+        { error: "utStatus is required for school profiles" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    // Preserve existing pfp_url if not supplied
+    const { data: existingProfile } = await supabase
+      .from("profiles")
+      .select("pfp_url")
+      .eq("user_id", userId)
+      .single();
+
+    if (!body.pfp_url && !existingProfile?.pfp_url) {
+      return NextResponse.json(
+        { error: "Profile picture is required. Please upload a photo before continuing." },
+        { status: 400 },
+      );
+    }
+
+    // Compose education string from UT fields for the profiles table
+    const educationStr = [
+      body.utCollege,
+      body.gradYear ? `Class of ${body.gradYear}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ") || "UT Austin";
+
+    // Map shared fields, then override UT-unused required fields with safe defaults
+    const dbData = {
+      ...mapOnboardingDatatoProfileDB(body),
+      education: educationStr,
+      satisfaction: "Browsing" as const,
+      battery_level: "Energized" as const,
+    };
+
+    if (existingProfile?.pfp_url && !dbData.pfp_url) {
+      dbData.pfp_url = existingProfile.pfp_url;
+    }
+
+    // 1. Upsert shared profile fields
+    const { error: profileError } = await supabase
+      .from("profiles")
+      .upsert({ user_id: userId, ...dbData }, { onConflict: "user_id" });
+
+    if (profileError) {
+      console.error("Supabase profiles upsert error:", profileError);
+      return NextResponse.json(
+        { error: `Error saving profile: ${profileError.message}` },
+        { status: 500 },
+      );
+    }
+
+    // 2. Upsert school-specific fields. Persisted in the unified school_profiles
+    //    table; the request body keys (utStatus, utCollege, ...) are the
+    //    application-layer contract with the UT form components and are
+    //    translated to generic column names here.
+    const { error: schoolError } = await supabase
+      .from("school_profiles")
+      .upsert(
+        {
+          user_id: userId,
+          organization_id: orgId,
+          school_status: body.utStatus,
+          graduation_year: body.gradYear ?? null,
+          college: body.utCollege ?? null,
+          degree_type: body.utDegreeType ?? null,
+          major: body.utMajor ?? null,
+          sector_interests: body.utSectorInterests ?? null,
+          additional_education: body.additionalEducation ?? null,
+        },
+        { onConflict: "user_id" },
+      );
+
+    if (schoolError) {
+      console.error("Supabase school_profiles upsert error:", schoolError);
+      return NextResponse.json(
+        { error: `Error saving school profile: ${schoolError.message}` },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true, message: "School profile saved successfully" });
+  } catch (error) {
+    console.error("Error in UT profile upsert API:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,18 @@
   --mist-white: #fafaf9;
   --charcoal-black: #1c1c1c;
 
+  /* - semantic UI tokens (dark-mode defaults — overridden by school layout for light orgs) - */
+  --ui-text: #ffffff;
+  --ui-text-muted: rgba(255, 255, 255, 0.5);
+  --ui-text-subtle: rgba(255, 255, 255, 0.3);
+  --ui-border: rgba(255, 255, 255, 0.1);
+  --ui-border-strong: rgba(255, 255, 255, 0.2);
+  --ui-surface: rgba(255, 255, 255, 0.05);
+  --ui-surface-active: rgba(255, 255, 255, 0.15);
+  --ui-btn-bg: #ffffff;
+  --ui-btn-text: #000000;
+  --ui-popover-bg: #1a1a1a;
+
   /* - font sizes according to golden ratio typescale - */
   --heading-1: 17.942rem;
   --heading-2: 11.089rem;

--- a/src/app/onboarding/form-components/AboutYouForm.tsx
+++ b/src/app/onboarding/form-components/AboutYouForm.tsx
@@ -24,12 +24,12 @@ type AboutYouData = {
 };
 
 const TEXTAREA_CLS =
-  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 placeholder-white/30 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20 resize-none";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
-const LABEL_CLS = "text-xs font-semibold tracking-widest text-white/45 uppercase";
+const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 const PILL_RADIO_CLS =
-  "flex cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white transition-all duration-150 hover:border-white/20 hover:bg-white/8 has-[:checked]:border-white/40 has-[:checked]:bg-white/15 has-[:checked]:text-white";
+  "flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all duration-150 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)] has-[:checked]:text-[var(--ui-text)]";
 
 function AboutYouForm({
   onNext,
@@ -81,11 +81,11 @@ function AboutYouForm({
 
         {/* ── Header ── */}
         <div className="pb-4">
-          <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Step 2 of 6
           </p>
-          <h2 className="text-2xl font-bold text-white">About you</h2>
-          <p className="mt-1.5 text-sm text-white/50">
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">About you</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             Help potential co-founders understand who you are.
           </p>
         </div>
@@ -238,7 +238,7 @@ function AboutYouForm({
           <div className="flex items-start justify-between gap-3">
             <div>
               <label className={LABEL_CLS}>Founder Archetype *</label>
-              <p className="mt-1 text-xs leading-relaxed text-white/40">
+              <p className="mt-1 text-xs leading-relaxed text-[var(--ui-text-muted)]">
                 Which best describes your founding style?
               </p>
             </div>
@@ -246,7 +246,7 @@ function AboutYouForm({
               href="/founder-archetypes"
               target="_blank"
               rel="noopener noreferrer"
-              className="shrink-0 mt-0.5 text-xs text-white/35 underline-offset-2 transition-colors duration-150 hover:text-white/65 hover:underline"
+              className="shrink-0 mt-0.5 text-xs text-[var(--ui-text-subtle)] underline-offset-2 transition-colors duration-150 hover:text-[var(--ui-text-muted)] hover:underline"
             >
               Learn more ↗
             </a>
@@ -286,8 +286,8 @@ function AboutYouForm({
                 <span
                   className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-150 ${
                     archetypeValue === value
-                      ? "border-white bg-white"
-                      : "border-white/30 bg-transparent"
+                      ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                      : "border-[var(--ui-border-strong)] bg-transparent"
                   }`}
                 />
                 <span className="flex-1">{label}</span>
@@ -296,10 +296,10 @@ function AboutYouForm({
                   className="group/tip relative ml-auto flex items-center"
                   onClick={(e) => e.preventDefault()}
                 >
-                  <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-white/15 text-[10px] font-medium text-white/30 transition-colors duration-150 group-hover/tip:border-white/35 group-hover/tip:text-white/60">
+                  <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[10px] font-medium text-[var(--ui-text-subtle)] transition-colors duration-150 group-hover/tip:border-white/35 group-hover/tip:text-[var(--ui-text-muted)]">
                     i
                   </span>
-                  <span className="pointer-events-none absolute right-0 bottom-7 z-50 w-60 rounded-xl border border-white/10 bg-neutral-900 px-3.5 py-3 text-left text-xs leading-relaxed text-white/60 opacity-0 shadow-2xl transition-opacity duration-150 group-hover/tip:opacity-100">
+                  <span className="pointer-events-none absolute right-0 bottom-7 z-50 w-60 rounded-xl border border-[var(--ui-border)] bg-neutral-900 px-3.5 py-3 text-left text-xs leading-relaxed text-[var(--ui-text-muted)] opacity-0 shadow-2xl transition-opacity duration-150 group-hover/tip:opacity-100">
                     {tooltip}
                   </span>
                 </span>
@@ -328,8 +328,8 @@ function AboutYouForm({
                   <span
                     className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-150 ${
                       watch("satisfaction") === option
-                        ? "border-white bg-white"
-                        : "border-white/30 bg-transparent"
+                        ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                        : "border-[var(--ui-border-strong)] bg-transparent"
                     }`}
                   />
                   {option}
@@ -357,8 +357,8 @@ function AboutYouForm({
                     <span
                       className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-150 ${
                         watch("batteryLevel") === option
-                          ? "border-white bg-white"
-                          : "border-white/30 bg-transparent"
+                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                          : "border-[var(--ui-border-strong)] bg-transparent"
                       }`}
                     />
                     {option}
@@ -380,8 +380,8 @@ function AboutYouForm({
                   key={val}
                   className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
                     isTechnicalValue === val
-                      ? "border-white/40 bg-white/15 text-white"
-                      : "border-white/10 bg-white/5 text-white/50 hover:border-white/20 hover:text-white/70"
+                      ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                      : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
                   }`}
                 >
                   <input
@@ -401,17 +401,17 @@ function AboutYouForm({
         </div>
 
         {/* ── Navigation ── */}
-        <div className="flex items-center justify-between gap-4 pt-10 border-t border-white/8">
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-sm font-medium text-white/60 transition-all duration-200 hover:border-white/30 hover:text-white"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
           >
             ← Back
           </button>
           <button
             type="submit"
-            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-white/10 transition-all duration-200 hover:bg-white/90 active:scale-[0.98] sm:flex-none"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
           >
             Continue →
           </button>

--- a/src/app/onboarding/form-components/BackgroundAndSocialsForm.tsx
+++ b/src/app/onboarding/form-components/BackgroundAndSocialsForm.tsx
@@ -18,9 +18,9 @@ type BackgroundAndSocialsData = {
 };
 
 const TEXTAREA_CLS =
-  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 placeholder-white/30 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20 resize-none";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
-const LABEL_CLS = "text-xs font-semibold tracking-widest text-white/45 uppercase";
+const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 function BackgroundAndSocialsForm({
   onNext,
@@ -57,11 +57,11 @@ function BackgroundAndSocialsForm({
 
         {/* ── Header ── */}
         <div className="pb-4">
-          <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Step 4 of 6
           </p>
-          <h2 className="text-2xl font-bold text-white">Additional details</h2>
-          <p className="mt-1.5 text-sm text-white/50">
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">Additional details</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             All fields are optional — add what feels relevant.
           </p>
         </div>
@@ -105,7 +105,7 @@ function BackgroundAndSocialsForm({
           <div className="flex flex-col gap-y-1.5">
             <label className={LABEL_CLS}>
               Scheduling Link
-              <span className="ml-1 font-normal normal-case text-white/30">
+              <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
                 (Calendly, Cal.com…)
               </span>
             </label>
@@ -119,11 +119,11 @@ function BackgroundAndSocialsForm({
 
         {/* ── Section break ── */}
         <div className="flex items-center gap-3">
-          <div className="h-px flex-1 bg-white/8" />
-          <span className="text-xs font-semibold tracking-widest text-white/25 uppercase">
+          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+          <span className="text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
             Socials
           </span>
-          <div className="h-px flex-1 bg-white/8" />
+          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
         </div>
 
         {/* ── Social links: 2×2 grid ── */}
@@ -166,17 +166,17 @@ function BackgroundAndSocialsForm({
         </div>
 
         {/* ── Navigation ── */}
-        <div className="flex items-center justify-between gap-4 pt-10 border-t border-white/8">
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-sm font-medium text-white/60 transition-all duration-200 hover:border-white/30 hover:text-white"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
           >
             ← Back
           </button>
           <button
             type="submit"
-            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-white/10 transition-all duration-200 hover:bg-white/90 active:scale-[0.98] sm:flex-none"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
           >
             Continue →
           </button>

--- a/src/app/onboarding/form-components/InterestsAndValuesForm.tsx
+++ b/src/app/onboarding/form-components/InterestsAndValuesForm.tsx
@@ -7,9 +7,9 @@ import AIWriter from "@/components/ui/AIWriter";
 import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
 
 const TEXTAREA_CLS =
-  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 placeholder-white/30 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20 resize-none";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
-const LABEL_CLS = "text-xs font-semibold tracking-widest text-white/45 uppercase";
+const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 function InterestsAndValuesForm({
   onBack,
@@ -88,13 +88,13 @@ function InterestsAndValuesForm({
 
         {/* ── Header ── */}
         <div className="pb-4">
-          <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Step 5 of 6
           </p>
-          <h2 className="text-2xl font-bold text-white">
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">
             Interests &amp; values
           </h2>
-          <p className="mt-1.5 text-sm text-white/50">
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             What drives you and what you want to work on.
           </p>
         </div>
@@ -118,7 +118,7 @@ function InterestsAndValuesForm({
         <div className="flex flex-col gap-y-3">
           <div>
             <label className={LABEL_CLS}>MAMUN Priority Areas</label>
-            <p className="mt-1 text-xs text-white/35">
+            <p className="mt-1 text-xs text-[var(--ui-text-subtle)]">
               Select any that apply to your work.
             </p>
           </div>
@@ -130,8 +130,8 @@ function InterestsAndValuesForm({
                   key={area}
                   className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm transition-all duration-150 ${
                     checked
-                      ? "border-white/40 bg-white/15 text-white"
-                      : "border-white/10 bg-white/5 text-white/50 hover:border-white/20 hover:text-white/70"
+                      ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                      : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
                   }`}
                 >
                   <input
@@ -149,8 +149,8 @@ function InterestsAndValuesForm({
             <label
               className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm transition-all duration-150 ${
                 showOtherInput
-                  ? "border-white/40 bg-white/15 text-white"
-                  : "border-white/10 bg-white/5 text-white/50 hover:border-white/20 hover:text-white/70"
+                  ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                  : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
               }`}
             >
               <input
@@ -167,7 +167,7 @@ function InterestsAndValuesForm({
             <input
               type="text"
               placeholder="Please specify"
-              className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 placeholder-white/30 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20"
+              className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
               value={otherPriority}
               onChange={(e) => setOtherPriority(e.target.value)}
             />
@@ -191,17 +191,17 @@ function InterestsAndValuesForm({
         </div>
 
         {/* ── Navigation ── */}
-        <div className="flex items-center justify-between gap-4 pt-10 border-t border-white/8">
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-sm font-medium text-white/60 transition-all duration-200 hover:border-white/30 hover:text-white"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
           >
             ← Back
           </button>
           <button
             type="submit"
-            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-white/10 transition-all duration-200 hover:bg-white/90 active:scale-[0.98] sm:flex-none"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
           >
             Review →
           </button>

--- a/src/app/onboarding/form-components/ProfilePhotoForm.tsx
+++ b/src/app/onboarding/form-components/ProfilePhotoForm.tsx
@@ -11,7 +11,7 @@ const FaceDetectionUploader = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex animate-pulse items-center gap-2.5 text-white/40">
+      <div className="flex animate-pulse items-center gap-2.5 text-[var(--ui-text-muted)]">
         <svg
           className="h-4 w-4 animate-spin"
           xmlns="http://www.w3.org/2000/svg"
@@ -132,13 +132,13 @@ function ProfilePhotoForm({ onNext, defaultValues }: ProfilePhotoFormProps) {
       <div ref={fieldsRef} className="flex flex-col gap-y-8">
         {/* Header */}
         <div className="pb-4">
-          <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Step 1 of 6
           </p>
-          <h2 className="text-2xl font-bold text-white">
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">
             Add your profile photo
           </h2>
-          <p className="mt-1.5 text-sm text-white/50">
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             Our AI verifies it contains a real face to keep profiles authentic.
           </p>
         </div>
@@ -182,9 +182,9 @@ function ProfilePhotoForm({ onNext, defaultValues }: ProfilePhotoFormProps) {
 
         {/* Resume upload — optional, pre-fills Step 2 & 4 */}
         <div className="flex flex-col gap-y-2">
-          <p className="text-xs font-semibold tracking-widest text-white/45 uppercase">
+          <p className="text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Resume{" "}
-            <span className="font-normal normal-case text-white/30">
+            <span className="font-normal normal-case text-[var(--ui-text-subtle)]">
               (optional)
             </span>
           </p>
@@ -199,11 +199,11 @@ function ProfilePhotoForm({ onNext, defaultValues }: ProfilePhotoFormProps) {
         )}
 
         {/* Action */}
-        <div className="pt-10 border-t border-white/8">
+        <div className="pt-10 border-t border-[var(--ui-border)]">
           <button
             type="submit"
             disabled={isUploading || (!validatedPhotoFile && !uploadSuccess)}
-            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-white/10 transition-all duration-200 hover:bg-white/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto"
+            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto"
           >
             {isUploading ? (
               <>

--- a/src/app/onboarding/form-components/ReviewForm.tsx
+++ b/src/app/onboarding/form-components/ReviewForm.tsx
@@ -23,11 +23,11 @@ export default function ReviewForm({
     <div ref={fieldsRef} className="flex flex-col gap-y-8">
       {/* Header */}
       <div className="pb-4">
-        <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+        <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
           Step 6 of 6
         </p>
-        <h2 className="text-2xl font-bold text-white">Review your info</h2>
-        <p className="mt-1.5 text-sm text-white/50">
+        <h2 className="text-2xl font-bold text-[var(--ui-text)]">Review your info</h2>
+        <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
           Double-check everything before submitting.
         </p>
       </div>
@@ -151,16 +151,16 @@ export default function ReviewForm({
       </div>
 
       {/* Navigation */}
-      <div className="flex items-center justify-between gap-4 pt-10 border-t border-white/8">
+      <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
         <button
           onClick={onBack}
-          className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-sm font-medium text-white/60 transition-all duration-200 hover:border-white/30 hover:text-white"
+          className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
         >
           ← Back
         </button>
         <button
           onClick={onSubmit}
-          className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-emerald-500 px-8 py-3.5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/20 transition-all duration-200 hover:bg-emerald-400 active:scale-[0.98] sm:flex-none"
+          className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-emerald-500 px-8 py-3.5 text-sm font-semibold text-[var(--ui-text)] shadow-lg shadow-emerald-500/20 transition-all duration-200 hover:bg-emerald-400 active:scale-[0.98] sm:flex-none"
         >
           Confirm &amp; Submit ✓
         </button>
@@ -179,14 +179,14 @@ function Section({
   onEdit: () => void;
 }) {
   return (
-    <div className="rounded-xl border border-white/8 bg-white/4 p-4">
+    <div className="rounded-xl border border-[var(--ui-border)] bg-white/4 p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold tracking-wide text-white">
+        <h3 className="text-sm font-semibold tracking-wide text-[var(--ui-text)]">
           {title}
         </h3>
         <button
           onClick={onEdit}
-          className="cursor-pointer rounded-lg px-2.5 py-1 text-xs font-medium text-white/40 transition-all duration-150 hover:bg-white/8 hover:text-white"
+          className="cursor-pointer rounded-lg px-2.5 py-1 text-xs font-medium text-[var(--ui-text-muted)] transition-all duration-150 hover:bg-[var(--ui-surface)] hover:text-[var(--ui-text)]"
         >
           Edit
         </button>
@@ -194,8 +194,8 @@ function Section({
       <ul className="space-y-1.5">
         {fields.map((f, i) => (
           <li key={i} className="flex gap-2 text-sm">
-            <span className="w-36 shrink-0 text-white/40">{f.label}</span>
-            <span className="text-white/80">{f.value || "—"}</span>
+            <span className="w-36 shrink-0 text-[var(--ui-text-muted)]">{f.label}</span>
+            <span className="text-[var(--ui-text)]">{f.value || "—"}</span>
           </li>
         ))}
       </ul>

--- a/src/app/onboarding/form-components/StartupForm.tsx
+++ b/src/app/onboarding/form-components/StartupForm.tsx
@@ -27,15 +27,15 @@ const RESPONSIBILITY_OPTIONS = [
 ];
 
 const TEXTAREA_CLS =
-  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 placeholder-white/30 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20 resize-none";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5 text-white/90 transition-all duration-200 focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none hover:border-white/20 [&>option]:bg-neutral-900";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
 
-const LABEL_CLS = "text-xs font-semibold tracking-widest text-white/45 uppercase";
+const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 const PILL_RADIO_CLS =
-  "flex cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white transition-all duration-150 hover:border-white/20 hover:bg-white/8 has-[:checked]:border-white/40 has-[:checked]:bg-white/15";
+  "flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all duration-150 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)]";
 
 function StartupForm({
   onNext,
@@ -74,11 +74,11 @@ function StartupForm({
 
         {/* ── Header ── */}
         <div className="pb-4">
-          <p className="mb-1 text-xs font-semibold tracking-widest text-white/40 uppercase">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
             Step 3 of 6
           </p>
-          <h2 className="text-2xl font-bold text-white">Startup or idea</h2>
-          <p className="mt-1.5 text-sm text-white/50">
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">Startup or idea</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             Share what you&apos;re building — or what you want to build.
           </p>
         </div>
@@ -94,8 +94,8 @@ function StartupForm({
                 key={val}
                 className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
                   hasStartup === val
-                    ? "border-white/40 bg-white/15 text-white"
-                    : "border-white/10 bg-white/5 text-white/50 hover:border-white/20 hover:text-white/70"
+                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
                 }`}
               >
                 <input
@@ -144,11 +144,11 @@ function StartupForm({
 
             {/* ── Section break: optional details ── */}
             <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-white/8" />
-              <span className="text-xs font-semibold tracking-widest text-white/25 uppercase">
+              <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+              <span className="text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
                 Optional details
               </span>
-              <div className="h-px flex-1 bg-white/8" />
+              <div className="h-px flex-1 bg-[var(--ui-surface)]" />
             </div>
 
             {/* ── Status: Time + Funding (2-col) ── */}
@@ -199,8 +199,8 @@ function StartupForm({
                     <span
                       className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
                         watch("coFounderStatus") === option
-                          ? "border-white bg-white"
-                          : "border-white/30 bg-transparent"
+                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                          : "border-[var(--ui-border-strong)] bg-transparent"
                       }`}
                     />
                     {option}
@@ -261,8 +261,8 @@ function StartupForm({
                       key={area}
                       className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm transition-all duration-150 ${
                         checked
-                          ? "border-white/40 bg-white/15 text-white"
-                          : "border-white/10 bg-white/5 text-white/50 hover:border-white/20 hover:text-white/70"
+                          ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                          : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
                       }`}
                     >
                       <input
@@ -281,17 +281,17 @@ function StartupForm({
         )}
 
         {/* ── Navigation ── */}
-        <div className="flex items-center justify-between gap-4 pt-10 border-t border-white/8">
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/15 px-5 py-3 text-sm font-medium text-white/60 transition-all duration-200 hover:border-white/30 hover:text-white"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
           >
             ← Back
           </button>
           <button
             type="submit"
-            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-sm font-semibold text-black shadow-lg shadow-white/10 transition-all duration-200 hover:bg-white/90 active:scale-[0.98] sm:flex-none"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
           >
             Continue →
           </button>

--- a/src/app/onboarding/form-components/UTAboutYouForm.tsx
+++ b/src/app/onboarding/form-components/UTAboutYouForm.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import FormInput from "@/components/ui/FormInput";
+import LocationSelector from "@/components/ui/LocationSelector";
+import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
+import {
+  UT_SCHOOLS_AND_PROGRAMS,
+  getDegreeTypesForSchool,
+  getProgramsForSchoolAndDegreeType,
+  DEGREE_TYPE_LABELS,
+  SECTOR_INTEREST_LABELS,
+} from "@/lib/utSchoolsAndMajors";
+
+type UTAboutYouData = {
+  firstName: string;
+  lastName: string;
+  title: string;
+  city: string;
+  country: string;
+  state?: string;
+  utStatus: "student" | "alumni";
+  gradYear?: number;
+  utCollege?: UTCollege;
+  utDegreeType?: UTDegreeType;
+  utMajor?: string;
+  utSectorInterests?: UTSectorInterest[];
+  additionalEducation?: string;
+  experience: string;
+  personalIntro: string;
+  archetype: FounderArchetype;
+  isTechnical: "yes" | "no";
+};
+
+const CHAR_LIMIT = 500;
+
+const TEXTAREA_CLS =
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
+
+const LABEL_CLS =
+  "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
+
+const PILL_RADIO_CLS =
+  "flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all duration-150 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)] has-[:checked]:text-[var(--ui-text)]";
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  const remaining = max - value.length;
+  return (
+    <p
+      className={`text-right text-xs ${
+        remaining < 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"
+      }`}
+    >
+      {value.length} / {max}
+    </p>
+  );
+}
+
+function UTAboutYouForm({
+  onNext,
+  onBack,
+  defaultValues,
+}: {
+  onNext: (data: UTAboutYouData) => void;
+  onBack: () => void;
+  defaultValues?: Partial<UTAboutYouData>;
+}) {
+  const fieldsRef = useStepEntry();
+  const { formRef, triggerShake } = useErrorShake();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    watch,
+    setValue,
+  } = useForm<UTAboutYouData>({ defaultValues });
+
+  const experienceValue = watch("experience") || "";
+  const personalIntroValue = watch("personalIntro") || "";
+  const archetypeValue = watch("archetype");
+  const isTechnicalValue = watch("isTechnical");
+  const utStatusValue = watch("utStatus");
+  const utCollegeValue = watch("utCollege");
+  const utDegreeTypeValue = watch("utDegreeType");
+  const utSectorInterestsValue = watch("utSectorInterests") || [];
+
+  const availableDegreeTypes = utCollegeValue
+    ? getDegreeTypesForSchool(utCollegeValue)
+    : [];
+
+  const availablePrograms = utCollegeValue && utDegreeTypeValue
+    ? getProgramsForSchoolAndDegreeType(utCollegeValue, utDegreeTypeValue)
+    : [];
+
+  useEffect(() => {
+    if (defaultValues) reset(defaultValues);
+  }, [defaultValues, reset]);
+
+  const errCount = Object.keys(errors).length;
+  useEffect(() => {
+    if (errCount > 0) triggerShake();
+  }, [errCount, triggerShake]);
+
+  const onSubmit = (data: UTAboutYouData) => onNext(data);
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit(onSubmit)}>
+      <div ref={fieldsRef} className="flex flex-col gap-y-8">
+
+        {/* ── Header ── */}
+        <div className="pb-4">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+            Step 2 of 5
+          </p>
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">About you</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+            Help potential co-founders understand who you are.
+          </p>
+        </div>
+
+        {/* ── Identity: Name + Title ── */}
+        <div className="flex flex-col gap-y-5">
+          <div className="flex gap-x-4">
+            <div className="flex w-full flex-col gap-y-1.5">
+              <label className={LABEL_CLS}>First Name *</label>
+              <FormInput
+                type="text"
+                placeholder="e.g. Teslim"
+                {...register("firstName", { required: true })}
+              />
+              {errors.firstName && (
+                <p className="text-xs text-red-400">First name is required</p>
+              )}
+            </div>
+            <div className="flex w-full flex-col gap-y-1.5">
+              <label className={LABEL_CLS}>Last Name *</label>
+              <FormInput
+                type="text"
+                placeholder="e.g. Deen"
+                {...register("lastName", { required: true })}
+              />
+              {errors.lastName && (
+                <p className="text-xs text-red-400">Last name is required</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>Job Title *</label>
+            <FormInput
+              type="text"
+              placeholder="e.g. UX Designer, Software Engineer"
+              {...register("title", { required: true })}
+            />
+            {errors.title && (
+              <p className="text-xs text-red-400">Job title is required</p>
+            )}
+          </div>
+        </div>
+
+        {/* ── Location ── */}
+        <div className="flex flex-col gap-y-1.5">
+          <input type="hidden" {...register("country", { required: true })} />
+          <input type="hidden" {...register("city", { required: true })} />
+          <input type="hidden" {...register("state")} />
+          <LocationSelector
+            countryValue={watch("country") || ""}
+            stateValue={watch("state") || ""}
+            cityValue={watch("city") || ""}
+            onCountryChange={(v) => setValue("country", v, { shouldValidate: true })}
+            onStateChange={(v) => setValue("state", v, { shouldValidate: true })}
+            onCityChange={(v) => setValue("city", v, { shouldValidate: true })}
+            errors={{
+              country: errors.country ? "Country is required" : undefined,
+              state: errors.state ? "State is required" : undefined,
+              city: errors.city ? "City is required" : undefined,
+            }}
+          />
+        </div>
+
+        {/* ── Student or Alumni ── */}
+        <div className="flex flex-col gap-y-3">
+          <label className={LABEL_CLS}>Are you a student or alumni? *</label>
+          <div className="flex gap-x-3">
+            {(["student", "alumni"] as const).map((val) => (
+              <label
+                key={val}
+                className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                  utStatusValue === val
+                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                }`}
+              >
+                <input
+                  type="radio"
+                  value={val}
+                  {...register("utStatus", { required: true })}
+                  className="sr-only"
+                />
+                {val === "student" ? "Student" : "Alumni"}
+              </label>
+            ))}
+          </div>
+          {errors.utStatus && (
+            <p className="text-xs text-red-400">Please select an option</p>
+          )}
+        </div>
+
+        {/* ── Education (UT-specific) ── */}
+        <div className="flex flex-col gap-y-5">
+          {/* School Selection */}
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>UT College / School *</label>
+            <select
+              {...register("utCollege")}
+              className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
+            >
+              <option value="">Select a school...</option>
+              {Object.entries(UT_SCHOOLS_AND_PROGRAMS).map(([key, school]) => (
+                <option key={key} value={key}>
+                  {school.label}
+                </option>
+              ))}
+            </select>
+            {errors.utCollege && (
+              <p className="text-xs text-red-400">School is required</p>
+            )}
+          </div>
+
+          {/* Degree Type Selection (conditional) */}
+          {utCollegeValue && (
+            <div className="flex flex-col gap-y-1.5">
+              <label className={LABEL_CLS}>Degree Type *</label>
+              <select
+                {...register("utDegreeType")}
+                className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
+              >
+                <option value="">Select a degree type...</option>
+                {availableDegreeTypes.map((degreeType) => (
+                  <option key={degreeType} value={degreeType}>
+                    {DEGREE_TYPE_LABELS[degreeType]}
+                  </option>
+                ))}
+              </select>
+              {errors.utDegreeType && (
+                <p className="text-xs text-red-400">Degree type is required</p>
+              )}
+            </div>
+          )}
+
+          {/* Major Selection (conditional) */}
+          {utCollegeValue && utDegreeTypeValue && (
+            <div className="flex flex-col gap-y-1.5">
+              <label className={LABEL_CLS}>Program / Major *</label>
+              <select
+                {...register("utMajor")}
+                className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
+              >
+                <option value="">Select a program...</option>
+                {availablePrograms.map((program) => (
+                  <option key={program.name} value={program.name}>
+                    {program.name}
+                  </option>
+                ))}
+              </select>
+              {errors.utMajor && (
+                <p className="text-xs text-red-400">Program is required</p>
+              )}
+            </div>
+          )}
+
+          {/* Sector Interests (conditional) */}
+          {utCollegeValue && (
+            <div className="flex flex-col gap-y-3">
+              <label className={LABEL_CLS}>Areas of Interest</label>
+              <p className="text-xs text-[var(--ui-text-muted)]">
+                Select relevant sectors aligned with your program
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {UT_SCHOOLS_AND_PROGRAMS[utCollegeValue].sectorInterests.map(
+                  (sector) => (
+                    <label
+                      key={sector}
+                      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-all duration-150 ${
+                        utSectorInterestsValue.includes(sector)
+                          ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                          : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)]"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        value={sector}
+                        checked={utSectorInterestsValue.includes(sector)}
+                        onChange={(e) => {
+                          const newValue = e.target.checked
+                            ? [...utSectorInterestsValue, sector as UTSectorInterest]
+                            : utSectorInterestsValue.filter((s) => s !== sector);
+                          setValue("utSectorInterests", newValue);
+                        }}
+                        className="sr-only"
+                      />
+                      <span>{SECTOR_INTEREST_LABELS[sector]}</span>
+                    </label>
+                  ),
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Graduation Year */}
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>Graduation Year</label>
+            <FormInput
+              type="number"
+              placeholder="e.g. 2026"
+              {...register("gradYear", {
+                valueAsNumber: true,
+                min: { value: 1900, message: "Invalid year" },
+                max: { value: 2035, message: "Invalid year" },
+              })}
+            />
+            {errors.gradYear && (
+              <p className="text-xs text-red-400">{errors.gradYear.message}</p>
+            )}
+          </div>
+
+          {/* Additional Education */}
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>
+              Additional Education
+              <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
+                (optional)
+              </span>
+            </label>
+            <textarea
+              {...register("additionalEducation")}
+              className={TEXTAREA_CLS}
+              rows={2}
+              placeholder="Other degrees or institutions (e.g. Austin Community College, BS Computer Science)"
+            />
+          </div>
+        </div>
+
+        {/* ── Work Experience ── */}
+        <div className="flex flex-col gap-y-1.5">
+          <label className={LABEL_CLS}>Work Experience *</label>
+          <textarea
+            {...register("experience", {
+              required: "Work experience is required",
+              maxLength: { value: CHAR_LIMIT, message: `Maximum ${CHAR_LIMIT} characters` },
+            })}
+            className={TEXTAREA_CLS}
+            rows={3}
+            maxLength={CHAR_LIMIT}
+            placeholder="Current/previous job title(s) or internships"
+          />
+          <CharCount value={experienceValue} max={CHAR_LIMIT} />
+          {errors.experience && (
+            <p className="text-xs text-red-400">{errors.experience.message}</p>
+          )}
+        </div>
+
+        {/* ── Personal Intro ── */}
+        <div className="flex flex-col gap-y-1.5">
+          <label className={LABEL_CLS}>Personal Introduction *</label>
+          <textarea
+            {...register("personalIntro", {
+              required: "Your introduction cannot be empty.",
+              minLength: { value: 10, message: "Must be at least 10 characters." },
+              maxLength: { value: CHAR_LIMIT, message: `Maximum ${CHAR_LIMIT} characters` },
+            })}
+            className={TEXTAREA_CLS}
+            rows={4}
+            maxLength={CHAR_LIMIT}
+            placeholder="Write a short paragraph introducing yourself…"
+          />
+          <CharCount value={personalIntroValue} max={CHAR_LIMIT} />
+          {errors.personalIntro && (
+            <p className="text-xs text-red-400">{errors.personalIntro.message}</p>
+          )}
+        </div>
+
+        {/* ── Founder Archetype ── */}
+        <div className="flex flex-col gap-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <label className={LABEL_CLS}>Founder Archetype *</label>
+              <p className="mt-1 text-xs leading-relaxed text-[var(--ui-text-muted)]">
+                Which best describes your founding style?
+              </p>
+            </div>
+            <a
+              href="/founder-archetypes"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 mt-0.5 text-xs text-[var(--ui-text-subtle)] underline-offset-2 transition-colors duration-150 hover:text-[var(--ui-text-muted)] hover:underline"
+            >
+              Learn more ↗
+            </a>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            {(
+              [
+                {
+                  value: "the_scaler",
+                  label: "The Scaler",
+                  tooltip:
+                    "Speed and scale above all else. Uses AI and proprietary data to grow without headcount. Measures success by 10–15% week-over-week revenue or user growth.",
+                },
+                {
+                  value: "the_steward",
+                  label: "The Steward",
+                  tooltip:
+                    "Values-driven and mission-first. Prioritizes ethical integrity and community trust in every decision. Measures success by social impact and adherence to moral guardrails.",
+                },
+                {
+                  value: "the_architect",
+                  label: "The Architect",
+                  tooltip:
+                    "Builds the infrastructure others run on. Creates platforms powered by network effects. Measures success by total value generated across the ecosystem — not just by the company itself.",
+                },
+              ] as const
+            ).map(({ value, label, tooltip }) => (
+              <label key={value} className={`${PILL_RADIO_CLS} relative`}>
+                <input
+                  type="radio"
+                  value={value}
+                  {...register("archetype", { required: "Please select an archetype" })}
+                  className="sr-only"
+                />
+                <span
+                  className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-150 ${
+                    archetypeValue === value
+                      ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                      : "border-[var(--ui-border-strong)] bg-transparent"
+                  }`}
+                />
+                <span className="flex-1">{label}</span>
+                <span
+                  className="group/tip relative ml-auto flex items-center"
+                  onClick={(e) => e.preventDefault()}
+                >
+                  <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[10px] font-medium text-[var(--ui-text-subtle)] transition-colors duration-150 group-hover/tip:border-white/35 group-hover/tip:text-[var(--ui-text-muted)]">
+                    i
+                  </span>
+                  <span className="pointer-events-none absolute right-0 bottom-7 z-50 w-60 rounded-xl border border-[var(--ui-border)] bg-neutral-900 px-3.5 py-3 text-left text-xs leading-relaxed text-[var(--ui-text-muted)] opacity-0 shadow-2xl transition-opacity duration-150 group-hover/tip:opacity-100">
+                    {tooltip}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+          {errors.archetype && (
+            <p className="text-xs text-red-400">{errors.archetype.message}</p>
+          )}
+        </div>
+
+        {/* ── Technical Background ── */}
+        <div className="flex flex-col gap-y-3">
+          <label className={LABEL_CLS}>Technical Background? *</label>
+          <div className="flex gap-x-3">
+            {(["yes", "no"] as const).map((val) => (
+              <label
+                key={val}
+                className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                  isTechnicalValue === val
+                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                }`}
+              >
+                <input
+                  type="radio"
+                  value={val}
+                  {...register("isTechnical", { required: true })}
+                  className="sr-only"
+                />
+                {val === "yes" ? "Yes" : "No"}
+              </label>
+            ))}
+          </div>
+          {errors.isTechnical && (
+            <p className="text-xs text-red-400">Please select an option</p>
+          )}
+        </div>
+
+        {/* ── Navigation ── */}
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+          >
+            ← Back
+          </button>
+          <button
+            type="submit"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
+          >
+            Continue →
+          </button>
+        </div>
+
+      </div>
+    </form>
+  );
+}
+
+export default UTAboutYouForm;

--- a/src/app/onboarding/form-components/UTBackgroundAndSocialsForm.tsx
+++ b/src/app/onboarding/form-components/UTBackgroundAndSocialsForm.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import FormInput from "@/components/ui/FormInput";
+import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
+
+type UTBackgroundAndSocialsData = {
+  schedulingUrl?: string;
+  linkedin?: string;
+  git?: string;
+};
+
+const LABEL_CLS =
+  "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
+
+function UTBackgroundAndSocialsForm({
+  onNext,
+  onBack,
+  defaultValues,
+}: {
+  onNext: (data: UTBackgroundAndSocialsData) => void;
+  onBack: () => void;
+  defaultValues?: Partial<UTBackgroundAndSocialsData>;
+}) {
+  const fieldsRef = useStepEntry();
+  const { formRef, triggerShake } = useErrorShake();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UTBackgroundAndSocialsData>({ defaultValues });
+
+  const errCount = Object.keys(errors).length;
+  useEffect(() => {
+    if (errCount > 0) triggerShake();
+  }, [errCount, triggerShake]);
+
+  const onSubmit = (data: UTBackgroundAndSocialsData) => onNext(data);
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit(onSubmit)}>
+      <div ref={fieldsRef} className="flex flex-col gap-y-8">
+
+        {/* ── Header ── */}
+        <div className="pb-4">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+            Step 4 of 6
+          </p>
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">Additional details</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+            All fields are optional — add what feels relevant.
+          </p>
+        </div>
+
+        {/* ── Scheduling ── */}
+        <div className="flex flex-col gap-y-1.5">
+          <label className={LABEL_CLS}>
+            Scheduling Link
+            <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
+              (Calendly, Cal.com…)
+            </span>
+          </label>
+          <FormInput
+            {...register("schedulingUrl")}
+            type="url"
+            placeholder="https://calendly.com/your-link"
+          />
+        </div>
+
+        {/* ── Section break ── */}
+        <div className="flex items-center gap-3">
+          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+          <span className="text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
+            Socials
+          </span>
+          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+        </div>
+
+        {/* ── Social links ── */}
+        <div className="flex flex-col gap-y-5">
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>LinkedIn</label>
+            <FormInput
+              type="text"
+              placeholder="linkedin.com/in/your-name"
+              {...register("linkedin")}
+            />
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>GitHub / GitLab</label>
+            <FormInput
+              type="text"
+              placeholder="github.com/yourusername"
+              {...register("git")}
+            />
+          </div>
+        </div>
+
+        {/* ── Navigation ── */}
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+          >
+            ← Back
+          </button>
+          <button
+            type="submit"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
+          >
+            Continue →
+          </button>
+        </div>
+
+      </div>
+    </form>
+  );
+}
+
+export default UTBackgroundAndSocialsForm;

--- a/src/app/onboarding/form-components/UTInterestsForm.tsx
+++ b/src/app/onboarding/form-components/UTInterestsForm.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
+
+const LABEL_CLS =
+  "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
+
+const MAX_SELECTIONS = 5;
+
+const INTEREST_DOMAINS = [
+  {
+    domain: "Deep tech & science",
+    tags: [
+      "AI / ML",
+      "Space Tech",
+      "Robotics",
+      "Quantum Computing",
+      "BioTech",
+      "Synthetic Biology",
+      "Semiconductors",
+      "Defense Tech",
+    ],
+  },
+  {
+    domain: "Planet & sustainability",
+    tags: [
+      "CleanTech",
+      "Climate Tech",
+      "AgriTech",
+      "FoodTech",
+      "Water Tech",
+      "Circular Economy",
+      "Energy Tech",
+      "Ocean Tech",
+    ],
+  },
+  {
+    domain: "Business & finance",
+    tags: [
+      "B2B SaaS",
+      "Fintech",
+      "InsurTech",
+      "Web3 / Crypto",
+      "Developer Tools",
+      "Cybersecurity",
+      "Data & Analytics",
+      "No-code / Low-code",
+    ],
+  },
+  {
+    domain: "Health & life sciences",
+    tags: [
+      "HealthTech",
+      "Mental Health",
+      "MedTech",
+      "Genomics",
+      "FemTech",
+      "Drug Discovery",
+      "Wellness / Fitness",
+      "Digital Health",
+    ],
+  },
+  {
+    domain: "People & society",
+    tags: [
+      "EdTech",
+      "Future of Work",
+      "GovTech",
+      "LegalTech",
+      "Social Impact",
+      "Diversity & Inclusion",
+      "Non-profit / NGO",
+      "Immigration Tech",
+    ],
+  },
+  {
+    domain: "Consumer & media",
+    tags: [
+      "Consumer",
+      "Creator Economy",
+      "Media & Entertainment",
+      "Gaming / XR",
+      "Fashion / Retail Tech",
+      "Travel Tech",
+      "Sports Tech",
+      "Music Tech",
+    ],
+  },
+  {
+    domain: "Infrastructure & industry",
+    tags: [
+      "PropTech",
+      "Construction Tech",
+      "Logistics & Supply Chain",
+      "Mobility / Transport",
+      "Manufacturing",
+      "Aerospace",
+      "Mining Tech",
+      "Oil & Gas Tech",
+    ],
+  },
+  {
+    domain: "Emerging & frontier",
+    tags: [
+      "Longevity Tech",
+      "Neurotech",
+      "Nanotechnology",
+      "Human Augmentation",
+      "Metaverse",
+      "Smart Cities",
+      "Halal Tech",
+      "Islamic Fintech",
+    ],
+  },
+] as const;
+
+type UTInterestsData = {
+  priorityAreas?: string[];
+};
+
+function UTInterestsForm({
+  onBack,
+  onNext,
+  defaultValues,
+}: {
+  onBack: () => void;
+  onNext: (data: UTInterestsData) => void;
+  defaultValues?: Partial<UTInterestsData>;
+}) {
+  const fieldsRef = useStepEntry();
+  const { formRef, triggerShake } = useErrorShake();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<UTInterestsData>({ defaultValues });
+
+  const selectedAreas = watch("priorityAreas") || [];
+
+  useEffect(() => {
+    if (defaultValues?.priorityAreas) {
+      reset(defaultValues);
+    }
+  }, [defaultValues, reset]);
+
+  const errCount = Object.keys(errors).length;
+  useEffect(() => {
+    if (errCount > 0) triggerShake();
+  }, [errCount, triggerShake]);
+
+  const onSubmit = (data: UTInterestsData) => {
+    onNext(data);
+  };
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit(onSubmit)}>
+      <div ref={fieldsRef} className="flex flex-col gap-y-8">
+
+        {/* ── Header ── */}
+        <div className="pb-4">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+            Step 5 of 6
+          </p>
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">
+            Interest library
+          </h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+            Select up to 5 areas you want to work on.
+          </p>
+        </div>
+
+        {/* ── Interest Library ── */}
+        <div className="flex flex-col gap-y-6">
+          <div className="flex items-center justify-between">
+            <label className={LABEL_CLS}>Your interests</label>
+            <span className="text-xs font-semibold text-[var(--ui-text-muted)]">
+              {selectedAreas.length} / {MAX_SELECTIONS}
+            </span>
+          </div>
+
+          {INTEREST_DOMAINS.map((section) => (
+            <div key={section.domain} className="flex flex-col gap-y-2">
+              <p className="text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+                {section.domain}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {section.tags.map((tag) => {
+                  const checked = selectedAreas.includes(tag);
+                  const isDisabled =
+                    selectedAreas.length >= MAX_SELECTIONS && !checked;
+                  return (
+                    <label
+                      key={tag}
+                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm transition-all duration-150 ${
+                        isDisabled
+                          ? "cursor-not-allowed border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-subtle)] opacity-50"
+                          : checked
+                            ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                            : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        value={tag}
+                        {...register("priorityAreas")}
+                        disabled={isDisabled}
+                        defaultChecked={defaultValues?.priorityAreas?.includes(
+                          tag,
+                        )}
+                        className="sr-only"
+                      />
+                      {tag}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* ── Navigation ── */}
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+          >
+            ← Back
+          </button>
+          <button
+            type="submit"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
+          >
+            Review →
+          </button>
+        </div>
+
+      </div>
+    </form>
+  );
+}
+
+export default UTInterestsForm;

--- a/src/app/onboarding/form-components/UTProfilePhotoForm.tsx
+++ b/src/app/onboarding/form-components/UTProfilePhotoForm.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import React, { useState } from "react";
+import dynamic from "next/dynamic";
+import { useAuth, useSession } from "@clerk/nextjs";
+import { useStepEntry } from "@/hooks/useOnboardingAnimation";
+
+const FaceDetectionUploader = dynamic(
+  () => import("@/components/FaceDetectionUploader"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex animate-pulse items-center gap-2.5 text-[var(--ui-text-muted)]">
+        <svg
+          className="h-4 w-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+        <span className="text-sm">Loading AI model…</span>
+      </div>
+    ),
+  },
+);
+
+interface UTProfilePhotoFormProps {
+  onNext: (data: { photoUploaded: boolean; pfp_url?: string }) => void;
+  defaultValues?: { photoUploaded?: boolean; pfp_url?: string };
+}
+
+function UTProfilePhotoForm({ onNext, defaultValues }: UTProfilePhotoFormProps) {
+  const fieldsRef = useStepEntry();
+
+  const [validatedPhotoFile, setValidatedPhotoFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadSuccess, setUploadSuccess] = useState(
+    defaultValues?.photoUploaded || false,
+  );
+
+  const { userId } = useAuth();
+  const { session } = useSession();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (uploadSuccess) {
+      if (!defaultValues?.pfp_url) {
+        setError("Profile photo URL is missing. Please upload your photo again.");
+        setUploadSuccess(false);
+        return;
+      }
+      onNext({ photoUploaded: true, pfp_url: defaultValues.pfp_url });
+      return;
+    }
+
+    if (!validatedPhotoFile) {
+      setError("Please upload a valid profile photo with a clear human face");
+      return;
+    }
+
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      const token = await session?.getToken();
+      if (!userId || !token) throw new Error("Authentication required");
+
+      const formData = new FormData();
+      formData.append("file", validatedPhotoFile);
+
+      const response = await fetch("/api/upload-profile-pic", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Upload failed");
+      }
+
+      const result = await response.json();
+      setUploadSuccess(true);
+      onNext({ photoUploaded: true, pfp_url: result.url });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to upload photo. Please try again.",
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div ref={fieldsRef} className="flex flex-col gap-y-8">
+        {/* Header */}
+        <div className="pb-4">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+            Step 1 of 5
+          </p>
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">
+            Add your profile photo
+          </h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+            Our AI verifies it contains a real face to keep profiles authentic.
+          </p>
+        </div>
+
+        {/* Uploader */}
+        <div>
+          {!uploadSuccess ? (
+            <FaceDetectionUploader
+              onValidationSuccess={(file) => {
+                setValidatedPhotoFile(file);
+                setError(null);
+              }}
+              onValidationFail={(errorMsg) => {
+                setValidatedPhotoFile(null);
+                setError(errorMsg);
+              }}
+            />
+          ) : (
+            <div className="flex items-center gap-3 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-5 py-4">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-500/20">
+                <svg
+                  className="h-4 w-4 text-emerald-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              </div>
+              <p className="text-sm font-medium text-emerald-400">
+                Profile photo uploaded successfully
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="rounded-xl border border-red-500/30 bg-red-500/8 px-4 py-3">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+
+        {/* Action */}
+        <div className="pt-10 border-t border-[var(--ui-border)]">
+          <button
+            type="submit"
+            disabled={isUploading || (!validatedPhotoFile && !uploadSuccess)}
+            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto"
+          >
+            {isUploading ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Uploading…
+              </>
+            ) : uploadSuccess ? (
+              "Continue →"
+            ) : (
+              "Upload & Continue →"
+            )}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export default UTProfilePhotoForm;

--- a/src/app/onboarding/form-components/UTReviewForm.tsx
+++ b/src/app/onboarding/form-components/UTReviewForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import React from "react";
+import { useStepEntry } from "@/hooks/useOnboardingAnimation";
+
+type UTReviewFormProps = {
+  data: OnboardingData;
+  onBack: () => void;
+  onEdit: (step: number) => void;
+  onSubmit: () => void;
+};
+
+export default function UTReviewForm({
+  data,
+  onBack,
+  onEdit,
+  onSubmit,
+}: UTReviewFormProps) {
+  const fieldsRef = useStepEntry();
+
+  const educationParts = [
+    data.utCollege,
+    data.gradYear ? `Class of ${data.gradYear}` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <div ref={fieldsRef} className="flex flex-col gap-y-8">
+      {/* Header */}
+      <div className="pb-4">
+        <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+          Step 6 of 6
+        </p>
+        <h2 className="text-2xl font-bold text-[var(--ui-text)]">Review your info</h2>
+        <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+          Double-check everything before submitting.
+        </p>
+      </div>
+
+      {/* Sections */}
+      <div className="flex flex-col gap-y-3">
+        <Section
+          title="About You"
+          fields={[
+            { label: "First Name", value: data.firstName },
+            { label: "Last Name", value: data.lastName },
+            { label: "Job Title", value: data.title },
+            {
+              label: "Location",
+              value:
+                data.city && data.country
+                  ? `${data.city}, ${data.country}`
+                  : data.city || data.country || "—",
+            },
+            {
+              label: "Status",
+              value: data.utStatus
+                ? data.utStatus.charAt(0).toUpperCase() + data.utStatus.slice(1)
+                : "—",
+            },
+            { label: "Education", value: educationParts || "—" },
+            {
+              label: "Addl. Education",
+              value: data.additionalEducation || "—",
+            },
+            { label: "Experience", value: data.experience || "—" },
+            { label: "Personal Intro", value: data.personalIntro || "—" },
+            { label: "Founder Archetype", value: data.archetype || "—" },
+            {
+              label: "Technical",
+              value: data.isTechnical === "yes" ? "Yes" : "No",
+            },
+          ]}
+          onEdit={() => onEdit(2)}
+        />
+
+        <Section
+          title="Startup or Idea"
+          fields={[
+            {
+              label: "Has Startup",
+              value: data.hasStartup === "yes" ? "Yes" : "Not yet",
+            },
+            { label: "Startup Name", value: data.startupName || "—" },
+            { label: "Description", value: data.startupDescription || "—" },
+            { label: "Time Spent", value: data.startupTimeSpent || "—" },
+            { label: "Funding Status", value: data.startupFunding || "—" },
+            { label: "Co-Founder Status", value: data.coFounderStatus || "—" },
+            { label: "Equity Expectation", value: data.equityExpectation ? `${data.equityExpectation}%` : "—" },
+          ]}
+          onEdit={() => onEdit(3)}
+        />
+
+        <Section
+          title="Additional Details"
+          fields={[
+            { label: "Scheduling", value: data.schedulingUrl || "—" },
+            { label: "LinkedIn", value: data.linkedin || "—" },
+            { label: "GitHub/GitLab", value: data.git || "—" },
+          ]}
+          onEdit={() => onEdit(4)}
+        />
+
+        <Section
+          title="Priority Areas"
+          fields={[
+            {
+              label: "Areas",
+              value: data.priorityAreas?.length
+                ? data.priorityAreas.join(", ")
+                : "—",
+            },
+          ]}
+          onEdit={() => onEdit(5)}
+        />
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
+        <button
+          onClick={onBack}
+          className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+        >
+          ← Back
+        </button>
+        <button
+          onClick={onSubmit}
+          className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-emerald-500 px-8 py-3.5 text-sm font-semibold text-[var(--ui-text)] shadow-lg shadow-emerald-500/20 transition-all duration-200 hover:bg-emerald-400 active:scale-[0.98] sm:flex-none"
+        >
+          Confirm &amp; Submit ✓
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  fields,
+  onEdit,
+}: {
+  title: string;
+  fields: { label: string; value: string | number | null | undefined }[];
+  onEdit: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--ui-border)] bg-white/4 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold tracking-wide text-[var(--ui-text)]">
+          {title}
+        </h3>
+        <button
+          onClick={onEdit}
+          className="cursor-pointer rounded-lg px-2.5 py-1 text-xs font-medium text-[var(--ui-text-muted)] transition-all duration-150 hover:bg-[var(--ui-surface)] hover:text-[var(--ui-text)]"
+        >
+          Edit
+        </button>
+      </div>
+      <ul className="space-y-1.5">
+        {fields.map((f, i) => (
+          <li key={i} className="flex gap-2 text-sm">
+            <span className="w-36 shrink-0 text-[var(--ui-text-muted)]">{f.label}</span>
+            <span className="text-[var(--ui-text)]">{f.value || "—"}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/onboarding/form-components/UTStartupForm.tsx
+++ b/src/app/onboarding/form-components/UTStartupForm.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import FormInput from "@/components/ui/FormInput";
+import AIWriter from "@/components/ui/AIWriter";
+import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
+
+type UTStartupFormData = {
+  hasStartup: "yes" | "no";
+  startupName?: string;
+  startupDescription?: string;
+  startupTimeSpent?: string;
+  startupFunding?: string;
+  coFounderStatus?: string;
+  equityExpectation?: number;
+};
+
+const TEXTAREA_CLS =
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
+
+const SELECT_CLS =
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+
+const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
+
+const PILL_RADIO_CLS =
+  "flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all duration-150 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)]";
+
+function UTStartupForm({
+  onNext,
+  onBack,
+  defaultValues,
+}: {
+  onNext: (data: UTStartupFormData) => void;
+  onBack: () => void;
+  defaultValues?: Partial<UTStartupFormData>;
+}) {
+  const fieldsRef = useStepEntry();
+  const { formRef, triggerShake } = useErrorShake();
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<UTStartupFormData>({ defaultValues });
+
+  const hasStartup = useWatch({ control, name: "hasStartup" });
+  const startupDescriptionValue = watch("startupDescription") || "";
+
+  const errCount = Object.keys(errors).length;
+  useEffect(() => {
+    if (errCount > 0) triggerShake();
+  }, [errCount, triggerShake]);
+
+  const onSubmit = (data: UTStartupFormData) => onNext(data);
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit(onSubmit)}>
+      <div ref={fieldsRef} className="flex flex-col gap-y-8">
+
+        {/* ── Header ── */}
+        <div className="pb-4">
+          <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
+            Step 3 of 5
+          </p>
+          <h2 className="text-2xl font-bold text-[var(--ui-text)]">Startup or idea</h2>
+          <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
+            Share what you&apos;re building — or what you want to build.
+          </p>
+        </div>
+
+        {/* ── Has startup? ── */}
+        <div className="flex flex-col gap-y-3">
+          <label className={LABEL_CLS}>
+            Do you already have a startup or idea? *
+          </label>
+          <div className="flex gap-x-3">
+            {(["yes", "no"] as const).map((val) => (
+              <label
+                key={val}
+                className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                  hasStartup === val
+                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                }`}
+              >
+                <input
+                  type="radio"
+                  value={val}
+                  {...register("hasStartup", { required: true })}
+                  className="sr-only"
+                />
+                {val === "yes" ? "Yes, I do" : "Not yet"}
+              </label>
+            ))}
+          </div>
+          {errors.hasStartup && (
+            <p className="text-xs text-red-400">This field is required</p>
+          )}
+        </div>
+
+        {hasStartup === "yes" && (
+          <>
+            {/* ── Startup basics: Name + Description ── */}
+            <div className="flex flex-col gap-y-5">
+              <div className="flex flex-col gap-y-1.5">
+                <label className={LABEL_CLS}>Company or Project Name</label>
+                <FormInput
+                  type="text"
+                  placeholder="e.g. Cohub, FinTrack"
+                  {...register("startupName")}
+                />
+              </div>
+
+              <div className="flex flex-col gap-y-1.5">
+                <label className={LABEL_CLS}>Brief Description</label>
+                <textarea
+                  rows={3}
+                  placeholder="Tell us what it's about in 1–2 sentences"
+                  className={TEXTAREA_CLS}
+                  {...register("startupDescription")}
+                />
+                <AIWriter
+                  text={startupDescriptionValue}
+                  fieldType="startupDescription"
+                  onAccept={(s) => setValue("startupDescription", s)}
+                />
+              </div>
+            </div>
+
+            {/* ── Section break: optional details ── */}
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+              <span className="text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
+                Details
+              </span>
+              <div className="h-px flex-1 bg-[var(--ui-surface)]" />
+            </div>
+
+            {/* ── Status: Time + Funding (2-col) ── */}
+            <div className="grid grid-cols-2 gap-x-4 gap-y-5">
+              <div className="flex flex-col gap-y-1.5">
+                <label className={LABEL_CLS}>Time Spent</label>
+                <select {...register("startupTimeSpent")} className={SELECT_CLS}>
+                  <option value="">Select…</option>
+                  <option value="Just started">Just started</option>
+                  <option value="1-3 months">1–3 months</option>
+                  <option value="3-6 months">3–6 months</option>
+                  <option value="6-12 months">6–12 months</option>
+                  <option value="1-2 years">1–2 years</option>
+                  <option value="2+ years">2+ years</option>
+                </select>
+              </div>
+
+              <div className="flex flex-col gap-y-1.5">
+                <label className={LABEL_CLS}>Funding Status</label>
+                <select {...register("startupFunding")} className={SELECT_CLS}>
+                  <option value="">Select…</option>
+                  <option value="Idea stage">Idea stage</option>
+                  <option value="Bootstrapped">Bootstrapped</option>
+                  <option value="Friends & Family">Friends & Family</option>
+                  <option value="Pre-seed">Pre-seed</option>
+                  <option value="Seed">Seed</option>
+                  <option value="Series A+">Series A+</option>
+                </select>
+              </div>
+            </div>
+
+            {/* ── Co-founder status ── */}
+            <div className="flex flex-col gap-y-3">
+              <label className={LABEL_CLS}>Co-Founder Status *</label>
+              <div className="flex flex-col gap-y-2">
+                {[
+                  "Solo founder",
+                  "Have co-founder(s)",
+                  "Seeking co-founder",
+                ].map((option) => (
+                  <label key={option} className={PILL_RADIO_CLS}>
+                    <input
+                      type="radio"
+                      value={option}
+                      {...register("coFounderStatus", { required: "Co-founder status is required" })}
+                      className="sr-only"
+                    />
+                    <span
+                      className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                        watch("coFounderStatus") === option
+                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                          : "border-[var(--ui-border-strong)] bg-transparent"
+                      }`}
+                    />
+                    {option}
+                  </label>
+                ))}
+              </div>
+              {errors.coFounderStatus && (
+                <p className="text-xs text-red-400">{errors.coFounderStatus.message}</p>
+              )}
+            </div>
+
+            {/* ── Equity Expectation ── */}
+            <div className="flex flex-col gap-y-1.5">
+              <label className={LABEL_CLS}>Equity Expectation (%) *</label>
+              <FormInput
+                type="number"
+                min="0"
+                max="100"
+                step="0.1"
+                placeholder="e.g. 20"
+                {...register("equityExpectation", {
+                  required: "Equity expectation is required",
+                  min: { value: 0, message: "Equity must be at least 0%" },
+                  max: { value: 100, message: "Cannot exceed 100%" },
+                })}
+              />
+              {errors.equityExpectation && (
+                <p className="text-xs text-red-400">
+                  {errors.equityExpectation.message}
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* ── Navigation ── */}
+        <div className="flex items-center justify-between gap-4 pt-10 border-t border-[var(--ui-border)]">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-3 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+          >
+            ← Back
+          </button>
+          <button
+            type="submit"
+            className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"
+          >
+            Continue →
+          </button>
+        </div>
+
+      </div>
+    </form>
+  );
+}
+
+export default UTStartupForm;

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -5,7 +5,7 @@ import { useSession, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 
 import { completeOnboarding } from "./_actions";
-import { useProfileUpsert } from "@/features/profile/useProfile";
+import { useProfileUpsert, useUserProfile } from "@/features/profile/useProfile";
 import CreateProfile from "@/components/forms/CreateProfile";
 import { posthog } from "@/lib/posthog";
 import { trackEvent } from "@/lib/posthog-events";
@@ -19,6 +19,7 @@ export default function OnboardingComponent() {
   const router = useRouter();
 
   const { mutateAsync: upsertProfileMutationFn } = useProfileUpsert();
+  const { data: existingProfile } = useUserProfile();
 
   const handleSubmit = async (formData: OnboardingData) => {
     try {
@@ -112,7 +113,11 @@ export default function OnboardingComponent() {
             </div>
           )}
 
-          <CreateProfile onSubmit={handleSubmit} onError={(e) => setError(e)} />
+          <CreateProfile
+            onSubmit={handleSubmit}
+            onError={(e) => setError(e)}
+            initialData={existingProfile}
+          />
         </div>
       </section>
     </>

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -34,7 +34,7 @@ export default function SchoolDashboardPage({
   const { schoolName } = useSchool();
   const { data: profiles } = useGetProfiles();
   const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
-  const { data: mutualLikes } = useMutualLikes();
+  useMutualLikes();
   const createConversationMutation = useCreateConversation();
   const skipProfileMutation = useSkipProfile();
   const { data: swipeLimitData } = useSwipeLimit();
@@ -67,12 +67,13 @@ export default function SchoolDashboardPage({
       { threshold: 0.5 }
     );
 
-    if (cardRef.current) {
-      observer.observe(cardRef.current);
+    const node = cardRef.current;
+    if (node) {
+      observer.observe(node);
     }
 
     return () => {
-      if (cardRef.current) observer.unobserve(cardRef.current);
+      if (node) observer.unobserve(node);
     };
   }, [curProfile?.user_id, curProfile?.isNew]);
 
@@ -155,10 +156,6 @@ export default function SchoolDashboardPage({
       </div>
     );
   }
-
-  const isMutualLike = mutualLikes?.matches?.some(
-    (id: string) => id === curProfile.user_id,
-  );
 
   // Helper: is profile online (active in last 5 minutes)
   const isOnline = curProfile.last_active_at

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -1,20 +1,16 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
-import { FaHeart, FaLocationDot } from "react-icons/fa6";
-import { TbMessageCircleFilled } from "react-icons/tb";
+import { FaHeart } from "react-icons/fa6";
+import { TbSend } from "react-icons/tb";
 import { MdSkipNext } from "react-icons/md";
-import { CiCircleInfo } from "react-icons/ci";
 import { motion, AnimatePresence } from "motion/react";
 import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
 
-import BatteryLevel from "@/components/BatteryLevel";
-import ActivityIndicator from "@/components/ActivityIndicator";
 import HiringBadge from "@/components/HiringBadge";
-import InformationTooltipButton from "@/components/ui/InformationTooltipButton";
 import SwipeLimit from "@/components/SwipeLimit";
 import { useGetProfiles } from "@/features/profile/useProfile";
 import { useSchool } from "@/components/school/SchoolContext";
@@ -23,16 +19,17 @@ import { useCreateConversation } from "@/hooks/useConversations";
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
 import { useSwipeLimit } from "@/features/swipes/useSwipes";
 import { trackEvent } from "@/lib/posthog-events";
+import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/lib/utSchoolsAndMajors";
 
 export default function SchoolDashboardPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  const [showMore, setShowMore] = useState(false);
   const [isStartingConversation, setIsStartingConversation] = useState(false);
   const queryClient = useQueryClient();
   const router = useRouter();
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const { schoolName } = useSchool();
   const { data: profiles } = useGetProfiles();
@@ -53,6 +50,32 @@ export default function SchoolDashboardPage({
     }
   }, [curProfile?.user_id]);
 
+  // Mark profile as seen when it enters viewport
+  useEffect(() => {
+    if (!curProfile?.user_id || !curProfile?.isNew) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          fetch(`/api/profiles/seen`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ candidate_user_id: curProfile.user_id }),
+          }).catch((err) => console.error("Failed to mark as seen:", err));
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    if (cardRef.current) {
+      observer.observe(cardRef.current);
+    }
+
+    return () => {
+      if (cardRef.current) observer.unobserve(cardRef.current);
+    };
+  }, [curProfile?.user_id, curProfile?.isNew]);
+
   const handleLike = async () => {
     if (!curProfile?.user_id || isLikeLoading) return;
     try {
@@ -66,7 +89,7 @@ export default function SchoolDashboardPage({
   const handleSkip = async () => {
     if (!curProfile?.user_id) return;
     try {
-      await skipProfileMutation.mutateAsync(curProfile.user_id);
+      await skipProfileMutation.mutateAsync({ skippedProfileId: curProfile.user_id });
       queryClient.invalidateQueries({ queryKey: ["profiles"] });
     } catch {
       toast.error("Failed to skip profile");
@@ -137,11 +160,36 @@ export default function SchoolDashboardPage({
     (id: string) => id === curProfile.user_id,
   );
 
+  // Helper: is profile online (active in last 5 minutes)
+  const isOnline = curProfile.last_active_at
+    ? new Date().getTime() - new Date(curProfile.last_active_at).getTime() < 5 * 60 * 1000
+    : false;
+
+  // Helper: get initials from first and last name
+  const initials = (curProfile.firstName?.[0] ?? "").toUpperCase() +
+    (curProfile.lastName?.[0] ?? "").toUpperCase();
+
+  // Helper: get degree abbreviation
+  const degreeAbbrev = curProfile.utCollege && curProfile.utMajor
+    ? getDegreeAbbreviation(curProfile.utCollege, curProfile.utMajor)
+    : undefined;
+
+  // Helper: format year (e.g., 2025 → '25)
+  const yearSuffix = curProfile.gradYear
+    ? `'${String(curProfile.gradYear).slice(-2)}`
+    : undefined;
+
+  // Helper: get school full name
+  const schoolFullName = curProfile.utCollege
+    ? getSchoolFullName(curProfile.utCollege)
+    : undefined;
+
   return (
     <div className="mx-auto max-w-2xl p-4 pt-6">
       {brandingHeader}
       <AnimatePresence mode="wait">
         <motion.div
+          ref={cardRef}
           key={curProfile.user_id}
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
@@ -149,121 +197,158 @@ export default function SchoolDashboardPage({
           transition={{ duration: 0.25 }}
           className="overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]"
         >
-          {/* Profile picture */}
-          <div className="relative h-72 w-full bg-[var(--ui-surface)]">
-            {curProfile.pfp_url ? (
-              <Image
-                src={curProfile.pfp_url}
-                alt={`${curProfile.firstName}'s photo`}
-                fill
-                className="object-cover"
-              />
-            ) : (
-              <div className="flex h-full items-center justify-center text-[var(--ui-text-subtle)]">
-                <FaLocationDot className="h-16 w-16" />
-              </div>
-            )}
-            {isMutualLike && (
-              <div className="absolute right-3 top-3 rounded-full bg-pink-500 px-3 py-1 text-xs font-semibold text-[var(--ui-text)]">
-                Mutual Match ❤️
-              </div>
-            )}
-            {curProfile.is_hiring && <HiringBadge />}
-          </div>
-
-          {/* Profile info */}
+          {/* Card header with avatar, name, badges */}
           <div className="p-5">
-            <div className="mb-1 flex items-center justify-between">
-              <h2 className="text-xl font-bold text-[var(--ui-text)]">
-                {curProfile.firstName} {curProfile.lastName}
-              </h2>
-              <ActivityIndicator lastActiveAt={curProfile.last_active_at} />
-            </div>
-
-            <p className="mb-1 text-sm text-[var(--ui-text-muted)]">{curProfile.title}</p>
-
-            <div className="mb-3 flex items-center gap-1 text-xs text-[var(--ui-text-muted)]">
-              <FaLocationDot className="h-3 w-3" />
-              <span>
-                {curProfile.city}, {curProfile.country}
-              </span>
-            </div>
-
-            {curProfile.personalIntro && (
-              <p className="mb-3 text-sm leading-relaxed text-[var(--ui-text)]">
-                {curProfile.personalIntro}
-              </p>
-            )}
-
-            <BatteryLevel level={curProfile.batteryLevel} />
-
-            {showMore && (
-              <div className="mt-4 space-y-2 border-t border-[var(--ui-border)] pt-4 text-sm text-[var(--ui-text-muted)]">
-                {curProfile.education && (
-                  <p>
-                    <span className="font-medium text-[var(--ui-text)]">Education: </span>
-                    {curProfile.education}
-                  </p>
+            {/* Avatar + Name row */}
+            <div className="mb-4 flex items-start gap-3">
+              {/* Circular avatar with photo or initials fallback */}
+              <div className="relative flex-shrink-0">
+                {curProfile.pfp_url ? (
+                  <Image
+                    src={curProfile.pfp_url}
+                    alt={`${curProfile.firstName} ${curProfile.lastName}`}
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-lg font-bold text-[var(--ui-text)]">
+                    {initials}
+                  </div>
                 )}
-                {curProfile.experience && (
-                  <p>
-                    <span className="font-medium text-[var(--ui-text)]">Experience: </span>
-                    {curProfile.experience}
-                  </p>
-                )}
-                {curProfile.accomplishments && (
-                  <p>
-                    <span className="font-medium text-[var(--ui-text)]">
-                      Accomplishments:{" "}
+                {/* Online/Offline status dot */}
+                <div
+                  className={`absolute bottom-0 right-0 h-4 w-4 rounded-full border-2 border-[var(--ui-surface)] ${
+                    isOnline ? "bg-green-500" : "bg-red-500"
+                  }`}
+                />
+              </div>
+
+              {/* Name, New badge, Degree */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h2 className="text-lg font-bold text-[var(--ui-text)]">
+                    {curProfile.firstName} {curProfile.lastName}
+                  </h2>
+                  {curProfile.isNew && (
+                    <span className="inline-flex rounded-md bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
+                      New
                     </span>
-                    {curProfile.accomplishments}
-                  </p>
+                  )}
+                </div>
+                {degreeAbbrev && yearSuffix && (
+                  <div className="text-sm font-medium text-[var(--ui-text-muted)]">
+                    {degreeAbbrev} {yearSuffix}
+                  </div>
                 )}
+              </div>
+
+              {/* Status + Archetype (right column, stacked) */}
+              <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
+                {curProfile.utStatus && (
+                  <span className="inline-flex items-center rounded-md border border-[var(--ui-border-strong)] px-2.5 py-1 text-xs font-medium text-[var(--ui-text-muted)]">
+                    {curProfile.utStatus === "student" ? "Student" : "Alumni"}
+                  </span>
+                )}
+                {curProfile.archetype && (
+                  <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                    {curProfile.archetype === "the_scaler"
+                      ? "The Scaler"
+                      : curProfile.archetype === "the_steward"
+                        ? "The Steward"
+                        : "The Architect"}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Founder type badge */}
+            {curProfile.isTechnical && (
+              <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                {curProfile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
               </div>
             )}
 
-            <button
-              onClick={() => setShowMore((v) => !v)}
-              className="mt-3 flex items-center gap-1 text-xs text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
-            >
-              <CiCircleInfo className="h-4 w-4" />
-              {showMore ? "Show less" : "Show more"}
-            </button>
+            {/* Department */}
+            {schoolFullName && curProfile.utMajor && (
+              <div className="mb-3 text-xs text-[var(--ui-text-muted)]">
+                {schoolFullName} — {curProfile.utMajor}
+              </div>
+            )}
+
+            {/* Hiring badge */}
+            {curProfile.is_hiring && <HiringBadge />}
+
+            {/* About section */}
+            {curProfile.personalIntro && (
+              <div className="mb-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface-active)] p-3">
+                <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+                  About
+                </p>
+                <p className="text-sm leading-relaxed text-[var(--ui-text)]">
+                  {curProfile.personalIntro}
+                </p>
+              </div>
+            )}
+
+            {/* Category interests */}
+            {curProfile.utSectorInterests && curProfile.utSectorInterests.length > 0 && (
+              <div className="mb-4">
+                <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+                  Category Interests
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {curProfile.utSectorInterests.map((interest: string, i: number) => (
+                    <span
+                      key={interest}
+                      className="rounded-md px-2.5 py-1 text-xs font-medium"
+                      style={
+                        i < 2
+                          ? { backgroundColor: "#bf5700", color: "#fff" }
+                          : {
+                              backgroundColor: "var(--ui-surface-active)",
+                              color: "var(--ui-text-muted)",
+                            }
+                      }
+                    >
+                      {SECTOR_INTEREST_LABELS[interest as keyof typeof SECTOR_INTEREST_LABELS] || interest}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center justify-between border-t border-[var(--ui-border)] px-5 py-4">
-            <InformationTooltipButton text={<span>Skip for now</span>}>
-              <button
-                onClick={handleSkip}
-                disabled={skipProfileMutation.isPending}
-                className="flex h-11 w-11 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
-              >
-                <MdSkipNext className="h-5 w-5" />
-              </button>
-            </InformationTooltipButton>
+          <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-border)] px-5 py-4">
+            <button
+              onClick={handleSkip}
+              disabled={skipProfileMutation.isPending}
+              className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
+            >
+              <MdSkipNext className="h-5 w-5" />
+            </button>
+
+            <button
+              onClick={handleMessage}
+              disabled={isStartingConversation}
+              className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[#bf5700] py-3 text-white transition hover:bg-[#a04e00] disabled:opacity-50"
+            >
+              <TbSend className="h-5 w-5" />
+              <span className="text-sm font-medium">Message</span>
+            </button>
 
             <button
               onClick={handleLike}
               disabled={isLikeLoading}
-              className={`flex h-14 w-14 items-center justify-center rounded-full transition ${
+              className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full transition ${
                 likeStatus?.isLiked
-                  ? "bg-pink-500 text-[var(--ui-text)]"
+                  ? "bg-pink-500 text-white"
                   : "border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] hover:border-pink-400 hover:text-pink-400"
               }`}
             >
-              <FaHeart className="h-6 w-6" />
+              <FaHeart className="h-5 w-5" />
             </button>
-
-            <InformationTooltipButton text={<span>Send a message</span>}>
-              <button
-                onClick={handleMessage}
-                disabled={isStartingConversation}
-                className="flex h-11 w-11 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
-              >
-                <TbMessageCircleFilled className="h-5 w-5" />
-              </button>
-            </InformationTooltipButton>
           </div>
         </motion.div>
       </AnimatePresence>

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -93,10 +93,10 @@ export default function SchoolDashboardPage({
 
   const brandingHeader = (
     <div className="mb-5 text-center">
-      <p className="text-xs font-semibold uppercase tracking-widest text-white/50">
+      <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
         Mamun &times; {schoolName}
       </p>
-      <h1 className="mt-0.5 text-base font-semibold text-white/80">
+      <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">
         Co-Founder Matching
       </h1>
     </div>
@@ -122,10 +122,10 @@ export default function SchoolDashboardPage({
       <div className="mx-auto max-w-2xl p-4 pt-6">
         {brandingHeader}
         <div className="flex min-h-[calc(100vh-200px)] flex-col items-center justify-center gap-4 text-center">
-          <p className="text-xl font-semibold text-(--mist-white)">
+          <p className="text-xl font-semibold text-[var(--ui-text)]">
             No more co-founders to show right now
           </p>
-          <p className="text-sm text-white/50">
+          <p className="text-sm text-[var(--ui-text-muted)]">
             Check back later — more students from your program will be joining.
           </p>
         </div>
@@ -147,10 +147,10 @@ export default function SchoolDashboardPage({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -16 }}
           transition={{ duration: 0.25 }}
-          className="overflow-hidden rounded-2xl border border-white/10 bg-white/5"
+          className="overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]"
         >
           {/* Profile picture */}
-          <div className="relative h-72 w-full bg-white/10">
+          <div className="relative h-72 w-full bg-[var(--ui-surface)]">
             {curProfile.pfp_url ? (
               <Image
                 src={curProfile.pfp_url}
@@ -159,12 +159,12 @@ export default function SchoolDashboardPage({
                 className="object-cover"
               />
             ) : (
-              <div className="flex h-full items-center justify-center text-white/20">
+              <div className="flex h-full items-center justify-center text-[var(--ui-text-subtle)]">
                 <FaLocationDot className="h-16 w-16" />
               </div>
             )}
             {isMutualLike && (
-              <div className="absolute right-3 top-3 rounded-full bg-pink-500 px-3 py-1 text-xs font-semibold text-white">
+              <div className="absolute right-3 top-3 rounded-full bg-pink-500 px-3 py-1 text-xs font-semibold text-[var(--ui-text)]">
                 Mutual Match ❤️
               </div>
             )}
@@ -174,15 +174,15 @@ export default function SchoolDashboardPage({
           {/* Profile info */}
           <div className="p-5">
             <div className="mb-1 flex items-center justify-between">
-              <h2 className="text-xl font-bold text-(--mist-white)">
+              <h2 className="text-xl font-bold text-[var(--ui-text)]">
                 {curProfile.firstName} {curProfile.lastName}
               </h2>
               <ActivityIndicator lastActiveAt={curProfile.last_active_at} />
             </div>
 
-            <p className="mb-1 text-sm text-white/60">{curProfile.title}</p>
+            <p className="mb-1 text-sm text-[var(--ui-text-muted)]">{curProfile.title}</p>
 
-            <div className="mb-3 flex items-center gap-1 text-xs text-white/40">
+            <div className="mb-3 flex items-center gap-1 text-xs text-[var(--ui-text-muted)]">
               <FaLocationDot className="h-3 w-3" />
               <span>
                 {curProfile.city}, {curProfile.country}
@@ -190,7 +190,7 @@ export default function SchoolDashboardPage({
             </div>
 
             {curProfile.personalIntro && (
-              <p className="mb-3 text-sm leading-relaxed text-white/70">
+              <p className="mb-3 text-sm leading-relaxed text-[var(--ui-text)]">
                 {curProfile.personalIntro}
               </p>
             )}
@@ -198,22 +198,22 @@ export default function SchoolDashboardPage({
             <BatteryLevel level={curProfile.batteryLevel} />
 
             {showMore && (
-              <div className="mt-4 space-y-2 border-t border-white/10 pt-4 text-sm text-white/60">
+              <div className="mt-4 space-y-2 border-t border-[var(--ui-border)] pt-4 text-sm text-[var(--ui-text-muted)]">
                 {curProfile.education && (
                   <p>
-                    <span className="font-medium text-white/80">Education: </span>
+                    <span className="font-medium text-[var(--ui-text)]">Education: </span>
                     {curProfile.education}
                   </p>
                 )}
                 {curProfile.experience && (
                   <p>
-                    <span className="font-medium text-white/80">Experience: </span>
+                    <span className="font-medium text-[var(--ui-text)]">Experience: </span>
                     {curProfile.experience}
                   </p>
                 )}
                 {curProfile.accomplishments && (
                   <p>
-                    <span className="font-medium text-white/80">
+                    <span className="font-medium text-[var(--ui-text)]">
                       Accomplishments:{" "}
                     </span>
                     {curProfile.accomplishments}
@@ -224,7 +224,7 @@ export default function SchoolDashboardPage({
 
             <button
               onClick={() => setShowMore((v) => !v)}
-              className="mt-3 flex items-center gap-1 text-xs text-white/40 hover:text-white/70"
+              className="mt-3 flex items-center gap-1 text-xs text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
             >
               <CiCircleInfo className="h-4 w-4" />
               {showMore ? "Show less" : "Show more"}
@@ -232,12 +232,12 @@ export default function SchoolDashboardPage({
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center justify-between border-t border-white/10 px-5 py-4">
+          <div className="flex items-center justify-between border-t border-[var(--ui-border)] px-5 py-4">
             <InformationTooltipButton text={<span>Skip for now</span>}>
               <button
                 onClick={handleSkip}
                 disabled={skipProfileMutation.isPending}
-                className="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 text-white/40 transition hover:border-white/40 hover:text-white/70"
+                className="flex h-11 w-11 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
               >
                 <MdSkipNext className="h-5 w-5" />
               </button>
@@ -248,8 +248,8 @@ export default function SchoolDashboardPage({
               disabled={isLikeLoading}
               className={`flex h-14 w-14 items-center justify-center rounded-full transition ${
                 likeStatus?.isLiked
-                  ? "bg-pink-500 text-white"
-                  : "border border-white/20 text-white/60 hover:border-pink-400 hover:text-pink-400"
+                  ? "bg-pink-500 text-[var(--ui-text)]"
+                  : "border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] hover:border-pink-400 hover:text-pink-400"
               }`}
             >
               <FaHeart className="h-6 w-6" />
@@ -259,7 +259,7 @@ export default function SchoolDashboardPage({
               <button
                 onClick={handleMessage}
                 disabled={isStartingConversation}
-                className="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 text-white/40 transition hover:border-white/40 hover:text-white/70"
+                className="flex h-11 w-11 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
               >
                 <TbMessageCircleFilled className="h-5 w-5" />
               </button>

--- a/src/app/school/[slug]/layout.tsx
+++ b/src/app/school/[slug]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import SchoolHeader from "@/components/school/SchoolHeader";
+import { auth } from "@clerk/nextjs/server";
+import OrgHeaderSwitch from "@/components/school/OrgHeaderSwitch";
 import { SchoolProvider } from "@/components/school/SchoolContext";
 import { getOrganizationBySlug } from "@/lib/organizations";
 import { getOrgConfig, DEFAULT_ORG_CONFIG } from "@/orgs/registry";
@@ -30,7 +31,10 @@ export default async function SchoolSlugLayout({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const org = await getOrganizationBySlug(slug);
+  const [{ userId }, org] = await Promise.all([
+    auth(),
+    getOrganizationBySlug(slug),
+  ]);
 
   if (!org) {
     notFound();
@@ -47,11 +51,27 @@ export default async function SchoolSlugLayout({
             "--org-accent": cfg.branding.accentColor,
             "--org-bg": cfg.branding.backgroundColor,
             "--org-text": cfg.branding.textColor,
+            // Semantic UI tokens — light-mode overrides for school orgs with white bg
+            ...(cfg.branding.backgroundColor === "#FFFFFF" ||
+            cfg.branding.backgroundColor === "#ffffff"
+              ? {
+                  "--ui-text": cfg.branding.textColor,
+                  "--ui-text-muted": "#9cadb7",
+                  "--ui-text-subtle": "rgba(51,63,72,0.45)",
+                  "--ui-border": "#e8e4dc",
+                  "--ui-border-strong": "#c8c3b8",
+                  "--ui-surface": "rgba(51,63,72,0.04)",
+                  "--ui-surface-active": "rgba(191,87,0,0.08)",
+                  "--ui-btn-bg": cfg.branding.primaryColor,
+                  "--ui-btn-text": "#ffffff",
+                  "--ui-popover-bg": "#ffffff",
+                }
+              : {}),
           } as React.CSSProperties
         }
         className="min-h-screen bg-[var(--org-bg)] text-[var(--org-text)]"
       >
-        <SchoolHeader slug={slug} schoolName={org.name} config={cfg} />
+        <OrgHeaderSwitch slug={slug} schoolName={org.name} config={cfg} isSignedIn={!!userId} />
         <main>{children}</main>
       </div>
     </SchoolProvider>

--- a/src/app/school/[slug]/matches/page.tsx
+++ b/src/app/school/[slug]/matches/page.tsx
@@ -67,7 +67,7 @@ export default function SchoolMatchesPage({
   if (isLoading) {
     return (
       <div className="flex min-h-[calc(100vh-64px)] items-center justify-center">
-        <FaSync className="h-6 w-6 animate-spin text-white/40" />
+        <FaSync className="h-6 w-6 animate-spin text-[var(--ui-text-muted)]" />
       </div>
     );
   }
@@ -75,8 +75,8 @@ export default function SchoolMatchesPage({
   return (
     <div className="mx-auto max-w-2xl p-4 pt-6">
       <div className="mb-6 flex items-center gap-2">
-        <FaEnvelope className="h-5 w-5 text-white/60" />
-        <h1 className="text-xl font-semibold text-(--mist-white)">Messages</h1>
+        <FaEnvelope className="h-5 w-5 text-[var(--ui-text-muted)]" />
+        <h1 className="text-xl font-semibold text-[var(--ui-text)]">Messages</h1>
       </div>
 
       {error && (
@@ -87,9 +87,9 @@ export default function SchoolMatchesPage({
 
       {conversations.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-16 text-center">
-          <FaHeart className="h-10 w-10 text-white/10" />
-          <p className="font-medium text-white/40">No conversations yet</p>
-          <p className="text-sm text-white/25">
+          <FaHeart className="h-10 w-10 text-[var(--ui-text-subtle)]" />
+          <p className="font-medium text-[var(--ui-text-muted)]">No conversations yet</p>
+          <p className="text-sm text-[var(--ui-text-subtle)]">
             Like a co-founder to start a conversation.
           </p>
         </div>

--- a/src/app/school/[slug]/onboarding/page.tsx
+++ b/src/app/school/[slug]/onboarding/page.tsx
@@ -1,47 +1,64 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 
 import { completeOnboarding } from "@/app/onboarding/_actions";
-import { useProfileUpsert, useUserProfile } from "@/features/profile/useProfile";
+import { useUserProfile } from "@/features/profile/useProfile";
 import ProfilePhotoForm from "@/app/onboarding/form-components/ProfilePhotoForm";
+import UTProfilePhotoForm from "@/app/onboarding/form-components/UTProfilePhotoForm";
 import AboutYouForm from "@/app/onboarding/form-components/AboutYouForm";
 import BackgroundAndSocialsForm from "@/app/onboarding/form-components/BackgroundAndSocialsForm";
 import InterestsAndValuesForm from "@/app/onboarding/form-components/InterestsAndValuesForm";
 import ReviewForm from "@/app/onboarding/form-components/ReviewForm";
+import UTAboutYouForm from "@/app/onboarding/form-components/UTAboutYouForm";
+import UTStartupForm from "@/app/onboarding/form-components/UTStartupForm";
+import UTBackgroundAndSocialsForm from "@/app/onboarding/form-components/UTBackgroundAndSocialsForm";
+import UTInterestsForm from "@/app/onboarding/form-components/UTInterestsForm";
+import UTReviewForm from "@/app/onboarding/form-components/UTReviewForm";
 import OnboardingProgressBar from "@/components/ui/OnboardingProgressBar";
 import { useStepTransition } from "@/hooks/useOnboardingAnimation";
 import { useOnboardingDraft } from "@/hooks/useOnboardingDraft";
 import { useSchool } from "@/components/school/SchoolContext";
 
-// School onboarding skips the StartupForm — 5 steps instead of 6
-const TOTAL_STEPS = 5;
+const TOTAL_STEPS = 6;
 
-// Step map: 1=Photo, 2=AboutYou, 3=Background&Socials, 4=Interests, 5=Review
 function getCompletedSteps(
   data: OnboardingData,
   visited: Set<number>,
+  isUT: boolean,
 ): Set<number> {
   const completed = new Set<number>();
   if (data.pfp_url) completed.add(1);
-  if (
+
+  const step2BaseFields =
     data.firstName &&
     data.lastName &&
     data.title &&
     data.country &&
     data.city &&
-    data.education &&
     data.experience &&
     data.personalIntro &&
-    data.satisfaction &&
-    data.batteryLevel &&
-    data.isTechnical
-  )
-    completed.add(2);
-  if (visited.has(3)) completed.add(3);
+    data.isTechnical;
+
+  if (isUT) {
+    if (step2BaseFields && data.utStatus) completed.add(2);
+    // Step 3: Startup details (has startup field required)
+    if (data.hasStartup && data.coFounderStatus !== undefined && data.equityExpectation !== undefined)
+      completed.add(3);
+  } else {
+    if (
+      step2BaseFields &&
+      data.education &&
+      data.satisfaction &&
+      data.batteryLevel
+    )
+      completed.add(2);
+  }
+
   if (visited.has(4)) completed.add(4);
+  if (visited.has(5)) completed.add(5);
   return completed;
 }
 
@@ -50,6 +67,9 @@ export default function SchoolOnboardingPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  const { slug } = use(params);
+  const isUT = slug === "ut";
+
   const [stepNumber, setStepNumber] = useState(1);
   const [formData, setFormData] = useState<OnboardingData>({});
   const [visitedSteps, setVisitedSteps] = useState<Set<number>>(new Set());
@@ -83,8 +103,6 @@ export default function SchoolOnboardingPage({
     }
     setInitialized(true);
   }, [initialized, profileLoading, existingProfile]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const { mutateAsync: upsertProfileMutationFn } = useProfileUpsert();
 
   const goToStep = (
     newStep: number,
@@ -123,11 +141,17 @@ export default function SchoolOnboardingPage({
         return;
       }
 
-      const { success, error: upsertError } =
-        await upsertProfileMutationFn(formData);
+      const endpoint = isUT ? "/api/ut-profile" : "/api/profile";
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify(formData),
+      });
 
-      if (!success) {
-        setError(upsertError || "Failed to save profile. Please try again.");
+      const result = await res.json();
+
+      if (!res.ok || !result.success) {
+        setError(result.error || "Failed to save profile. Please try again.");
         return;
       }
 
@@ -136,8 +160,7 @@ export default function SchoolOnboardingPage({
 
       draft.clear();
 
-      const resolvedParams = await params;
-      router.push(`/school/${resolvedParams.slug}/dashboard`);
+      router.push(`/school/${slug}/dashboard`);
     } catch {
       setError("Something went wrong. Please try again.");
     }
@@ -181,7 +204,7 @@ export default function SchoolOnboardingPage({
         currentStep={stepNumber}
         totalSteps={TOTAL_STEPS}
         onStepClick={handleEditStep}
-        completedSteps={getCompletedSteps(formData, visitedSteps)}
+        completedSteps={getCompletedSteps(formData, visitedSteps, isUT)}
       />
 
       {error && (
@@ -192,33 +215,79 @@ export default function SchoolOnboardingPage({
 
       <div ref={containerRef} className="will-change-transform">
         {stepNumber === 1 && (
-          <ProfilePhotoForm
-            onNext={(newData) => advanceStep(newData, 2)}
-            defaultValues={formData}
-          />
+          isUT ? (
+            <UTProfilePhotoForm
+              onNext={(newData) => advanceStep(newData, 2)}
+              defaultValues={formData}
+            />
+          ) : (
+            <ProfilePhotoForm
+              onNext={(newData) => advanceStep(newData, 2)}
+              defaultValues={formData}
+            />
+          )
         )}
         {stepNumber === 2 && (
-          <AboutYouForm
-            onBack={handleBack}
-            onNext={(newData) => advanceStep(newData, 3)}
-            defaultValues={formData}
-          />
+          isUT ? (
+            <UTAboutYouForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 3)}
+              defaultValues={formData}
+            />
+          ) : (
+            <AboutYouForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 3)}
+              defaultValues={formData}
+            />
+          )
         )}
-        {stepNumber === 3 && (
-          <BackgroundAndSocialsForm
+        {stepNumber === 3 && isUT && (
+          <UTStartupForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 4)}
             defaultValues={formData}
           />
         )}
         {stepNumber === 4 && (
-          <InterestsAndValuesForm
-            onBack={handleBack}
-            onNext={(newData) => advanceStep(newData, 5)}
-            defaultValues={formData}
-          />
+          isUT ? (
+            <UTBackgroundAndSocialsForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 5)}
+              defaultValues={formData}
+            />
+          ) : (
+            <BackgroundAndSocialsForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 4)}
+              defaultValues={formData}
+            />
+          )
         )}
         {stepNumber === 5 && (
+          isUT ? (
+            <UTInterestsForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 6)}
+              defaultValues={formData}
+            />
+          ) : (
+            <InterestsAndValuesForm
+              onBack={handleBack}
+              onNext={(newData) => advanceStep(newData, 5)}
+              defaultValues={formData}
+            />
+          )
+        )}
+        {stepNumber === 6 && isUT && (
+          <UTReviewForm
+            data={formData}
+            onBack={handleBack}
+            onEdit={handleEditStep}
+            onSubmit={handleSubmit}
+          />
+        )}
+        {stepNumber === 5 && !isUT && (
           <ReviewForm
             data={formData}
             onBack={handleBack}

--- a/src/app/school/[slug]/onboarding/page.tsx
+++ b/src/app/school/[slug]/onboarding/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 
 import { completeOnboarding } from "@/app/onboarding/_actions";
-import { useProfileUpsert } from "@/features/profile/useProfile";
+import { useProfileUpsert, useUserProfile } from "@/features/profile/useProfile";
 import ProfilePhotoForm from "@/app/onboarding/form-components/ProfilePhotoForm";
 import AboutYouForm from "@/app/onboarding/form-components/AboutYouForm";
 import BackgroundAndSocialsForm from "@/app/onboarding/form-components/BackgroundAndSocialsForm";
@@ -54,6 +54,8 @@ export default function SchoolOnboardingPage({
   const [formData, setFormData] = useState<OnboardingData>({});
   const [visitedSteps, setVisitedSteps] = useState<Set<number>>(new Set());
   const [error, setError] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+  const [preFilledNotice, setPreFilledNotice] = useState(false);
 
   const { schoolName } = useSchool();
   const { user } = useUser();
@@ -61,6 +63,26 @@ export default function SchoolOnboardingPage({
   const router = useRouter();
   const draft = useOnboardingDraft();
   const { containerRef, transition } = useStepTransition();
+  const { data: existingProfile, isLoading: profileLoading } = useUserProfile();
+
+  useEffect(() => {
+    if (initialized || profileLoading) return;
+    const savedDraft = draft.load();
+    if (savedDraft) {
+      setStepNumber(savedDraft.step);
+      setFormData(savedDraft.data);
+      const visited = new Set<number>();
+      for (let i = 1; i < savedDraft.step; i++) visited.add(i);
+      setVisitedSteps(visited);
+    } else if (
+      existingProfile &&
+      (existingProfile.firstName || existingProfile.personalIntro || existingProfile.pfp_url)
+    ) {
+      setFormData(existingProfile);
+      setPreFilledNotice(true);
+    }
+    setInitialized(true);
+  }, [initialized, profileLoading, existingProfile]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { mutateAsync: upsertProfileMutationFn } = useProfileUpsert();
 
@@ -121,17 +143,39 @@ export default function SchoolOnboardingPage({
     }
   };
 
+  if (!initialized) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--ui-border)] border-t-[var(--org-primary)]" />
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-xl px-4 py-8">
       <div className="mb-8 text-center">
-        <p className="text-xs font-semibold uppercase tracking-widest text-white/30">
+        <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ui-text-subtle)]">
           Mamun &times; {schoolName}
         </p>
-        <h1 className="mt-1 text-xl font-semibold text-white">
+        <h1 className="mt-1 text-xl font-semibold text-[var(--ui-text)]">
           Co-Founder Matching
         </h1>
-        <p className="mt-1 text-sm text-white/40">Student Profile Setup</p>
+        <p className="mt-1 text-sm text-[var(--ui-text-muted)]">Student Profile Setup</p>
       </div>
+
+      {preFilledNotice && (
+        <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">
+          <span>✦ Some fields were pre-filled from your existing profile — review and update as needed.</span>
+          <button
+            type="button"
+            onClick={() => setPreFilledNotice(false)}
+            className="shrink-0 text-[var(--ui-text-subtle)] hover:text-[var(--ui-text-muted)]"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       <OnboardingProgressBar
         currentStep={stepNumber}

--- a/src/app/school/[slug]/page.tsx
+++ b/src/app/school/[slug]/page.tsx
@@ -3,6 +3,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { getOrganizationBySlug } from "@/lib/organizations";
 import { getOrgConfig } from "@/orgs/registry";
+import Hero from "@/components/school/landing/Hero";
+import HowItWorks from "@/components/school/landing/HowItWorks";
+import ValuesPillars from "@/components/school/landing/ValuesPillars";
+import CtaBand from "@/components/school/landing/CtaBand";
+import DepartmentMosaic from "@/components/school/landing/DepartmentMosaic";
+import PublicFooter from "@/components/school/landing/PublicFooter";
 
 export default async function SchoolLanding({
   params,
@@ -15,6 +21,19 @@ export default async function SchoolLanding({
 
   const cfg = getOrgConfig(slug);
   if (!cfg) notFound();
+
+  if (slug === "ut") {
+    return (
+      <>
+        <Hero />
+        <HowItWorks />
+        <ValuesPillars />
+        <CtaBand />
+        <DepartmentMosaic />
+        <PublicFooter />
+      </>
+    );
+  }
 
   const { branding, landing } = cfg;
 

--- a/src/app/school/[slug]/pending-activation/page.tsx
+++ b/src/app/school/[slug]/pending-activation/page.tsx
@@ -7,16 +7,16 @@ export default function PendingActivationPage() {
         <FaShieldAlt className="h-8 w-8 text-yellow-400" />
       </div>
       <div className="max-w-sm space-y-2">
-        <h1 className="text-2xl font-bold text-(--mist-white)">
+        <h1 className="text-2xl font-bold text-[var(--ui-text)]">
           Account Pending Activation
         </h1>
-        <p className="text-sm leading-relaxed text-white/50">
+        <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
           Your school account is being set up. This typically takes 1-2
           business days. You will receive an email once your program is
           activated.
         </p>
       </div>
-      <p className="text-xs text-white/25">
+      <p className="text-xs text-[var(--ui-text-subtle)]">
         If you believe this is an error, please contact your program
         coordinator.
       </p>

--- a/src/app/school/[slug]/profile/page.tsx
+++ b/src/app/school/[slug]/profile/page.tsx
@@ -22,7 +22,7 @@ const FaceDetectionUploader = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex animate-pulse items-center gap-2 text-white/40">
+      <div className="flex animate-pulse items-center gap-2 text-[var(--ui-text-muted)]">
         <svg
           className="h-5 w-5 animate-spin"
           xmlns="http://www.w3.org/2000/svg"
@@ -149,7 +149,7 @@ export default function SchoolProfilePage() {
 
   if (isLoading)
     return (
-      <div className="flex min-h-[60vh] items-center justify-center text-white/40">
+      <div className="flex min-h-[60vh] items-center justify-center text-[var(--ui-text-muted)]">
         Loading profile…
       </div>
     );
@@ -161,19 +161,19 @@ export default function SchoolProfilePage() {
     );
 
   const sectionClass =
-    "rounded-2xl border border-white/10 bg-white/5 p-6 space-y-5";
-  const labelClass = "block text-sm font-medium text-white/60";
+    "rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-6 space-y-5";
+  const labelClass = "block text-sm font-medium text-[var(--ui-text-muted)]";
   const textareaClass =
-    "w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 focus:border-white/30 focus:outline-none focus:ring-1 focus:ring-white/20";
+    "w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]";
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-6">
       {/* Branding header */}
       <div className="mb-6 text-center">
-        <p className="text-xs font-semibold uppercase tracking-widest text-white/50">
+        <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
           Mamun &times; {schoolName}
         </p>
-        <h1 className="mt-0.5 text-base font-semibold text-white/80">
+        <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">
           Edit Your Profile
         </h1>
       </div>
@@ -181,7 +181,7 @@ export default function SchoolProfilePage() {
       {/* Back link */}
       <Link
         href={`/school/${slug}/dashboard`}
-        className="mb-6 inline-flex items-center gap-1.5 text-xs text-white/40 hover:text-white/70"
+        className="mb-6 inline-flex items-center gap-1.5 text-xs text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
       >
         <FaArrowLeft className="h-3 w-3" />
         Back to dashboard
@@ -197,7 +197,7 @@ export default function SchoolProfilePage() {
       <div className="space-y-5">
         {/* Profile picture */}
         <div className={sectionClass}>
-          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
             Profile Picture
           </h2>
           {profileData?.pfp_url && (
@@ -206,7 +206,7 @@ export default function SchoolProfilePage() {
               alt="Current profile photo"
               width={96}
               height={96}
-              className="h-24 w-24 rounded-full border border-white/10 object-cover"
+              className="h-24 w-24 rounded-full border border-[var(--ui-border)] object-cover"
             />
           )}
           <FaceDetectionUploader
@@ -226,7 +226,7 @@ export default function SchoolProfilePage() {
               type="button"
               onClick={handlePhotoUpload}
               disabled={isUploadingPhoto}
-              className="rounded-lg bg-white/10 px-5 py-2 text-sm text-white transition hover:bg-white/20 disabled:opacity-50"
+              className="rounded-lg bg-[var(--ui-surface)] px-5 py-2 text-sm text-[var(--ui-text)] transition hover:bg-[var(--ui-surface)] disabled:opacity-50"
             >
               {isUploadingPhoto ? "Uploading…" : "Upload Photo"}
             </button>
@@ -240,7 +240,7 @@ export default function SchoolProfilePage() {
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
           {/* Basic information */}
           <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Basic Information
             </h2>
 
@@ -322,7 +322,7 @@ export default function SchoolProfilePage() {
 
           {/* Professional information */}
           <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Professional Information
             </h2>
 
@@ -377,7 +377,7 @@ export default function SchoolProfilePage() {
                       {...register("satisfaction", { required: "Required" })}
                       className="h-4 w-4 accent-white"
                     />
-                    <span className="text-sm text-white/70">{opt}</span>
+                    <span className="text-sm text-[var(--ui-text)]">{opt}</span>
                   </label>
                 ))}
               </div>
@@ -399,7 +399,7 @@ export default function SchoolProfilePage() {
                       {...register("batteryLevel", { required: "Required" })}
                       className="h-4 w-4 accent-white"
                     />
-                    <span className="text-sm text-white/70">{opt}</span>
+                    <span className="text-sm text-[var(--ui-text)]">{opt}</span>
                   </label>
                 ))}
               </div>
@@ -413,7 +413,7 @@ export default function SchoolProfilePage() {
 
           {/* Personal story */}
           <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Personal Story
             </h2>
 
@@ -462,7 +462,7 @@ export default function SchoolProfilePage() {
                   href="/founder-archetypes"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-xs text-white/30 underline-offset-2 hover:text-white/60 hover:underline"
+                  className="text-xs text-[var(--ui-text-subtle)] underline-offset-2 hover:text-[var(--ui-text-muted)] hover:underline"
                 >
                   Learn more ↗
                 </a>
@@ -492,7 +492,7 @@ export default function SchoolProfilePage() {
                 ).map(({ value, label, tooltip }) => (
                   <label
                     key={value}
-                    className="relative flex cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white transition-all hover:border-white/20 hover:bg-white/8 has-[:checked]:border-white/40 has-[:checked]:bg-white/15"
+                    className="relative flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)]"
                   >
                     <input
                       type="radio"
@@ -503,8 +503,8 @@ export default function SchoolProfilePage() {
                     <span
                       className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
                         watch("archetype") === value
-                          ? "border-white bg-white"
-                          : "border-white/30 bg-transparent"
+                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                          : "border-[var(--ui-border-strong)] bg-transparent"
                       }`}
                     />
                     <span className="flex-1">{label}</span>
@@ -512,10 +512,10 @@ export default function SchoolProfilePage() {
                       className="group/tip relative ml-auto flex items-center"
                       onClick={(e) => e.preventDefault()}
                     >
-                      <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-white/15 text-[10px] font-medium text-white/30 transition-colors group-hover/tip:border-white/35 group-hover/tip:text-white/60">
+                      <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[10px] font-medium text-[var(--ui-text-subtle)] transition-colors group-hover/tip:border-white/35 group-hover/tip:text-[var(--ui-text-muted)]">
                         i
                       </span>
-                      <span className="pointer-events-none absolute right-0 bottom-7 z-50 w-56 rounded-xl border border-white/10 bg-neutral-900 px-3.5 py-3 text-left text-xs leading-relaxed text-white/60 opacity-0 shadow-2xl transition-opacity group-hover/tip:opacity-100">
+                      <span className="pointer-events-none absolute right-0 bottom-7 z-50 w-56 rounded-xl border border-[var(--ui-border)] bg-neutral-900 px-3.5 py-3 text-left text-xs leading-relaxed text-[var(--ui-text-muted)] opacity-0 shadow-2xl transition-opacity group-hover/tip:opacity-100">
                         {tooltip}
                       </span>
                     </span>
@@ -527,7 +527,7 @@ export default function SchoolProfilePage() {
 
           {/* Social links */}
           <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Social Links
             </h2>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -552,7 +552,7 @@ export default function SchoolProfilePage() {
 
           {/* Interests & values */}
           <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-white/40">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Interests &amp; Values
             </h2>
 
@@ -568,7 +568,7 @@ export default function SchoolProfilePage() {
                         {...register("responsibilities")}
                         className="h-4 w-4 accent-white"
                       />
-                      <span className="text-sm text-white/70">{area}</span>
+                      <span className="text-sm text-[var(--ui-text)]">{area}</span>
                     </label>
                   ),
                 )}
@@ -595,7 +595,7 @@ export default function SchoolProfilePage() {
                       {...register("priorityAreas")}
                       className="h-4 w-4 accent-white"
                     />
-                    <span className="text-sm text-white/70">{area}</span>
+                    <span className="text-sm text-[var(--ui-text)]">{area}</span>
                   </label>
                 ))}
               </div>
@@ -636,7 +636,7 @@ export default function SchoolProfilePage() {
           <div className="flex items-center justify-between pb-8">
             <Link
               href={`/school/${slug}/dashboard`}
-              className="text-sm text-white/40 hover:text-white/70"
+              className="text-sm text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
             >
               Cancel
             </Link>
@@ -648,7 +648,7 @@ export default function SchoolProfilePage() {
                   ? "Upload a profile picture first"
                   : undefined
               }
-              className="rounded-xl bg-white/10 px-8 py-2.5 text-sm font-medium text-white transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="rounded-xl bg-[var(--ui-surface)] px-8 py-2.5 text-sm font-medium text-[var(--ui-text)] transition hover:bg-[var(--ui-surface)] disabled:cursor-not-allowed disabled:opacity-40"
             >
               {isSubmitting ? "Saving…" : "Save Changes"}
             </button>

--- a/src/app/school/[slug]/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/school/[slug]/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import { getOrganizationBySlug } from "@/lib/organizations";
+import SchoolSignIn from "@/components/school/auth/SchoolSignIn";
+
+export default async function SchoolSignInPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const org = await getOrganizationBySlug(slug);
+  if (!org) notFound();
+
+  return (
+    <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
+      <SchoolSignIn
+        slug={org.slug}
+        schoolName={org.name}
+        allowedDomains={org.allowed_email_domains ?? []}
+      />
+    </div>
+  );
+}

--- a/src/app/school/[slug]/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/school/[slug]/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import { getOrganizationBySlug } from "@/lib/organizations";
+import SchoolSignUp from "@/components/school/auth/SchoolSignUp";
+
+export default async function SchoolSignUpPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const org = await getOrganizationBySlug(slug);
+  if (!org) notFound();
+
+  return (
+    <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
+      <SchoolSignUp
+        slug={org.slug}
+        schoolName={org.name}
+        allowedDomains={org.allowed_email_domains ?? []}
+      />
+    </div>
+  );
+}

--- a/src/app/school/[slug]/sso-callback/page.tsx
+++ b/src/app/school/[slug]/sso-callback/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { AuthenticateWithRedirectCallback } from "@clerk/nextjs";
+
+export default function SSOCallbackPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-sm" style={{ color: "#9cadb7" }}>
+        Completing sign-in…
+      </div>
+      <AuthenticateWithRedirectCallback />
+    </div>
+  );
+}

--- a/src/app/school/[slug]/sso-complete/page.tsx
+++ b/src/app/school/[slug]/sso-complete/page.tsx
@@ -4,6 +4,7 @@ import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getOrganizationBySlug } from "@/lib/organizations";
 import { isEmailDomainAllowed } from "@/lib/auth/email-domain";
+import SessionRefreshRedirect from "@/components/school/auth/SessionRefreshRedirect";
 
 export default async function SSOCompletePage({
   params,
@@ -32,20 +33,20 @@ export default async function SSOCompletePage({
     return (
       <DomainMismatch
         slug={slug}
-        orgName={org.name}
+        orgName={org!.name}
         email="unknown"
-        domains={org.allowed_email_domains}
+        domains={org!.allowed_email_domains}
       />
     );
   }
 
-  if (!isEmailDomainAllowed(primaryEmail, org.allowed_email_domains)) {
+  if (!isEmailDomainAllowed(primaryEmail, org!.allowed_email_domains)) {
     return (
       <DomainMismatch
         slug={slug}
-        orgName={org.name}
+        orgName={org!.name}
         email={primaryEmail}
-        domains={org.allowed_email_domains}
+        domains={org!.allowed_email_domains}
       />
     );
   }
@@ -53,7 +54,7 @@ export default async function SSOCompletePage({
   await clerk.users.updateUserMetadata(userId, {
     publicMetadata: {
       ...(user.publicMetadata ?? {}),
-      organization_id: org.id,
+      organization_id: org!.id,
     },
   });
 
@@ -64,13 +65,13 @@ export default async function SSOCompletePage({
     );
     await supabase
       .from("profiles")
-      .update({ organization_id: org.id })
+      .update({ organization_id: org!.id })
       .eq("user_id", userId);
   } catch (err) {
     console.error("sso-complete: profile org update failed:", err);
   }
 
-  redirect(`/school/${slug}/onboarding`);
+  return <SessionRefreshRedirect to={`/school/${slug}/onboarding`} />;
 }
 
 function DomainMismatch({

--- a/src/app/school/[slug]/sso-complete/page.tsx
+++ b/src/app/school/[slug]/sso-complete/page.tsx
@@ -1,0 +1,119 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { getOrganizationBySlug } from "@/lib/organizations";
+import { isEmailDomainAllowed } from "@/lib/auth/email-domain";
+
+export default async function SSOCompletePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const { userId } = await auth();
+
+  if (!userId) {
+    redirect(`/school/${slug}/sign-in`);
+  }
+
+  const org = await getOrganizationBySlug(slug);
+  if (!org) {
+    redirect("/");
+  }
+
+  const clerk = await clerkClient();
+  const user = await clerk.users.getUser(userId);
+  const primaryEmail = user.emailAddresses.find(
+    (e) => e.id === user.primaryEmailAddressId,
+  )?.emailAddress;
+
+  if (!primaryEmail) {
+    return (
+      <DomainMismatch
+        slug={slug}
+        orgName={org.name}
+        email="unknown"
+        domains={org.allowed_email_domains}
+      />
+    );
+  }
+
+  if (!isEmailDomainAllowed(primaryEmail, org.allowed_email_domains)) {
+    return (
+      <DomainMismatch
+        slug={slug}
+        orgName={org.name}
+        email={primaryEmail}
+        domains={org.allowed_email_domains}
+      />
+    );
+  }
+
+  await clerk.users.updateUserMetadata(userId, {
+    publicMetadata: {
+      ...(user.publicMetadata ?? {}),
+      organization_id: org.id,
+    },
+  });
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+    await supabase
+      .from("profiles")
+      .update({ organization_id: org.id })
+      .eq("user_id", userId);
+  } catch (err) {
+    console.error("sso-complete: profile org update failed:", err);
+  }
+
+  redirect(`/school/${slug}/onboarding`);
+}
+
+function DomainMismatch({
+  slug,
+  orgName,
+  email,
+  domains,
+}: {
+  slug: string;
+  orgName: string;
+  email: string;
+  domains: string[];
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-2xl border border-[#e8e4dc] bg-white p-8 shadow-sm">
+        <h1
+          className="mb-2 text-xl font-semibold"
+          style={{ color: "#333f48" }}
+        >
+          This isn&apos;t your portal
+        </h1>
+        <p className="mb-4 text-sm" style={{ color: "#9cadb7" }}>
+          You signed in as <strong>{email}</strong>, but {orgName} is restricted
+          to {domains.map((d) => `@${d}`).join(", ")}.
+        </p>
+        <div className="space-y-2">
+          <a
+            href="https://www.mamuncofoundr.com"
+            className="block rounded-lg px-4 py-2.5 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "#bf5700" }}
+          >
+            Go to mamuncofoundr.com
+          </a>
+          <Link
+            href={`/school/${slug}/sign-in`}
+            className="block rounded-lg border px-4 py-2.5 text-center text-sm font-semibold transition-opacity hover:opacity-70"
+            style={{ borderColor: "#e8e4dc", color: "#333f48" }}
+          >
+            Try a different account
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResumeUploader.tsx
+++ b/src/components/ResumeUploader.tsx
@@ -115,7 +115,7 @@ export default function ResumeUploader({ onParsed }: ResumeUploaderProps) {
         <button
           type="button"
           onClick={reset}
-          className="text-xs text-white/30 transition-colors hover:text-white/60"
+          className="text-xs text-[var(--ui-text-subtle)] transition-colors hover:text-[var(--ui-text-muted)]"
         >
           Remove
         </button>
@@ -125,9 +125,9 @@ export default function ResumeUploader({ onParsed }: ResumeUploaderProps) {
 
   if (state === "parsing") {
     return (
-      <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-4">
+      <div className="flex items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-5 py-4">
         <svg
-          className="h-4 w-4 shrink-0 animate-spin text-white/50"
+          className="h-4 w-4 shrink-0 animate-spin text-[var(--ui-text-muted)]"
           fill="none"
           viewBox="0 0 24 24"
         >
@@ -146,8 +146,8 @@ export default function ResumeUploader({ onParsed }: ResumeUploaderProps) {
           />
         </svg>
         <div>
-          <p className="text-sm text-white/70">Parsing resume…</p>
-          {fileName && <p className="text-xs text-white/30">{fileName}</p>}
+          <p className="text-sm text-[var(--ui-text)]">Parsing resume…</p>
+          {fileName && <p className="text-xs text-[var(--ui-text-subtle)]">{fileName}</p>}
         </div>
       </div>
     );
@@ -162,10 +162,10 @@ export default function ResumeUploader({ onParsed }: ResumeUploaderProps) {
         onKeyDown={(e) => e.key === "Enter" && inputRef.current?.click()}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
-        className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed border-white/15 bg-white/3 px-6 py-5 text-center transition-all duration-200 hover:border-white/25 hover:bg-white/5"
+        className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed border-[var(--ui-border-strong)] bg-white/3 px-6 py-5 text-center transition-all duration-200 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)]"
       >
         <svg
-          className="h-5 w-5 text-white/30"
+          className="h-5 w-5 text-[var(--ui-text-subtle)]"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -178,13 +178,13 @@ export default function ResumeUploader({ onParsed }: ResumeUploaderProps) {
           />
         </svg>
         <div>
-          <p className="text-sm text-white/50">
-            <span className="text-white/70 underline underline-offset-2">
+          <p className="text-sm text-[var(--ui-text-muted)]">
+            <span className="text-[var(--ui-text)] underline underline-offset-2">
               Upload resume
             </span>{" "}
             to auto-fill your profile
           </p>
-          <p className="mt-0.5 text-xs text-white/25">
+          <p className="mt-0.5 text-xs text-[var(--ui-text-subtle)]">
             PDF, DOC, DOCX · max 5MB · optional
           </p>
         </div>

--- a/src/components/forms/CreateProfile.tsx
+++ b/src/components/forms/CreateProfile.tsx
@@ -67,23 +67,35 @@ function getCompletedSteps(
   return completed;
 }
 
-function CreateProfile({ onSubmit, onSuccess, onError }: CreateProfileProps) {
+function hasExistingProfileData(profile: OnboardingData): boolean {
+  return !!(
+    profile.firstName ||
+    profile.lastName ||
+    profile.personalIntro ||
+    profile.pfp_url
+  );
+}
+
+function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProfileProps) {
   const draft = useOnboardingDraft();
   const { containerRef, transition } = useStepTransition();
 
   const [stepNumber, setStepNumber] = useState(1);
   const [formData, setFormData] = useState<OnboardingData>({});
   const [visitedSteps, setVisitedSteps] = useState<Set<number>>(new Set());
+  const [preFilledNotice, setPreFilledNotice] = useState(false);
 
   useEffect(() => {
     const savedDraft = draft.load();
     if (savedDraft) {
       setStepNumber(savedDraft.step);
       setFormData(savedDraft.data);
-      // Treat every step before the saved step as already visited
       const visited = new Set<number>();
       for (let i = 1; i < savedDraft.step; i++) visited.add(i);
       setVisitedSteps(visited);
+    } else if (initialData && hasExistingProfileData(initialData)) {
+      setFormData(initialData);
+      setPreFilledNotice(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -132,6 +144,21 @@ function CreateProfile({ onSubmit, onSuccess, onError }: CreateProfileProps) {
 
   return (
     <>
+      {preFilledNotice && (
+        <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">
+          <span>
+            ✦ Some fields were pre-filled from your existing profile — review and update as needed.
+          </span>
+          <button
+            type="button"
+            onClick={() => setPreFilledNotice(false)}
+            className="shrink-0 text-[var(--ui-text-subtle)] hover:text-[var(--ui-text-muted)]"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <OnboardingProgressBar
         currentStep={stepNumber}
         totalSteps={TOTAL_STEPS}

--- a/src/components/header_footer/Footer.tsx
+++ b/src/components/header_footer/Footer.tsx
@@ -58,6 +58,14 @@ function Footer() {
               >
                 Book a Demo
               </a>
+              <a
+                href="https://forms.gle/u3tS9KUfNhdFFG489"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-base text-(--mist-white) opacity-80 transition-opacity hover:underline hover:underline-offset-4 hover:opacity-100"
+              >
+                Partner with Us
+              </a>
             </div>
 
             {/* Company column */}

--- a/src/components/header_footer/Header.tsx
+++ b/src/components/header_footer/Header.tsx
@@ -90,16 +90,18 @@ function Header() {
               Pricing
             </Link>
           </li>
-          {/* <li className="translate-y text-sm font-semibold sm:text-base">
+
+          <li className="translate-y text-sm font-semibold sm:text-base">
             <Link
-              href="https://calendly.com/mcfm-mamuncofoundr/30min"
+              href="https://forms.gle/u3tS9KUfNhdFFG489"
               target="_blank"
               className="underline underline-offset-4 transition hover:text-white"
             >
-              Book a Demo
+              Partner with Us{" "}
             </Link>
           </li>
 
+          {/*
           <li className="translate-y text-sm font-semibold sm:text-base">
             <Link
               href="https://luma.com/user/usr-eZsILDku7ToYtZZ"

--- a/src/components/school/OrgHeaderSwitch.tsx
+++ b/src/components/school/OrgHeaderSwitch.tsx
@@ -1,0 +1,17 @@
+import SchoolHeader from "./SchoolHeader";
+import PublicSchoolHeader from "./landing/PublicSchoolHeader";
+import type { OrgConfig } from "@/orgs/types";
+
+type Props = {
+  slug: string;
+  schoolName: string;
+  config: OrgConfig;
+  isSignedIn: boolean;
+};
+
+export default function OrgHeaderSwitch({ slug, schoolName, config, isSignedIn }: Props) {
+  if (isSignedIn) {
+    return <SchoolHeader slug={slug} schoolName={schoolName} config={config} />;
+  }
+  return <PublicSchoolHeader />;
+}

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { UserButton } from "@clerk/nextjs";
-import { FaUsers, FaEnvelope, FaUserCircle, FaShieldAlt } from "react-icons/fa";
-import { useUser } from "@clerk/nextjs";
+import { FaHeart } from "react-icons/fa6";
 import clsx from "clsx";
+import { useMutualLikes } from "@/features/likes/useLikes";
 import type { OrgConfig } from "@/orgs/types";
 
 type SchoolHeaderProps = {
@@ -17,83 +17,79 @@ type SchoolHeaderProps = {
 
 export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderProps) {
   const pathname = usePathname();
-  const { user } = useUser();
-  const isSchoolAdmin = user?.publicMetadata?.is_school_admin === true;
+  const [mounted, setMounted] = useState(false);
+  const { data: mutualLikes } = useMutualLikes();
+
+  useEffect(() => setMounted(true), []);
+
+  const savedMatchesCount = mutualLikes?.matches?.length ?? 0;
 
   const navItems = [
     {
       href: `/school/${slug}/dashboard`,
-      label: "Find Co-Founders",
-      icon: FaUsers,
+      label: "Find a co-foundr",
     },
     {
-      href: `/school/${slug}/matches`,
-      label: "Messages",
-      icon: FaEnvelope,
+      href: "https://www.mccombs.utexas.edu/about/contact/",
+      label: "Contact us",
+      external: true,
     },
-    {
-      href: `/school/${slug}/profile`,
-      label: "My Profile",
-      icon: FaUserCircle,
-    },
-    ...(isSchoolAdmin
-      ? [
-          {
-            href: `/school/${slug}/admin`,
-            label: "Admin",
-            icon: FaShieldAlt,
-          },
-        ]
-      : []),
   ];
+
+  const headerText = config.branding.wordmark ? `${config.branding.wordmark} McCombs Co-Foundr` : schoolName;
 
   return (
     <header
-      className="flex items-center justify-between border-b border-black/10 px-6 py-3"
-      style={{ backgroundColor: config.branding.backgroundColor, color: config.branding.textColor }}
+      className="flex items-center justify-between px-6 py-4"
+      style={{ backgroundColor: config.branding.primaryColor, color: "#ffffff" }}
     >
       <Link
-        href={`/school/${slug}/dashboard`}
-        className="flex items-center gap-3"
+        href={`/school/${slug}`}
+        className="text-base font-semibold tracking-tight text-white"
       >
-        <Image
-          src={config.branding.logoUrl}
-          alt={config.branding.wordmark ?? schoolName}
-          width={72}
-          height={72}
-          className="h-9 w-auto"
-        />
-        <span className="h-5 w-px bg-black/20" aria-hidden="true" />
-        <span className="text-sm font-semibold tracking-tight">
-          {schoolName}
-        </span>
+        {headerText}
       </Link>
 
-      <nav className="hidden items-center gap-1 md:flex">
-        {navItems.map(({ href, label, icon: Icon }) => (
-          <Link
-            key={href}
-            href={href}
-            className={clsx(
-              "flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-              pathname.startsWith(href)
-                ? "opacity-100 font-semibold"
-                : "opacity-60 hover:opacity-90",
-            )}
-            style={
-              pathname.startsWith(href)
-                ? { color: config.branding.primaryColor }
-                : undefined
-            }
-          >
-            <Icon className="h-4 w-4" />
-            {label}
-          </Link>
-        ))}
+      <nav className="hidden flex-1 items-center justify-end gap-8 md:flex">
+        {navItems.map(({ href, label, external }) => {
+          const classes = clsx(
+            "text-sm font-medium transition-opacity border-b-2",
+            !external && pathname.startsWith(href)
+              ? "opacity-100 border-white"
+              : "opacity-70 hover:opacity-90 border-transparent",
+          );
+          return external ? (
+            <a
+              key={href}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={classes}
+            >
+              {label}
+            </a>
+          ) : (
+            <Link key={href} href={href} className={classes}>
+              {label}
+            </Link>
+          );
+        })}
       </nav>
 
-      <div className="flex items-center gap-3">
-        <UserButton afterSignOutUrl="/" />
+      <div className="ml-8 flex items-center gap-6">
+        <Link
+          href={`/school/${slug}/matches`}
+          className="relative flex items-center justify-center transition-opacity hover:opacity-80"
+        >
+          <FaHeart className="h-5 w-5 text-white" />
+          {savedMatchesCount > 0 && (
+            <span className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+              {savedMatchesCount > 99 ? "99+" : savedMatchesCount}
+            </span>
+          )}
+        </Link>
+
+        {mounted && <UserButton />}
       </div>
     </header>
   );

--- a/src/components/school/auth/GoogleOAuthButton.tsx
+++ b/src/components/school/auth/GoogleOAuthButton.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useSignIn, useSignUp } from "@clerk/nextjs";
+import { useState } from "react";
+import { FcGoogle } from "react-icons/fc";
+
+type Props = {
+  slug: string;
+  mode: "signIn" | "signUp";
+  label?: string;
+};
+
+export default function GoogleOAuthButton({ slug, mode, label }: Props) {
+  const { isLoaded: signInLoaded, signIn } = useSignIn();
+  const { isLoaded: signUpLoaded, signUp } = useSignUp();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoaded = mode === "signIn" ? signInLoaded : signUpLoaded;
+  const display =
+    label ??
+    (mode === "signIn" ? "Sign in with Google" : "Sign up with Google");
+
+  async function handleClick() {
+    if (!isLoaded) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const opts = {
+        strategy: "oauth_google" as const,
+        redirectUrl: `/school/${slug}/sso-callback`,
+        redirectUrlComplete: `/school/${slug}/sso-complete`,
+      };
+      if (mode === "signIn" && signIn) {
+        await signIn.authenticateWithRedirect(opts);
+      } else if (mode === "signUp" && signUp) {
+        await signUp.authenticateWithRedirect(opts);
+      }
+    } catch (err: unknown) {
+      const msg =
+        err &&
+        typeof err === "object" &&
+        "errors" in err &&
+        Array.isArray((err as { errors: { message: string }[] }).errors)
+          ? (err as { errors: { message: string }[] }).errors[0]?.message
+          : "Could not start Google sign-in. Please try again.";
+      setError(msg ?? "Could not start Google sign-in. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={submitting || !isLoaded}
+        className="flex w-full items-center justify-center gap-2 rounded-lg border border-[#e8e4dc] bg-white px-4 py-2.5 text-sm font-semibold transition hover:bg-[#faf8f4] disabled:opacity-50"
+        style={{ color: "#333f48" }}
+      >
+        <FcGoogle className="h-4 w-4" />
+        {submitting ? "Redirecting…" : display}
+      </button>
+      {error && (
+        <p className="mt-1.5 text-xs text-red-600">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/school/auth/SchoolSignIn.tsx
+++ b/src/components/school/auth/SchoolSignIn.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth, useSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  isEmailDomainAllowed,
+  formatAllowedDomainsForCopy,
+} from "@/lib/auth/email-domain";
+import {
+  assignSchoolOrg,
+  checkExistingUser,
+  type ExistingUserInfo,
+} from "@/lib/actions/school-auth";
+import GoogleOAuthButton from "./GoogleOAuthButton";
+
+type Props = {
+  slug: string;
+  schoolName: string;
+  allowedDomains: string[];
+};
+
+export default function SchoolSignIn({
+  slug,
+  schoolName,
+  allowedDomains,
+}: Props) {
+  const { isLoaded, signIn, setActive } = useSignIn();
+  const { getToken } = useAuth();
+  const router = useRouter();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [existingUser, setExistingUser] = useState<ExistingUserInfo>({
+    exists: false,
+    hasPassword: false,
+    oauthProviders: [],
+  });
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const allowedCopy = formatAllowedDomainsForCopy(allowedDomains);
+  const existingHasGoogle = existingUser.oauthProviders.includes("oauth_google");
+  const showPasswordField =
+    !existingUser.exists || existingUser.hasPassword;
+  const showGoogleHint =
+    existingUser.exists &&
+    existingHasGoogle &&
+    !existingUser.hasPassword;
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setExistingUser({ exists: false, hasPassword: false, oauthProviders: [] });
+    const trimmed = email.trim();
+    if (!trimmed || !isEmailDomainAllowed(trimmed, allowedDomains)) return;
+    debounceRef.current = setTimeout(async () => {
+      const info = await checkExistingUser(trimmed);
+      setExistingUser(info);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [email, allowedDomains]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (!isEmailDomainAllowed(email, allowedDomains)) {
+      setError(
+        `This portal is for ${schoolName}. Sign in at mamuncofoundr.com instead, or use a ${allowedCopy} email.`,
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await signIn.create({
+        identifier: email,
+        password,
+        strategy: "password",
+      });
+
+      if (result.status === "complete") {
+        await setActive({ session: result.createdSessionId });
+        const assigned = await assignSchoolOrg(slug);
+        if ("error" in assigned) {
+          setError(assigned.error);
+          return;
+        }
+        await getToken({ skipCache: true });
+        router.push(`/school/${slug}`);
+      } else {
+        setError("Additional verification required. Please try again.");
+      }
+    } catch (err: unknown) {
+      const msg =
+        err &&
+        typeof err === "object" &&
+        "errors" in err &&
+        Array.isArray((err as { errors: { message: string }[] }).errors)
+          ? (err as { errors: { message: string }[] }).errors[0]?.message
+          : "Invalid credentials. Please try again.";
+      setError(msg ?? "Invalid credentials. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-2xl border border-[#e8e4dc] bg-white p-8 shadow-sm">
+        <div className="mb-6">
+          <h1
+            className="mb-1 text-2xl font-semibold tracking-tight"
+            style={{ color: "#333f48" }}
+          >
+            Sign in to {schoolName}
+          </h1>
+          <p className="text-sm" style={{ color: "#9cadb7" }}>
+            Use your {allowedCopy} account.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <div className="mb-4">
+          <GoogleOAuthButton slug={slug} mode="signIn" />
+        </div>
+        <div className="mb-4 flex items-center gap-3">
+          <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
+          <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+            or
+          </span>
+          <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-1 block text-xs font-medium"
+              style={{ color: "#333f48" }}
+            >
+              School email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@utexas.edu"
+              className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+              required
+            />
+            {showGoogleHint && (
+              <p className="mt-1.5 text-xs" style={{ color: "#7a3a00" }}>
+                This account uses Google sign-in. Use the button above.
+              </p>
+            )}
+          </div>
+
+          {showPasswordField && (
+            <div>
+              <label
+                htmlFor="password"
+                className="mb-1 block text-xs font-medium"
+                style={{ color: "#333f48" }}
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                required={showPasswordField}
+              />
+            </div>
+          )}
+
+          <div id="clerk-captcha" />
+
+          {showPasswordField && (
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ backgroundColor: "#bf5700" }}
+            >
+              {submitting ? "Signing in…" : "Sign in"}
+            </button>
+          )}
+        </form>
+
+        <div
+          className="mt-6 border-t pt-4 text-center text-xs"
+          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+        >
+          Don&apos;t have an account?{" "}
+          <Link
+            href={`/school/${slug}/sign-up`}
+            className="font-semibold hover:underline"
+            style={{ color: "#bf5700" }}
+          >
+            Sign up
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/school/auth/SchoolSignUp.tsx
+++ b/src/components/school/auth/SchoolSignUp.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth, useSignUp } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  isEmailDomainAllowed,
+  formatAllowedDomainsForCopy,
+} from "@/lib/auth/email-domain";
+import {
+  assignSchoolOrg,
+  checkExistingUser,
+  type ExistingUserInfo,
+} from "@/lib/actions/school-auth";
+import GoogleOAuthButton from "./GoogleOAuthButton";
+
+type Props = {
+  slug: string;
+  schoolName: string;
+  allowedDomains: string[];
+};
+
+export default function SchoolSignUp({
+  slug,
+  schoolName,
+  allowedDomains,
+}: Props) {
+  const { isLoaded, signUp, setActive } = useSignUp();
+  const { getToken } = useAuth();
+  const router = useRouter();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [code, setCode] = useState("");
+  const [pendingVerification, setPendingVerification] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [existingUser, setExistingUser] = useState<ExistingUserInfo>({
+    exists: false,
+    hasPassword: false,
+    oauthProviders: [],
+  });
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const allowedCopy = formatAllowedDomainsForCopy(allowedDomains);
+  const emailExists = existingUser.exists;
+  const existingHasGoogle = existingUser.oauthProviders.includes("oauth_google");
+  const existingHasPassword = existingUser.hasPassword;
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setExistingUser({ exists: false, hasPassword: false, oauthProviders: [] });
+    const trimmed = email.trim();
+    if (!trimmed || !isEmailDomainAllowed(trimmed, allowedDomains)) return;
+    debounceRef.current = setTimeout(async () => {
+      const info = await checkExistingUser(trimmed);
+      setExistingUser(info);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [email, allowedDomains]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (!isEmailDomainAllowed(email, allowedDomains)) {
+      setError(
+        `Sign-up at ${schoolName} requires a ${allowedCopy} email address.`,
+      );
+      return;
+    }
+
+    if (emailExists) {
+      setError(
+        `An account with this email already exists. Sign in instead to access ${schoolName}.`,
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await signUp.create({
+        emailAddress: email,
+        password,
+        firstName: firstName || undefined,
+        lastName: lastName || undefined,
+      });
+      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+      setPendingVerification(true);
+    } catch (err: unknown) {
+      const msg =
+        err &&
+        typeof err === "object" &&
+        "errors" in err &&
+        Array.isArray((err as { errors: { message: string }[] }).errors)
+          ? (err as { errors: { message: string }[] }).errors[0]?.message
+          : "Something went wrong. Please try again.";
+      setError(msg ?? "Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const attempt = await signUp.attemptEmailAddressVerification({ code });
+      if (attempt.status === "complete") {
+        await setActive({ session: attempt.createdSessionId });
+        const result = await assignSchoolOrg(slug);
+        if ("error" in result) {
+          setError(result.error);
+          return;
+        }
+        await getToken({ skipCache: true });
+        router.push(`/school/${slug}/onboarding`);
+      } else {
+        setError("Verification could not be completed. Please try again.");
+      }
+    } catch (err: unknown) {
+      const msg =
+        err &&
+        typeof err === "object" &&
+        "errors" in err &&
+        Array.isArray((err as { errors: { message: string }[] }).errors)
+          ? (err as { errors: { message: string }[] }).errors[0]?.message
+          : "Invalid code. Please try again.";
+      setError(msg ?? "Invalid code. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-2xl border border-[#e8e4dc] bg-white p-8 shadow-sm">
+        <div className="mb-6">
+          <h1
+            className="mb-1 text-2xl font-semibold tracking-tight"
+            style={{ color: "#333f48" }}
+          >
+            {pendingVerification ? "Verify your email" : `Join ${schoolName}`}
+          </h1>
+          <p className="text-sm" style={{ color: "#9cadb7" }}>
+            {pendingVerification
+              ? `We sent a 6-digit code to ${email}.`
+              : `Sign up with your ${allowedCopy} email.`}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {!pendingVerification ? (
+          <>
+            <div className="mb-4">
+              <GoogleOAuthButton slug={slug} mode="signUp" />
+            </div>
+            <div className="mb-4 flex items-center gap-3">
+              <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
+              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+                or
+              </span>
+              <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
+            </div>
+            <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="firstName"
+                  className="mb-1 block text-xs font-medium"
+                  style={{ color: "#333f48" }}
+                >
+                  First name
+                </label>
+                <input
+                  id="firstName"
+                  type="text"
+                  autoComplete="given-name"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                  required
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="lastName"
+                  className="mb-1 block text-xs font-medium"
+                  style={{ color: "#333f48" }}
+                >
+                  Last name
+                </label>
+                <input
+                  id="lastName"
+                  type="text"
+                  autoComplete="family-name"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                  required
+                />
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="email"
+                className="mb-1 block text-xs font-medium"
+                style={{ color: "#333f48" }}
+              >
+                School email
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@utexas.edu"
+                className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                required
+              />
+              {emailExists && (
+                <div className="mt-2 rounded-lg border border-[#f5d9c4] bg-[#fdf4ec] px-3 py-2.5 text-xs">
+                  <p style={{ color: "#7a3a00" }}>
+                    An account already exists for this email.{" "}
+                    {existingHasGoogle && !existingHasPassword
+                      ? "Sign in with Google to access " + schoolName + "."
+                      : existingHasPassword && !existingHasGoogle
+                        ? null
+                        : "Choose how you'd like to sign in."}
+                  </p>
+                  <div className="mt-2 flex flex-col gap-2">
+                    {existingHasGoogle && (
+                      <GoogleOAuthButton slug={slug} mode="signIn" />
+                    )}
+                    {existingHasPassword && (
+                      <Link
+                        href={`/school/${slug}/sign-in`}
+                        className="block rounded-lg px-4 py-2 text-center text-xs font-semibold text-white transition-opacity hover:opacity-90"
+                        style={{ backgroundColor: "#bf5700" }}
+                      >
+                        Sign in with password
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label
+                htmlFor="password"
+                className="mb-1 block text-xs font-medium"
+                style={{ color: "#333f48" }}
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                minLength={8}
+                required
+              />
+            </div>
+
+            <div id="clerk-captcha" />
+
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ backgroundColor: "#bf5700" }}
+            >
+              {submitting ? "Creating account…" : "Create account"}
+            </button>
+          </form>
+          </>
+        ) : (
+          <form onSubmit={handleVerify} className="space-y-4">
+            <div>
+              <label
+                htmlFor="code"
+                className="mb-1 block text-xs font-medium"
+                style={{ color: "#333f48" }}
+              >
+                Verification code
+              </label>
+              <input
+                id="code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className="w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-base tracking-[0.5em] outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20"
+                maxLength={6}
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ backgroundColor: "#bf5700" }}
+            >
+              {submitting ? "Verifying…" : "Verify and continue"}
+            </button>
+          </form>
+        )}
+
+        <div
+          className="mt-6 border-t pt-4 text-center text-xs"
+          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+        >
+          Already have an account?{" "}
+          <Link
+            href={`/school/${slug}/sign-in`}
+            className="font-semibold hover:underline"
+            style={{ color: "#bf5700" }}
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/school/auth/SessionRefreshRedirect.tsx
+++ b/src/components/school/auth/SessionRefreshRedirect.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSession } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function SessionRefreshRedirect({ to }: { to: string }) {
+  const { session } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!session) return;
+    session.reload().then(() => router.push(to));
+  }, [session, router, to]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-sm" style={{ color: "#9cadb7" }}>
+        Setting up your account…
+      </p>
+    </div>
+  );
+}

--- a/src/components/school/landing/CtaBand.tsx
+++ b/src/components/school/landing/CtaBand.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+export default function CtaBand() {
+  return (
+    <section
+      className="px-6 py-20 text-center"
+      style={{ backgroundColor: "#bf5700" }}
+    >
+      <div
+        className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
+        style={{ color: "rgba(255,255,255,0.5)" }}
+      >
+        Texas McCombs School of Business
+      </div>
+      <h2 className="mb-3 text-3xl font-semibold text-white sm:text-4xl">
+        Make it here.
+      </h2>
+      <p className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white/70">
+        Join the McCombs co-foundr community — verified, value-aligned, and
+        ready to build something that changes the world.
+      </p>
+      <Link
+        href="/school/ut/sign-up"
+        className="mb-4 inline-block rounded-md px-7 py-3 text-sm font-semibold"
+        style={{ backgroundColor: "#ffffff", color: "#bf5700" }}
+      >
+        Create your profile
+      </Link>
+      <div className="text-xs text-white/40">
+        Exclusively for McCombs students, alumni, and faculty
+      </div>
+    </section>
+  );
+}

--- a/src/components/school/landing/DepartmentMosaic.tsx
+++ b/src/components/school/landing/DepartmentMosaic.tsx
@@ -1,0 +1,202 @@
+type Dept = {
+  name: string;
+  programs: string;
+  chips: { label: string; bg: string; fg: string }[];
+  accent: string;
+};
+
+const TIER_1: Dept[] = [
+  {
+    name: "McCombs Business",
+    programs: "MBA · BBA · MPA · MFinance · MIS",
+    accent: "#bf5700",
+    chips: [
+      { label: "B2B SaaS", bg: "#fdf0e8", fg: "#a04800" },
+      { label: "Fintech", bg: "#fdf0e8", fg: "#a04800" },
+    ],
+  },
+  {
+    name: "Cockrell Engineering",
+    programs: "CS · ECE · ME · Biomedical · ChE",
+    accent: "#005f86",
+    chips: [
+      { label: "AI/ML", bg: "#e8f4fb", fg: "#005f86" },
+      { label: "DeepTech", bg: "#e8f4fb", fg: "#005f86" },
+    ],
+  },
+  {
+    name: "School of Information",
+    programs: "Data Science · UX · HCI · MIS",
+    accent: "#00a9b7",
+    chips: [
+      { label: "Data", bg: "#e0f7f9", fg: "#007a85" },
+      { label: "UX", bg: "#e0f7f9", fg: "#007a85" },
+    ],
+  },
+  {
+    name: "Natural Sciences",
+    programs: "Biology · Chemistry · Neuroscience",
+    accent: "#579d42",
+    chips: [
+      { label: "HealthTech", bg: "#eaf3de", fg: "#2d6e1a" },
+      { label: "BioTech", bg: "#eaf3de", fg: "#2d6e1a" },
+    ],
+  },
+  {
+    name: "Liberal Arts",
+    programs: "Economics · Government · Plan II",
+    accent: "#f8971f",
+    chips: [
+      { label: "Policy", bg: "#fff3e0", fg: "#b36200" },
+      { label: "Impact", bg: "#fff3e0", fg: "#b36200" },
+    ],
+  },
+];
+
+const TIER_2: Dept[] = [
+  {
+    name: "Moody Communication",
+    programs: "Journalism · Advertising · PR · RTF",
+    accent: "#a6cd57",
+    chips: [
+      { label: "Media", bg: "#f3f9e8", fg: "#4a7a10" },
+      { label: "Consumer", bg: "#f3f9e8", fg: "#4a7a10" },
+    ],
+  },
+  {
+    name: "College of Fine Arts",
+    programs: "Design · Studio Art · Music · Theatre",
+    accent: "#ffd600",
+    chips: [
+      { label: "EdTech", bg: "#fffde0", fg: "#7a6a00" },
+      { label: "Consumer", bg: "#fffde0", fg: "#7a6a00" },
+    ],
+  },
+  {
+    name: "School of Architecture",
+    programs: "BArch · MArch · Urban Design",
+    accent: "#333f48",
+    chips: [
+      { label: "PropTech", bg: "#eaecee", fg: "#333f48" },
+      { label: "CleanTech", bg: "#eaecee", fg: "#333f48" },
+    ],
+  },
+  {
+    name: "LBJ Public Affairs",
+    programs: "MPAff · Global Policy · JD/MPAff",
+    accent: "#9cadb7",
+    chips: [
+      { label: "GovTech", bg: "#edf1f3", fg: "#3a5a6a" },
+      { label: "Impact", bg: "#edf1f3", fg: "#3a5a6a" },
+    ],
+  },
+  {
+    name: "Dell Medical School",
+    programs: "MD · MD/PhD · Health Innovation",
+    accent: "#c0392b",
+    chips: [
+      { label: "HealthTech", bg: "#fdecea", fg: "#922b21" },
+      { label: "BioTech", bg: "#fdecea", fg: "#922b21" },
+    ],
+  },
+];
+
+function Card({ dept, featured }: { dept: Dept; featured?: boolean }) {
+  return (
+    <div
+      className="relative overflow-hidden rounded-lg bg-white p-3"
+      style={{
+        border: featured ? `1.5px solid ${dept.accent}` : "0.5px solid #e8e4dc",
+      }}
+    >
+      <div
+        className="absolute left-0 top-0 h-full w-[3px]"
+        style={{ backgroundColor: dept.accent }}
+      />
+      <div
+        className="mb-1 pl-1 text-xs font-semibold leading-tight"
+        style={{ color: "#333f48" }}
+      >
+        {dept.name}
+      </div>
+      <div
+        className="mb-2 pl-1 text-[11px]"
+        style={{ color: "#9cadb7" }}
+      >
+        {dept.programs}
+      </div>
+      <div className="flex flex-wrap gap-1 pl-1">
+        {dept.chips.map((c) => (
+          <span
+            key={c.label}
+            className="rounded-sm px-1.5 py-0.5 text-[10px] font-medium"
+            style={{ backgroundColor: c.bg, color: c.fg }}
+          >
+            {c.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TierHeader({ label, dotColor }: { label: string; dotColor: string }) {
+  return (
+    <div
+      className="mb-3 flex items-center gap-2 border-b pb-2 text-[11px] font-semibold uppercase tracking-[0.08em]"
+      style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: dotColor }}
+      />
+      {label}
+    </div>
+  );
+}
+
+export default function DepartmentMosaic() {
+  return (
+    <section
+      id="departments"
+      className="px-6 py-20"
+      style={{ backgroundColor: "#ffffff" }}
+    >
+      <div className="mx-auto max-w-6xl">
+        <h2
+          className="mb-1.5 text-center text-2xl font-semibold sm:text-3xl"
+          style={{ color: "#333f48" }}
+        >
+          Who&apos;s building here
+        </h2>
+        <p
+          className="mb-10 text-center text-sm"
+          style={{ color: "#9cadb7" }}
+        >
+          Founders from across every corner of UT Austin — 10 schools, one
+          platform, one mission.
+        </p>
+
+        <TierHeader
+          label="Tier 1 — Core Schools · Highest founder density"
+          dotColor="#bf5700"
+        />
+        <div className="mb-8 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+          {TIER_1.map((d, i) => (
+            <Card key={d.name} dept={d} featured={i === 0} />
+          ))}
+        </div>
+
+        <TierHeader
+          label="Tier 2 — Partner Schools · Strong secondary pipeline"
+          dotColor="#9cadb7"
+        />
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+          {TIER_2.map((d) => (
+            <Card key={d.name} dept={d} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/school/landing/Hero.tsx
+++ b/src/components/school/landing/Hero.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function Hero() {
+  return (
+    <section
+      className="px-6 py-24 text-center"
+      style={{ backgroundColor: "#bf5700" }}
+    >
+      <h1 className="mx-auto mb-3 max-w-3xl text-4xl font-semibold leading-tight text-white sm:text-5xl">
+        Make it here.
+        <br />
+        <span className="text-white/60">Find your founding team.</span>
+      </h1>
+      <p className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white/70 sm:text-base">
+        The McCombs co-foundr matching platform connects value-aligned students,
+        alumni, and faculty ready to build something that changes the world.
+      </p>
+      <Link
+        href="/school/ut/sign-up"
+        className="inline-block rounded-md px-6 py-3 text-sm font-semibold"
+        style={{ backgroundColor: "#ffffff", color: "#bf5700" }}
+      >
+        Find your co-foundr →
+      </Link>
+    </section>
+  );
+}

--- a/src/components/school/landing/HowItWorks.tsx
+++ b/src/components/school/landing/HowItWorks.tsx
@@ -1,0 +1,62 @@
+const STEPS = [
+  {
+    n: 1,
+    title: "Build your profile",
+    desc: "Skills, startup vision, and values that matter most to you as a builder.",
+  },
+  {
+    n: 2,
+    title: "Get matched",
+    desc: "Engine surfaces verified McCombs founders with complementary skills and aligned values.",
+  },
+  {
+    n: 3,
+    title: "Start building",
+    desc: "Connect, message, and find the person you want to build the next decade with.",
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <section
+      className="px-6 py-20"
+      style={{ backgroundColor: "#d6d2c4" }}
+    >
+      <div className="mx-auto max-w-5xl">
+        <h2
+          className="mb-10 text-center text-2xl font-semibold sm:text-3xl"
+          style={{ color: "#333f48" }}
+        >
+          Three steps to your ideal founding partner
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {STEPS.map((s) => (
+            <div
+              key={s.n}
+              className="rounded-lg border border-black/5 bg-white p-6"
+            >
+              <div
+                className="mb-4 flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold text-white"
+                style={{ backgroundColor: "#bf5700" }}
+              >
+                {s.n}
+              </div>
+              <div
+                className="mb-1.5 text-sm font-semibold"
+                style={{ color: "#333f48" }}
+              >
+                {s.title}
+              </div>
+              <div
+                className="text-sm leading-relaxed"
+                style={{ color: "#9cadb7" }}
+              >
+                {s.desc}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/school/landing/PublicFooter.tsx
+++ b/src/components/school/landing/PublicFooter.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+export default function PublicFooter() {
+  return (
+    <footer
+      className="px-6 py-12"
+      style={{ backgroundColor: "#333f48" }}
+    >
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 flex flex-col items-start justify-between gap-8 sm:flex-row">
+          <div>
+            <div className="mb-1 text-sm font-semibold text-white">
+              Texas McCombs Co-Foundr
+            </div>
+            <div className="text-xs" style={{ color: "#9cadb7" }}>
+              Co-Foundr Matching Platform
+            </div>
+          </div>
+
+          <div className="flex gap-12">
+            <div>
+              <div
+                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
+                style={{ color: "rgba(255,255,255,0.4)" }}
+              >
+                Resources
+              </div>
+              <a
+                href="https://lu.ma"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-1.5 block text-xs hover:text-white"
+                style={{ color: "#9cadb7" }}
+              >
+                UT Luma Events
+              </a>
+              <Link
+                href="/cap-table"
+                className="block text-xs hover:text-white"
+                style={{ color: "#9cadb7" }}
+              >
+                Create Cap Table
+              </Link>
+            </div>
+            <div>
+              <div
+                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
+                style={{ color: "rgba(255,255,255,0.4)" }}
+              >
+                Company
+              </div>
+              <Link
+                href="/privacy-policy"
+                className="mb-1.5 block text-xs hover:text-white"
+                style={{ color: "#9cadb7" }}
+              >
+                Privacy Policy
+              </Link>
+              <Link
+                href="/contact-us"
+                className="block text-xs hover:text-white"
+                style={{ color: "#9cadb7" }}
+              >
+                Contact Support
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="border-t pt-5 text-xs"
+          style={{
+            borderColor: "rgba(255,255,255,0.08)",
+            color: "rgba(255,255,255,0.25)",
+          }}
+        >
+          © 2026 Texas McCombs Co-Foundr. Powered by Mamun. All rights
+          reserved.
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/school/landing/PublicFooter.tsx
+++ b/src/components/school/landing/PublicFooter.tsx
@@ -56,13 +56,15 @@ export default function PublicFooter() {
               >
                 Privacy Policy
               </Link>
-              <Link
-                href="/contact-us"
+              <a
+                href="https://www.mccombs.utexas.edu/about/contact/"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="block text-xs hover:text-white"
                 style={{ color: "#9cadb7" }}
               >
-                Contact Support
-              </Link>
+                Contact Us
+              </a>
             </div>
           </div>
         </div>

--- a/src/components/school/landing/PublicSchoolHeader.tsx
+++ b/src/components/school/landing/PublicSchoolHeader.tsx
@@ -18,12 +18,14 @@ export default function PublicSchoolHeader() {
         >
           Find a co-foundr
         </a>
-        <Link
-          href="/contact-us"
+        <a
+          href="https://www.mccombs.utexas.edu/about/contact/"
+          target="_blank"
+          rel="noopener noreferrer"
           className="text-xs font-medium text-white/75 hover:text-white"
         >
-          Contact support
-        </Link>
+          Contact us
+        </a>
 
         <div className="relative flex items-center">
           <FaHeart className="h-[17px] w-[17px] text-white/80" />

--- a/src/components/school/landing/PublicSchoolHeader.tsx
+++ b/src/components/school/landing/PublicSchoolHeader.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { FaHeart } from "react-icons/fa";
+
+export default function PublicSchoolHeader() {
+  return (
+    <header
+      className="flex items-center justify-between px-6 py-3"
+      style={{ backgroundColor: "#bf5700" }}
+    >
+      <Link href="/" className="text-sm font-semibold text-white">
+        Texas McCombs Co-Foundr
+      </Link>
+
+      <nav className="flex items-center gap-5">
+        <a
+          href="#departments"
+          className="border-b border-white/40 pb-0.5 text-xs font-medium text-white"
+        >
+          Find a co-foundr
+        </a>
+        <Link
+          href="/contact-us"
+          className="text-xs font-medium text-white/75 hover:text-white"
+        >
+          Contact support
+        </Link>
+
+        <div className="relative flex items-center">
+          <FaHeart className="h-[17px] w-[17px] text-white/80" />
+          <span
+            className="absolute -right-1.5 -top-1.5 flex h-[14px] w-[14px] items-center justify-center rounded-full border-[1.5px] text-[8px] font-bold"
+            style={{
+              backgroundColor: "#ffffff",
+              color: "#bf5700",
+              borderColor: "#bf5700",
+            }}
+          >
+            0
+          </span>
+        </div>
+
+        <Link
+          href="/school/ut/sign-in"
+          className="rounded-full px-3 py-1.5 text-xs font-semibold"
+          style={{ backgroundColor: "#ffffff", color: "#bf5700" }}
+        >
+          Sign in
+        </Link>
+      </nav>
+    </header>
+  );
+}

--- a/src/components/school/landing/ValuesPillars.tsx
+++ b/src/components/school/landing/ValuesPillars.tsx
@@ -1,0 +1,61 @@
+const PILLARS = [
+  {
+    title: "Human centered",
+    desc: "Matches built around people, not just skill sets or résumés.",
+  },
+  {
+    title: "Ideas launched",
+    desc: "Connecting bold thinkers ready to take the first step together.",
+  },
+  {
+    title: "Individuals intersected",
+    desc: "Diverse skills, backgrounds, and beliefs — stronger as a team.",
+  },
+  {
+    title: "Future focused",
+    desc: "Building for a world we can't yet imagine, starting now.",
+  },
+];
+
+export default function ValuesPillars() {
+  return (
+    <section
+      className="px-6 py-20"
+      style={{ backgroundColor: "#333f48" }}
+    >
+      <div className="mx-auto max-w-5xl">
+        <h2 className="mb-1.5 text-center text-2xl font-semibold text-white sm:text-3xl">
+          Built on McCombs values
+        </h2>
+        <p
+          className="mb-10 text-center text-sm"
+          style={{ color: "#9cadb7" }}
+        >
+          Every match is filtered against four pillars that define who we are
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {PILLARS.map((p) => (
+            <div
+              key={p.title}
+              className="rounded-lg border border-white/10 bg-white/5 p-5"
+            >
+              <div
+                className="mb-3 h-2 w-2 rounded-full"
+                style={{ backgroundColor: "#bf5700" }}
+              />
+              <div className="mb-1.5 text-sm font-semibold text-white">
+                {p.title}
+              </div>
+              <div
+                className="text-sm leading-relaxed"
+                style={{ color: "#9cadb7" }}
+              >
+                {p.desc}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -8,11 +8,11 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
       <input
         ref={ref}
         className={[
-          "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3.5",
-          "text-white/90 placeholder-white/30",
+          "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5",
+          "text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)]",
           "transition-all duration-200",
-          "focus:border-white/25 focus:bg-white/8 focus:ring-2 focus:ring-white/15 focus:outline-none",
-          "hover:border-white/20",
+          "focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none",
+          "hover:border-[var(--ui-border-strong)]",
           className,
         ].join(" ")}
         {...props}

--- a/src/components/ui/InformationTooltipButton.tsx
+++ b/src/components/ui/InformationTooltipButton.tsx
@@ -11,14 +11,12 @@ export default function TooltipButton({ text, children }: ToolTipProps) {
   const [show, setShow] = useState(false);
 
   return (
-    <div className="relative flex items-center">
-      <button
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        className="ml-3 cursor-pointer text-base"
-      >
-        {children}
-      </button>
+    <div
+      className="relative flex items-center"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      {children}
 
       {show && text}
     </div>

--- a/src/components/ui/LocationSelector.tsx
+++ b/src/components/ui/LocationSelector.tsx
@@ -213,14 +213,14 @@ export default function LocationSelector({
   const isDisabled = !selectedCountryIso || (isUS && !selectedStateIso);
 
   const selectClass =
-    "w-full rounded-lg border border-white/10 bg-[#1a1a1a] px-4 py-2.5 text-white " +
+    "w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] px-4 py-2.5 text-[var(--ui-text)] " +
     "focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none " +
     "disabled:opacity-50 disabled:cursor-not-allowed";
 
   const inputClass =
-    "w-full rounded-lg border border-white/10 bg-[#1a1a1a] px-4 py-2.5 text-white " +
+    "w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] px-4 py-2.5 text-[var(--ui-text)] " +
     "focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none " +
-    "placeholder-white/30 disabled:opacity-50 disabled:cursor-not-allowed";
+    "placeholder-[var(--ui-text-subtle)] disabled:opacity-50 disabled:cursor-not-allowed";
 
   return (
     <div className="space-y-4">
@@ -326,7 +326,7 @@ export default function LocationSelector({
               role="listbox"
               className={
                 "absolute z-50 mt-1 max-h-60 w-full overflow-y-auto " +
-                "rounded-lg border border-white/10 bg-[#1a1a1a] py-1 shadow-xl"
+                "rounded-lg border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] py-1 shadow-xl"
               }
             >
               {filteredCities.map((city, index) => (
@@ -336,10 +336,10 @@ export default function LocationSelector({
                   role="option"
                   aria-selected={index === activeIndex}
                   className={
-                    "cursor-pointer px-4 py-2 text-sm text-white " +
+                    "cursor-pointer px-4 py-2 text-sm text-[var(--ui-text)] " +
                     (index === activeIndex
                       ? "bg-blue-600"
-                      : "hover:bg-white/10")
+                      : "hover:bg-[var(--ui-surface)]")
                   }
                   onMouseDown={(e) => {
                     // Prevent blur from firing before click
@@ -359,8 +359,8 @@ export default function LocationSelector({
             filteredCities.length === 0 && (
               <div
                 className={
-                  "absolute z-50 mt-1 w-full rounded-lg border border-white/10 " +
-                  "bg-[#1a1a1a] px-4 py-3 text-sm text-white/40 shadow-xl"
+                  "absolute z-50 mt-1 w-full rounded-lg border border-[var(--ui-border)] " +
+                  "bg-[var(--ui-popover-bg)] px-4 py-3 text-sm text-[var(--ui-text-muted)] shadow-xl"
                 }
               >
                 No cities found for &ldquo;{cityInput}&rdquo;

--- a/src/components/ui/OnboardingProgressBar.tsx
+++ b/src/components/ui/OnboardingProgressBar.tsx
@@ -71,12 +71,12 @@ export default function OnboardingProgressBar({
             <React.Fragment key={i}>
               {/* Connector line before this dot (skip for first dot) */}
               {i > 0 && (
-                <div className="relative h-[2px] flex-1 overflow-hidden rounded-full bg-white/10">
+                <div className="relative h-[2px] flex-1 overflow-hidden rounded-full bg-[var(--ui-surface)]">
                   <div
                     ref={(el) => {
                       lineRefs.current[i - 1] = el;
                     }}
-                    className="absolute left-0 top-0 h-full rounded-full bg-white"
+                    className="absolute left-0 top-0 h-full rounded-full bg-[var(--ui-btn-bg)]"
                     // Initialise synchronously so GSAP always transitions from the right start value
                     style={{ width: currentStep > i + 1 ? "100%" : "0%" }}
                   />
@@ -95,12 +95,12 @@ export default function OnboardingProgressBar({
                 className={[
                   "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-colors duration-300",
                   isComplete
-                    ? "cursor-pointer bg-white text-black hover:bg-white/80"
+                    ? "cursor-pointer bg-[var(--ui-btn-bg)] text-[var(--ui-btn-text)] hover:bg-[var(--ui-surface)]"
                     : isActive
-                      ? "cursor-default bg-white/15 text-white ring-2 ring-white/50 ring-offset-2 ring-offset-transparent"
+                      ? "cursor-default bg-[var(--ui-surface-active)] text-[var(--ui-text)] ring-2 ring-[var(--ui-border-strong)] ring-offset-2 ring-offset-[var(--org-bg,transparent)]"
                       : isClickable
-                        ? "cursor-pointer bg-white/8 text-white/30 hover:bg-white/12 hover:text-white/50"
-                        : "cursor-default bg-white/8 text-white/25",
+                        ? "cursor-pointer bg-[var(--ui-surface)] text-[var(--ui-text-subtle)] hover:bg-[var(--ui-surface)] hover:text-[var(--ui-text-muted)]"
+                        : "cursor-default bg-[var(--ui-surface)] text-[var(--ui-text-subtle)]",
                 ].join(" ")}
               >
                 {isComplete ? (
@@ -129,10 +129,10 @@ export default function OnboardingProgressBar({
 
       {/* Label row */}
       <div className="mt-3 flex items-center justify-between">
-        <span className="text-xs font-medium tracking-widest text-white/30 uppercase">
+        <span className="text-xs font-medium tracking-widest text-[var(--ui-text-subtle)] uppercase">
           {STEP_LABELS[currentStep - 1]}
         </span>
-        <span className="text-xs text-white/30">
+        <span className="text-xs text-[var(--ui-text-subtle)]">
           {currentStep} / {totalSteps}
         </span>
       </div>

--- a/src/features/likes/likesService.ts
+++ b/src/features/likes/likesService.ts
@@ -93,7 +93,7 @@ export async function checkLikeStatus({
     .select("id")
     .eq("liker_id", likerId)
     .eq("liked_id", likedId)
-    .single();
+    .maybeSingle();
 
   if (error && error.code !== "PGRST116") {
     // PGRST116 is "not found" error, which is expected if no like exists

--- a/src/lib/actions/school-auth.ts
+++ b/src/lib/actions/school-auth.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { getOrganizationBySlug } from "@/lib/organizations";
+import { isEmailDomainAllowed } from "@/lib/auth/email-domain";
+
+export type ExistingUserInfo = {
+  exists: boolean;
+  hasPassword: boolean;
+  oauthProviders: string[];
+};
+
+export async function checkExistingUser(
+  email: string,
+): Promise<ExistingUserInfo> {
+  const empty: ExistingUserInfo = {
+    exists: false,
+    hasPassword: false,
+    oauthProviders: [],
+  };
+  const trimmed = email.trim().toLowerCase();
+  if (!trimmed || !trimmed.includes("@")) return empty;
+
+  try {
+    const clerk = await clerkClient();
+    const result = await clerk.users.getUserList({
+      emailAddress: [trimmed],
+      limit: 1,
+    });
+    if (result.totalCount === 0) return empty;
+    const user = result.data[0];
+    return {
+      exists: true,
+      hasPassword: Boolean(user.passwordEnabled),
+      oauthProviders: user.externalAccounts.map((a) => a.provider),
+    };
+  } catch (err) {
+    console.error("checkExistingUser error:", err);
+    return empty;
+  }
+}
+
+export async function assignSchoolOrg(
+  slug: string,
+): Promise<{ success: true } | { error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated." };
+
+  const org = await getOrganizationBySlug(slug);
+  if (!org) return { error: "Organization not found." };
+
+  const clerk = await clerkClient();
+  const user = await clerk.users.getUser(userId);
+  const primary = user.emailAddresses.find(
+    (e) => e.id === user.primaryEmailAddressId,
+  );
+  const email = primary?.emailAddress;
+  if (!email) return { error: "No email on account." };
+
+  if (!isEmailDomainAllowed(email, org.allowed_email_domains)) {
+    return {
+      error: `This account's email is not eligible for ${org.name}.`,
+    };
+  }
+
+  await clerk.users.updateUserMetadata(userId, {
+    publicMetadata: {
+      ...(user.publicMetadata ?? {}),
+      organization_id: org.id,
+    },
+  });
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+    await supabase
+      .from("profiles")
+      .update({ organization_id: org.id })
+      .eq("user_id", userId);
+  } catch (err) {
+    console.error("assignSchoolOrg: failed to update profile org:", err);
+  }
+
+  return { success: true };
+}

--- a/src/lib/auth/email-domain.ts
+++ b/src/lib/auth/email-domain.ts
@@ -1,0 +1,24 @@
+export function getEmailDomain(email: string): string | null {
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf("@");
+  if (at < 1 || at === trimmed.length - 1) return null;
+  return trimmed.slice(at + 1);
+}
+
+export function isEmailDomainAllowed(
+  email: string,
+  allowedDomains: string[],
+): boolean {
+  if (!allowedDomains || allowedDomains.length === 0) return true;
+  const domain = getEmailDomain(email);
+  if (!domain) return false;
+  return allowedDomains.some((d) => d.trim().toLowerCase() === domain);
+}
+
+export function formatAllowedDomainsForCopy(domains: string[]): string {
+  const cleaned = domains.map((d) => `@${d}`);
+  if (cleaned.length === 0) return "";
+  if (cleaned.length === 1) return cleaned[0];
+  if (cleaned.length === 2) return `${cleaned[0]} or ${cleaned[1]}`;
+  return `${cleaned.slice(0, -1).join(", ")}, or ${cleaned[cleaned.length - 1]}`;
+}

--- a/src/lib/mapProfileToFromDBFormat.ts
+++ b/src/lib/mapProfileToFromDBFormat.ts
@@ -68,7 +68,7 @@ export function mapOnboardingDatatoProfileDB(data: OnboardingData) {
     country: data.country || null,
     state: data.state || null,
     satisfaction: data.satisfaction ?? null,
-    battery_level: data.batteryLevel ?? null,
+    battery_level: (data.batteryLevel ?? null) as "Energized" | "Content" | "Burnt out" | null,
     gender: data.gender || null,
     birthdate: data.birthdate ? new Date(data.birthdate) : null,
     // pfp_url is preserved as-is; validation happens at API layer
@@ -77,7 +77,7 @@ export function mapOnboardingDatatoProfileDB(data: OnboardingData) {
     personal_intro: data.personalIntro || "",
     accomplishments: data.accomplishments || null,
     archetype: data.archetype || null,
-    education: data.education || null,
+    education: data.education ?? null,
     experience: data.experience || null,
     is_technical: data.isTechnical === "yes",
 

--- a/src/lib/utSchoolsAndMajors.ts
+++ b/src/lib/utSchoolsAndMajors.ts
@@ -1,0 +1,210 @@
+export type DegreeType = 'bachelors' | 'masters' | 'professional' | 'other';
+
+interface UTDegreeProgram {
+  degreeType: DegreeType;
+  name: string;
+  abbreviation: string;
+}
+
+export const UT_SCHOOLS_AND_PROGRAMS = {
+  mccombs_business: {
+    label: 'McCombs Business',
+    fullName: 'McCombs School of Business',
+    tier: 'core',
+    color: 'from-orange-600 to-orange-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Business Administration', abbreviation: 'BBA' },
+      { degreeType: 'masters', name: 'Business Administration', abbreviation: 'MBA' },
+      { degreeType: 'masters', name: 'Public Administration', abbreviation: 'MPA' },
+      { degreeType: 'masters', name: 'Finance', abbreviation: 'MFinance' },
+      { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
+    ] as const,
+    sectorInterests: ['b2b_saas', 'fintech'] as const,
+  },
+  cockrell_engineering: {
+    label: 'Cockrell Engineering',
+    fullName: 'Cockrell School of Engineering',
+    tier: 'core',
+    color: 'from-red-600 to-red-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Computer Science', abbreviation: 'CS' },
+      { degreeType: 'bachelors', name: 'Electrical & Computer Engineering', abbreviation: 'ECE' },
+      { degreeType: 'bachelors', name: 'Mechanical Engineering', abbreviation: 'ME' },
+      { degreeType: 'bachelors', name: 'Biomedical Engineering', abbreviation: 'Biomedical' },
+      { degreeType: 'bachelors', name: 'Chemical Engineering', abbreviation: 'ChE' },
+    ] as const,
+    sectorInterests: ['ai_ml', 'deeptech'] as const,
+  },
+  school_of_information: {
+    label: 'School of Information',
+    fullName: 'School of Information',
+    tier: 'core',
+    color: 'from-blue-600 to-blue-700',
+    programs: [
+      { degreeType: 'masters', name: 'Data Science', abbreviation: 'Data Science' },
+      { degreeType: 'masters', name: 'User Experience', abbreviation: 'UX' },
+      { degreeType: 'masters', name: 'Human-Computer Interaction', abbreviation: 'HCI' },
+      { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
+    ] as const,
+    sectorInterests: ['data', 'ux'] as const,
+  },
+  natural_sciences: {
+    label: 'Natural Sciences',
+    fullName: 'College of Natural Sciences',
+    tier: 'core',
+    color: 'from-green-600 to-green-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Biology', abbreviation: 'Biology' },
+      { degreeType: 'bachelors', name: 'Chemistry', abbreviation: 'Chemistry' },
+      { degreeType: 'bachelors', name: 'Neuroscience', abbreviation: 'Neuroscience' },
+    ] as const,
+    sectorInterests: ['healthtech', 'biotech'] as const,
+  },
+  liberal_arts: {
+    label: 'Liberal Arts',
+    fullName: 'College of Liberal Arts',
+    tier: 'core',
+    color: 'from-purple-600 to-purple-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Economics', abbreviation: 'Economics' },
+      { degreeType: 'bachelors', name: 'Government', abbreviation: 'Government' },
+      { degreeType: 'bachelors', name: 'Plan II Honors', abbreviation: 'Plan II' },
+    ] as const,
+    sectorInterests: ['policy', 'impact'] as const,
+  },
+  moody_communication: {
+    label: 'Moody Communication',
+    fullName: 'Moody College of Communication',
+    tier: 'partner',
+    color: 'from-pink-600 to-pink-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Journalism', abbreviation: 'Journalism' },
+      { degreeType: 'bachelors', name: 'Advertising', abbreviation: 'Advertising' },
+      { degreeType: 'bachelors', name: 'Public Relations', abbreviation: 'PR' },
+      { degreeType: 'bachelors', name: 'Radio-Television-Film', abbreviation: 'RTF' },
+    ] as const,
+    sectorInterests: ['media', 'consumer'] as const,
+  },
+  college_of_fine_arts: {
+    label: 'College of Fine Arts',
+    fullName: 'College of Fine Arts',
+    tier: 'partner',
+    color: 'from-cyan-600 to-cyan-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Design', abbreviation: 'Design' },
+      { degreeType: 'bachelors', name: 'Studio Art', abbreviation: 'Studio Art' },
+      { degreeType: 'bachelors', name: 'Music', abbreviation: 'Music' },
+      { degreeType: 'bachelors', name: 'Theatre', abbreviation: 'Theatre' },
+    ] as const,
+    sectorInterests: ['edtech', 'consumer'] as const,
+  },
+  school_of_architecture: {
+    label: 'School of Architecture',
+    fullName: 'School of Architecture',
+    tier: 'partner',
+    color: 'from-amber-600 to-amber-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Architecture', abbreviation: 'BArch' },
+      { degreeType: 'masters', name: 'Architecture', abbreviation: 'MArch' },
+      { degreeType: 'masters', name: 'Urban Design', abbreviation: 'Urban Design' },
+    ] as const,
+    sectorInterests: ['proptech', 'cleantech'] as const,
+  },
+  lbj_public_affairs: {
+    label: 'LBJ Public Affairs',
+    fullName: 'LBJ School of Public Affairs',
+    tier: 'partner',
+    color: 'from-slate-600 to-slate-700',
+    programs: [
+      { degreeType: 'masters', name: 'Public Affairs', abbreviation: 'MPAff' },
+      { degreeType: 'masters', name: 'Global Policy', abbreviation: 'Global Policy' },
+      { degreeType: 'professional', name: 'Juris Doctor / Public Affairs', abbreviation: 'JD/MPAff' },
+    ] as const,
+    sectorInterests: ['govtech', 'impact'] as const,
+  },
+  dell_medical_school: {
+    label: 'Dell Medical School',
+    fullName: 'Dell Medical School',
+    tier: 'partner',
+    color: 'from-rose-600 to-rose-700',
+    programs: [
+      { degreeType: 'professional', name: 'Doctor of Medicine', abbreviation: 'MD' },
+      { degreeType: 'professional', name: 'Doctor of Medicine / Doctor of Philosophy', abbreviation: 'MD/PhD' },
+      { degreeType: 'masters', name: 'Health Innovation', abbreviation: 'Health Innovation' },
+    ] as const,
+    sectorInterests: ['healthtech', 'biotech'] as const,
+  },
+} as const;
+
+export const DEGREE_TYPE_LABELS: Record<DegreeType, string> = {
+  bachelors: "Bachelor's Degree",
+  masters: "Master's Degree",
+  professional: 'Professional Degree',
+  other: 'Other',
+};
+
+export const SECTOR_INTEREST_LABELS: Record<UTSectorInterest, string> = {
+  b2b_saas: 'B2B SaaS',
+  fintech: 'Fintech',
+  ai_ml: 'AI/ML',
+  deeptech: 'DeepTech',
+  data: 'Data',
+  ux: 'UX',
+  healthtech: 'HealthTech',
+  biotech: 'BioTech',
+  policy: 'Policy',
+  impact: 'Impact',
+  media: 'Media',
+  consumer: 'Consumer',
+  edtech: 'EdTech',
+  proptech: 'PropTech',
+  cleantech: 'CleanTech',
+  govtech: 'GovTech',
+};
+
+export const getProgramsForSchool = (
+  school: UTCollege,
+): readonly UTDegreeProgram[] => {
+  return UT_SCHOOLS_AND_PROGRAMS[school].programs;
+};
+
+export const getDegreeTypesForSchool = (
+  school: UTCollege,
+): DegreeType[] => {
+  const programs = getProgramsForSchool(school);
+  const types = new Set(programs.map(p => p.degreeType));
+  return Array.from(types) as DegreeType[];
+};
+
+export const getProgramsForSchoolAndDegreeType = (
+  school: UTCollege,
+  degreeType: DegreeType,
+): readonly UTDegreeProgram[] => {
+  return getProgramsForSchool(school).filter(
+    p => p.degreeType === degreeType,
+  );
+};
+
+export const getSectorInterestsForSchool = (
+  school: UTCollege,
+): readonly UTSectorInterest[] => {
+  return UT_SCHOOLS_AND_PROGRAMS[school].sectorInterests;
+};
+
+export const getSchoolLabel = (school: UTCollege): string => {
+  return UT_SCHOOLS_AND_PROGRAMS[school].label;
+};
+
+export const getSchoolFullName = (school: UTCollege): string => {
+  return UT_SCHOOLS_AND_PROGRAMS[school].fullName;
+};
+
+export const getDegreeAbbreviation = (
+  school: UTCollege,
+  majorName: string | undefined,
+): string | undefined => {
+  if (!majorName) return undefined;
+  const programs = getProgramsForSchool(school);
+  const program = programs.find(p => p.name === majorName);
+  return program?.abbreviation || majorName;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,10 @@ const isPublicRoute = createRouteMatcher([
   "/founder-archetypes",
   "/api/webhooks/clerk",
   "/school/:slug",
+  "/school/:slug/sign-up(.*)",
+  "/school/:slug/sign-in(.*)",
+  "/school/:slug/sso-callback(.*)",
+  "/school/:slug/sso-complete(.*)",
 ]);
 
 type OrgRecord = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -201,7 +201,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
       return NextResponse.next();
     }
 
-    if (isSchoolRoute(req) && !isApiRoute) {
+    if (isSchoolRoute(req) && !isApiRoute && !isPublicRoute(req)) {
       return NextResponse.redirect(new URL("/cofoundr-matching", req.url));
     }
 

--- a/supabase-migrations/update_ut_allowed_email_domains.sql
+++ b/supabase-migrations/update_ut_allowed_email_domains.sql
@@ -1,0 +1,78 @@
+-- Migration: Seed UT Austin / Texas McCombs organization row
+-- Description:
+--   Inserts the UT Austin organization for the isolated sign-up flow at
+--   ut.mamuncofoundr.com. Idempotent: re-running will update the existing row
+--   rather than failing on the UNIQUE(slug) constraint.
+--
+--   Domains:
+--     utexas.edu             -- primary UT EID emails
+--     mccombs.utexas.edu     -- McCombs subdomain (if used separately)
+--     mamuncofoundr.com      -- Mamun internal team (testing access; revisit before public launch)
+--
+--   Sets ferpa_dpa_signed_at = now() so the webhook's email-domain → org
+--   assignment fires and middleware does not redirect to /pending-activation
+--   during testing.
+--
+--   ⚠️  IMPORTANT: ferpa_dpa_signed_at must reflect the actual DPA signing date
+--       before real student data is collected. Replace with the authoritative
+--       timestamp when UT formally signs the agreement.
+--
+-- Run in Supabase SQL Editor or via: supabase db push
+
+-- Defensive: ensure the subdomain column exists (referenced by middleware).
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS subdomain text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_subdomain_key
+  ON organizations (subdomain)
+  WHERE subdomain IS NOT NULL;
+
+INSERT INTO organizations (
+  name,
+  slug,
+  subdomain,
+  type,
+  allowed_email_domains,
+  ferpa_dpa_signed_at,
+  suppress_tracking,
+  settings
+)
+VALUES (
+  'The University of Texas at Austin',
+  'ut',
+  'ut',
+  'school',
+  ARRAY['utexas.edu', 'mccombs.utexas.edu', 'mamuncofoundr.com'],
+  now(),
+  true,
+  '{}'::jsonb
+)
+ON CONFLICT (slug) DO UPDATE
+SET
+  subdomain             = EXCLUDED.subdomain,
+  allowed_email_domains = EXCLUDED.allowed_email_domains,
+  ferpa_dpa_signed_at   = COALESCE(organizations.ferpa_dpa_signed_at, EXCLUDED.ferpa_dpa_signed_at);
+
+DO $$
+DECLARE
+  org_id     uuid;
+  org_name   text;
+  domains    text[];
+  ferpa      timestamptz;
+  subdom     text;
+BEGIN
+  SELECT id, name, subdomain, allowed_email_domains, ferpa_dpa_signed_at
+    INTO org_id, org_name, subdom, domains, ferpa
+    FROM organizations
+    WHERE slug = 'ut';
+
+  IF org_id IS NULL THEN
+    RAISE EXCEPTION 'UT organization row failed to insert.';
+  END IF;
+
+  RAISE NOTICE '✅ UT org id                = %', org_id;
+  RAISE NOTICE '✅ UT name                  = %', org_name;
+  RAISE NOTICE '✅ UT subdomain             = %', subdom;
+  RAISE NOTICE '✅ UT allowed_email_domains = %', domains;
+  RAISE NOTICE '✅ UT ferpa_dpa_signed_at   = %', ferpa;
+END $$;

--- a/supabase/migrations/20260511000000_seed_ut_org.sql
+++ b/supabase/migrations/20260511000000_seed_ut_org.sql
@@ -1,0 +1,90 @@
+-- Migration: Create organizations table (if not exists) and seed UT Austin row
+-- Synced from dev instance 2026-05-11.
+--
+-- Safe to run against prod where organizations table does not yet exist.
+-- Idempotent: re-running will not duplicate or overwrite existing data.
+
+-- ─── Table ────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS organizations (
+  id                    uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  name                  text          NOT NULL,
+  slug                  text          NOT NULL,
+  type                  text          NOT NULL DEFAULT 'school',
+  ferpa_dpa_signed_at   timestamptz,
+  settings              jsonb         DEFAULT '{}'::jsonb,
+  created_at            timestamptz   DEFAULT now(),
+  allowed_email_domains text[]        NOT NULL DEFAULT '{}'::text[],
+  suppress_tracking     boolean       NOT NULL DEFAULT true,
+  updated_at            timestamptz   NOT NULL DEFAULT now(),
+  subdomain             text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_slug_key
+  ON organizations (slug);
+
+-- Ensure subdomain column exists before indexing it
+-- (table may already exist in prod without this column)
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS subdomain text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_subdomain_key
+  ON organizations (subdomain)
+  WHERE subdomain IS NOT NULL;
+
+-- Keep updated_at in sync
+CREATE OR REPLACE FUNCTION update_organizations_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_organizations_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_organizations_updated_at
+      BEFORE UPDATE ON organizations
+      FOR EACH ROW EXECUTE FUNCTION update_organizations_updated_at();
+  END IF;
+END $$;
+
+-- ─── Seed: UT Austin ─────────────────────────────────────────────────────────
+--
+-- allowed_email_domains:
+--   utexas.edu           — primary UT EID emails
+--   mccombs.utexas.edu   — McCombs subdomain
+--   mamuncofoundr.com    — Mamun internal team (revisit before public launch)
+--
+-- ⚠️  ferpa_dpa_signed_at is set to a placeholder timestamp for testing.
+--     Replace with the authoritative DPA signing date before collecting
+--     real student data.
+
+INSERT INTO organizations (
+  name,
+  slug,
+  subdomain,
+  type,
+  allowed_email_domains,
+  ferpa_dpa_signed_at,
+  suppress_tracking,
+  settings
+)
+VALUES (
+  'University of Texas at Austin',
+  'ut',
+  'ut',
+  'school',
+  ARRAY['utexas.edu', 'mccombs.utexas.edu', 'mamuncofoundr.com'],
+  '2026-05-01T23:21:50.033129+00:00',
+  true,
+  '{}'::jsonb
+)
+ON CONFLICT (slug) DO UPDATE
+SET
+  subdomain             = EXCLUDED.subdomain,
+  allowed_email_domains = EXCLUDED.allowed_email_domains,
+  ferpa_dpa_signed_at   = COALESCE(organizations.ferpa_dpa_signed_at, EXCLUDED.ferpa_dpa_signed_at);

--- a/supabase/migrations/20260520000001_create_school_profiles.sql
+++ b/supabase/migrations/20260520000001_create_school_profiles.sql
@@ -1,0 +1,65 @@
+-- Migration: Create School Profiles Extension Table
+--
+-- Unified extension table for any school-tenant's onboarding data. Shared fields
+-- (name, title, experience, etc.) remain in the main `profiles` table; the
+-- school-specific structured fields (status, college, degree, major, sectors)
+-- live here. The shape is identical across schools — only the values differ.
+-- Per-school valid values for `college` and `sector_interests` are enforced at
+-- the application layer (see src/lib/utSchoolsAndMajors.ts for UT).
+--
+-- `organization_id` is duplicated from profiles for query performance, RLS
+-- scoping, and to support a user belonging to multiple schools in the future.
+
+CREATE TABLE IF NOT EXISTS school_profiles (
+  id                   bigserial PRIMARY KEY,
+  user_id              text NOT NULL REFERENCES profiles(user_id) ON DELETE CASCADE,
+  organization_id      uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  school_status        text NOT NULL CHECK (school_status IN ('student', 'alumni')),
+  graduation_year      integer CHECK (graduation_year BETWEEN 1900 AND 2100),
+  college              text,
+  degree_type          text CHECK (degree_type IN ('bachelors', 'masters', 'professional', 'other')),
+  major                text,
+  sector_interests     text[],
+  additional_education text,
+  school_data          jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_school_profiles_org
+  ON school_profiles (organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_school_profiles_sectors
+  ON school_profiles USING gin (sector_interests);
+
+ALTER TABLE school_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Users can read and write only their own row
+CREATE POLICY "school_profiles_own_row" ON school_profiles
+  FOR ALL
+  USING (user_id = auth.uid()::text)
+  WITH CHECK (user_id = auth.uid()::text);
+
+-- Keep updated_at in sync (mirrors the pattern from organizations table)
+CREATE OR REPLACE FUNCTION update_school_profiles_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_school_profiles_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_school_profiles_updated_at
+      BEFORE UPDATE ON school_profiles
+      FOR EACH ROW EXECUTE FUNCTION update_school_profiles_updated_at();
+  END IF;
+END $$;
+
+COMMENT ON TABLE school_profiles IS
+  'Extension table for school-tenant onboarding (UT Austin and future schools). One row per school-onboarded user, linked to profiles.user_id. Presence acts as the "verified school user" gate for matching.';

--- a/supabase/migrations/20260520000003_add_seen_at_to_matching_queue.sql
+++ b/supabase/migrations/20260520000003_add_seen_at_to_matching_queue.sql
@@ -1,0 +1,6 @@
+-- Migration: Add seen_at to matching_queue
+-- Tracks when a profile card was first viewed by the user
+
+ALTER TABLE matching_queue ADD COLUMN IF NOT EXISTS seen_at timestamptz;
+
+COMMENT ON COLUMN matching_queue.seen_at IS 'When the viewer first saw this profile card. NULL = unseen ("New" badge).';

--- a/supabase/migrations/20260524000001_seed_ut_mock_profiles.sql
+++ b/supabase/migrations/20260524000001_seed_ut_mock_profiles.sql
@@ -1,0 +1,235 @@
+-- Seed: 10 mock UT Austin profiles for development/testing
+--
+-- Covers all 10 UT colleges, a mix of students/alumni, founders/non-founders,
+-- technical and non-technical backgrounds.
+--
+-- UT affiliation is expressed via organization_id (FK to organizations.id).
+-- Prerequisites: 20260511000000_seed_ut_org.sql must have been run first.
+--
+-- Note: user_ids use a 'user_mock_ut_' prefix so they are easy to identify
+-- and clean up. These are not real Clerk auth users — remove before production.
+
+DO $$
+DECLARE
+  ut_org_id uuid;
+BEGIN
+  SELECT id INTO ut_org_id FROM organizations WHERE slug = 'ut';
+
+  IF ut_org_id IS NULL THEN
+    RAISE EXCEPTION 'UT organization not found — run 20260511000000_seed_ut_org.sql first.';
+  END IF;
+
+  INSERT INTO profiles (
+    user_id, first_name, last_name, title,
+    city, state, country,
+    satisfaction, battery_level,
+    experience, personal_intro,
+    archetype, is_technical,
+    has_startup, startup_name, startup_description,
+    startup_time_spent, startup_funding,
+    cofounder_status, equity_expectation,
+    linkedin, git,
+    priority_areas,
+    onboarding_complete, organization_id
+  )
+  VALUES
+
+  -- 1. Emma Rodriguez — McCombs BBA, Fintech founder
+  (
+    'user_mock_ut_001', 'Emma', 'Rodriguez',
+    'Finance & Product Intern at JPMorgan',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '3 years of internship experience in financial services and fintech startups. Led product discovery for a mobile payments feature serving 50k users.',
+    'I''m a finance and product nerd who believes fintech can democratize access to financial services. Exploring how AI can make personal finance less intimidating for Gen Z.',
+    'the_scaler', false,
+    true, 'SplitRight',
+    'AI-powered expense splitting for roommates and friend groups, with automatic settlement via Venmo/Zelle.',
+    '6-12 months', 'Pre-seed',
+    'Solo founder', 20,
+    'linkedin.com/in/emmarodriguez-ut', '',
+    ARRAY['Fintech', 'AI / ML', 'Consumer Tech'],
+    true, ut_org_id
+  ),
+
+  -- 2. James Chen — Cockrell CS, AI/ML founder
+  (
+    'user_mock_ut_002', 'James', 'Chen',
+    'ML Engineer Intern at Apple | CS @ UT Austin',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '2 years of software engineering across ML infrastructure, NLP, and applied AI research. Built and deployed production ML pipelines processing 1M+ records/day.',
+    'I build AI systems that actually work in production — not just demos. Passionate about applied machine learning, distributed systems, and the intersection of AI and developer tooling.',
+    'the_architect', true,
+    true, 'ContextIQ',
+    'Developer tooling that uses LLMs to auto-generate context-aware documentation and onboarding guides from existing codebases.',
+    '3-6 months', 'Bootstrapped',
+    'Seeking co-founder', 15,
+    'linkedin.com/in/jamesc-ut', 'github.com/jameschen-dev',
+    ARRAY['AI / ML', 'Developer Tools', 'B2B SaaS'],
+    true, ut_org_id
+  ),
+
+  -- 3. Sarah Kim — iSchool Data Science MS, no startup
+  (
+    'user_mock_ut_003', 'Sarah', 'Kim',
+    'Data Science MS @ UT Austin | UX Researcher',
+    'Austin', 'Texas', 'United States',
+    'Content', 'Content',
+    '4 years of UX research and data analysis. Conducted 100+ user interviews and translated findings into product strategy at two Series A startups.',
+    'I sit at the intersection of quantitative data and human behavior. Most excited about products that use data responsibly to improve how people learn and work.',
+    'the_steward', false,
+    false, null, null, null, null,
+    null, null,
+    'linkedin.com/in/sarahkim-ischool', '',
+    ARRAY['Data & Analytics', 'EdTech', 'No-code / Low-code'],
+    true, ut_org_id
+  ),
+
+  -- 4. Marcus Williams — Natural Sciences Neuroscience, digital health founder
+  (
+    'user_mock_ut_004', 'Marcus', 'Williams',
+    'Neuroscience Researcher & Digital Health Builder',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '2 years of wet lab research in computational neuroscience and 1 year building consumer digital health products. Experience with EEG signal processing and behavioral experiment design.',
+    'Neuroscience trained me to think about systems and feedback loops. Applying that lens to mental health tech — tools that help people understand and regulate their own nervous system.',
+    'the_architect', true,
+    true, 'Regulate',
+    'A biofeedback app that guides users through real-time stress regulation exercises using wearable sensor data (Oura, Apple Watch).',
+    '1-3 months', 'Pre-seed',
+    'Seeking co-founder', 20,
+    'linkedin.com/in/marcuswilliams-neuro', '',
+    ARRAY['HealthTech', 'Mental Health', 'BioTech'],
+    true, ut_org_id
+  ),
+
+  -- 5. Priya Patel — Liberal Arts Economics, no startup
+  (
+    'user_mock_ut_005', 'Priya', 'Patel',
+    'Policy Researcher & Social Entrepreneur',
+    'Austin', 'Texas', 'United States',
+    'Content', 'Content',
+    '3 years of policy research and community organizing. Worked at the Texas Policy Lab and interned with a US Senator''s office on economic policy.',
+    'I study how economic systems create or close opportunity gaps. Goal: build ventures at the intersection of policy and technology that expand access in education and workforce development.',
+    'the_steward', false,
+    false, null, null, null, null,
+    null, null,
+    'linkedin.com/in/priyapatel-policy', '',
+    ARRAY['GovTech', 'EdTech', 'Impact Investing'],
+    true, ut_org_id
+  ),
+
+  -- 6. Tyler Brooks — Moody Advertising, creator economy founder
+  (
+    'user_mock_ut_006', 'Tyler', 'Brooks',
+    'Creative Strategist & Media Founder',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '3 years of brand strategy and content creation. Grew a personal media brand to 80k followers across TikTok and Instagram. Led campaigns for 5 DTC brands.',
+    'The next generation of media brands will be built by creators who also understand business. Building at the intersection of creator economy, brand storytelling, and community.',
+    'the_scaler', false,
+    true, 'StoryStack',
+    'A platform that helps DTC brands co-create authentic content with micro-influencers at scale, using AI to match brand voice with creator style.',
+    '6-12 months', 'Bootstrapped',
+    'Have co-founder(s)', 15,
+    'linkedin.com/in/tylerbrooks-moody', '',
+    ARRAY['B2B SaaS', 'Social & Creator Economy', 'AI / ML'],
+    true, ut_org_id
+  ),
+
+  -- 7. Ananya Singh — Dell Medical School MD, no startup
+  (
+    'user_mock_ut_007', 'Ananya', 'Singh',
+    'MD Student @ Dell Med | Health Innovation',
+    'Austin', 'Texas', 'United States',
+    'Content', 'Energized',
+    '5 years of clinical research and health policy experience. Published 3 papers on AI diagnostics and ran a clinical trial at Johns Hopkins. Participating in Dell Med''s Health Innovation track.',
+    'I chose Dell Med for its focus on redesigning health care. Interested in building AI diagnostic tools that can bring specialist-level insights to underserved communities.',
+    'the_architect', false,
+    false, null, null, null, null,
+    null, null,
+    'linkedin.com/in/ananyasingh-md', '',
+    ARRAY['HealthTech', 'AI / ML', 'Genomics'],
+    true, ut_org_id
+  ),
+
+  -- 8. Connor Murphy — LBJ MPAff alumni, govtech founder
+  (
+    'user_mock_ut_008', 'Connor', 'Murphy',
+    'GovTech Founder | LBJ MPAff Alum',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '4 years of public sector technology and civic innovation. Worked at the City of Austin Office of Innovation and a YC-backed govtech company. Managed $2M in federal grant programs.',
+    'I spent two years inside city government learning where technology could reduce friction for citizens. Now building tools to modernize how local governments deliver services.',
+    'the_scaler', false,
+    true, 'CivicFlow',
+    'A no-code platform that lets city governments digitize and automate citizen-facing workflows — permits, licenses, benefits — without custom development.',
+    '2+ years', 'Seed',
+    'Have co-founder(s)', 10,
+    'linkedin.com/in/connormurphy-lbj', '',
+    ARRAY['GovTech', 'No-code / Low-code', 'B2B SaaS'],
+    true, ut_org_id
+  ),
+
+  -- 9. Luna Torres — Architecture MArch alumni, cleantech founder
+  (
+    'user_mock_ut_009', 'Luna', 'Torres',
+    'Sustainable Design & CleanTech Founder',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '5 years of architectural design and sustainable building. Led net-zero design projects at a top Austin firm. Expertise in embodied carbon analysis and biophilic design.',
+    'Architecture taught me to design systems holistically. Applying that to the built environment''s massive climate impact — starting with the construction materials supply chain.',
+    'the_architect', false,
+    true, 'TerraMod',
+    'A marketplace for low-carbon building materials, connecting sustainable manufacturers with architects and general contractors.',
+    '1-2 years', 'Pre-seed',
+    'Seeking co-founder', 25,
+    'linkedin.com/in/lunatorres-arch', '',
+    ARRAY['CleanTech', 'Climate Tech', 'Energy Tech'],
+    true, ut_org_id
+  ),
+
+  -- 10. David Park — McCombs MBA alumni, B2B SaaS / fintech founder
+  (
+    'user_mock_ut_010', 'David', 'Park',
+    'Venture Builder | McCombs MBA Alum | ex-Goldman',
+    'Austin', 'Texas', 'United States',
+    'Happy', 'Energized',
+    '9 years in finance and venture building. 5 years at Goldman Sachs in TMT investment banking, then MBA, then Head of Finance at a Series B fintech. Now building.',
+    'After years of financing other people''s startups, I decided to build my own. Focused on B2B SaaS and fintech where I have deep pattern recognition from the banking and operator side.',
+    'the_scaler', false,
+    true, 'Clearbook',
+    'Financial operations platform for venture-backed startups — automated bookkeeping, investor reporting, and runway forecasting powered by AI.',
+    '2+ years', 'Seed',
+    'Have co-founder(s)', 10,
+    'linkedin.com/in/davidpark-mba', '',
+    ARRAY['Fintech', 'B2B SaaS', 'AI / ML'],
+    true, ut_org_id
+  )
+
+  ON CONFLICT (user_id) DO NOTHING;
+
+  -- Companion school_profiles rows. Presence here is the "verified school user"
+  -- gate used by /api/profiles. Without these, the mock profiles above would be
+  -- invisible in the UT matching pool.
+  INSERT INTO school_profiles (
+    user_id, organization_id,
+    school_status, graduation_year,
+    college, degree_type, major,
+    sector_interests, additional_education
+  )
+  VALUES
+    ('user_mock_ut_001', ut_org_id, 'student',  2026, 'mccombs_business',     'bachelors',    'Business Administration',     ARRAY['fintech','b2b_saas','ai_ml'],          NULL),
+    ('user_mock_ut_002', ut_org_id, 'student',  2026, 'cockrell_engineering', 'bachelors',    'Computer Science',            ARRAY['ai_ml','deeptech','b2b_saas'],         NULL),
+    ('user_mock_ut_003', ut_org_id, 'student',  2027, 'school_of_information','masters',      'Data Science',                ARRAY['data','ux','edtech'],                  NULL),
+    ('user_mock_ut_004', ut_org_id, 'student',  2026, 'natural_sciences',     'bachelors',    'Neuroscience',                ARRAY['healthtech','biotech'],                NULL),
+    ('user_mock_ut_005', ut_org_id, 'student',  2026, 'liberal_arts',         'bachelors',    'Economics',                   ARRAY['policy','impact','govtech'],           NULL),
+    ('user_mock_ut_006', ut_org_id, 'student',  2026, 'moody_communication',  'bachelors',    'Advertising',                 ARRAY['media','consumer','b2b_saas'],         NULL),
+    ('user_mock_ut_007', ut_org_id, 'student',  2028, 'dell_medical_school',  'professional', 'Doctor of Medicine',          ARRAY['healthtech','biotech','ai_ml'],        NULL),
+    ('user_mock_ut_008', ut_org_id, 'alumni',   2023, 'lbj_public_affairs',   'masters',      'Public Affairs',              ARRAY['govtech','impact','policy'],           NULL),
+    ('user_mock_ut_009', ut_org_id, 'alumni',   2022, 'school_of_architecture','masters',     'Architecture',                ARRAY['cleantech','proptech'],                NULL),
+    ('user_mock_ut_010', ut_org_id, 'alumni',   2020, 'mccombs_business',     'masters',      'Business Administration',     ARRAY['fintech','b2b_saas','ai_ml'],          'BA Economics, Princeton (2014)')
+  ON CONFLICT (user_id) DO NOTHING;
+
+END $$;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -93,6 +93,55 @@ declare global {
     organization_id: string | null;
   };
 
+  // Mirrors the school_profiles DB row. The persistence layer is generic across
+  // schools; the form/dashboard layer still uses UT-prefixed names below
+  // (UTProfileData / utCollege / utSectorInterests) for back-compat — translation
+  // happens in the API routes.
+  type SchoolProfileFromDb = {
+    id: number;
+    user_id: string;
+    organization_id: string;
+    school_status: "student" | "alumni";
+    graduation_year: number | null;
+    college: string | null;
+    degree_type: "bachelors" | "masters" | "professional" | "other" | null;
+    major: string | null;
+    sector_interests: string[] | null;
+    additional_education: string | null;
+    school_data: Record<string, unknown>;
+    created_at: string;
+    updated_at: string;
+  };
+
+  type UTCollege =
+    | 'mccombs_business'
+    | 'cockrell_engineering'
+    | 'school_of_information'
+    | 'natural_sciences'
+    | 'liberal_arts'
+    | 'moody_communication'
+    | 'college_of_fine_arts'
+    | 'school_of_architecture'
+    | 'lbj_public_affairs'
+    | 'dell_medical_school';
+
+  type UTDegreeType = 'bachelors' | 'masters' | 'professional' | 'other';
+
+  type UTSectorInterest =
+    | 'b2b_saas' | 'fintech' | 'ai_ml' | 'deeptech' | 'data' | 'ux'
+    | 'healthtech' | 'biotech' | 'policy' | 'impact'
+    | 'media' | 'consumer' | 'edtech' | 'proptech' | 'cleantech' | 'govtech';
+
+  type UTProfileData = {
+    utStatus?: "student" | "alumni";
+    gradYear?: number;
+    utCollege?: UTCollege;
+    utDegreeType?: UTDegreeType;
+    utMajor?: string;
+    utSectorInterests?: UTSectorInterest[];
+    additionalEducation?: string;
+  };
+
   // Combine all individual form step types
   type OnboardingData = Partial<
     WhoYouAreFormData &
@@ -102,7 +151,9 @@ declare global {
       InterestsAndValuesFormData &
       Preferences &
       HiringSettingsFormData &
-      ActivityFields
+      ActivityFields &
+      MatchingQueueFields &
+      UTProfileData
   >;
 
   type WhoYouAreFormData = {
@@ -185,5 +236,9 @@ declare global {
     last_login_at?: string | null;
     logins_last_7_days?: number;
     logins_last_30_days?: number;
+  };
+
+  type MatchingQueueFields = {
+    isNew?: boolean;
   };
 }


### PR DESCRIPTION
# RFC: MCFM-103 — School Tenant Isolation & UT Austin Launch

**Branch:** `MCFM-103`
**Status:** Draft
**Authors:** Robbie Tambunting
**Diff:** 89 files changed, +7 523 / −578 lines

---

## 1. Motivation

Mamun Co-Foundr is a general-purpose co-founder matching platform. Universities want their own branded, privacy-compliant instance that limits matching to students and alumni of their school. The first partner is **UT Austin**.

This PR introduces a multi-tenant "school" isolation layer so that:

- Each school gets a branded portal at `/school/{slug}` (optionally served from its own subdomain).
- Student data is walled off from the general matching pool at the database, API, and middleware layers.
- FERPA compliance is enforced: no student data is collected until a Data Processing Agreement is recorded.
- Analytics tracking (PostHog) is suppressed per-org when `suppress_tracking` is set.

---

## 2. Architecture Overview

```
┌──────────────┐   subdomain   ┌─────────────┐   path rewrite   ┌──────────────────────┐
│  ut.mamun...  │ ──────────▶  │  middleware  │ ──────────────▶  │ /school/ut/dashboard  │
└──────────────┘               │  (clerk)     │                  └──────────────────────┘
                               │              │
┌──────────────┐   apex host   │  org_id in   │   general pool   ┌──────────────────────┐
│ mamuncofoundr │ ──────────▶  │  JWT claims  │ ──────────────▶  │ /cofoundr-matching    │
└──────────────┘               └─────┬────────┘                  └──────────────────────┘
                                     │
                          ┌──────────▼──────────┐
                          │   Supabase (RLS)     │
                          │  organization_id FK  │
                          └──────────────────────┘
```

### Tenant identity flow

1. **Sign-up:** Clerk `user.created` webhook checks the new user's email domain against `organizations.allowed_email_domains`. If matched (and FERPA DPA is signed), `publicMetadata.organization_id` is stamped on the Clerk user.
2. **Middleware:** Reads `sessionClaims.metadata.organization_id`. School users are routed to `/school/{slug}/*` and gated through FERPA and onboarding checks. General users are routed to `/cofoundr-matching`.
3. **API layer:** `GET /api/profiles` scopes candidates to the caller's `organization_id`. School tenants further filter to users with a `school_profiles` row (verified enrollment).
4. **Database:** RLS policies on `profiles`, `likes`, `matching_queue`, `conversations`, `messages`, and `organizations` enforce isolation via `auth.organization_id()` extracted from the Clerk JWT.

---

## 3. Database Changes

### New tables

| Table | Purpose |
|---|---|
| `organizations` | One row per school. Stores slug, allowed email domains, FERPA DPA timestamp, `suppress_tracking`, and a `settings` JSONB column. |
| `school_profiles` | Per-user school-specific fields (status, graduation year, college, degree type, major, sector interests). Keyed by `user_id`, FK to `organizations`. |

### Schema modifications

| Table | Change |
|---|---|
| `profiles` | Added `organization_id uuid REFERENCES organizations(id)`. `NULL` = general pool. |
| `matching_queue` | Added `seen_at timestamptz` for "New" badge support. |

### RLS policies

A new helper function `auth.organization_id()` extracts the org UUID from the Clerk JWT. Policies on 7 tables enforce: general users see only `organization_id IS NULL` rows; school users see only their own org's rows. Since the app uses the service-role key for API routes, these are defense-in-depth for any anon/client-key access.

### Migrations

| File | Description |
|---|---|
| `supabase-migrations/add_organizations_table.sql` | Creates `organizations` table |
| `supabase-migrations/add_organization_id_to_profiles.sql` | Adds FK column to `profiles` |
| `supabase-migrations/add_organization_rls_policies.sql` | All RLS policies across 7 tables |
| `supabase-migrations/update_ut_allowed_email_domains.sql` | Seeds UT org with `utexas.edu` + sub-domains |
| `supabase/migrations/20260511000000_seed_ut_org.sql` | Seeds the UT Austin organization record |
| `supabase/migrations/20260520000001_create_school_profiles.sql` | Creates `school_profiles` table |
| `supabase/migrations/20260520000003_add_seen_at_to_matching_queue.sql` | Adds `seen_at` column |
| `supabase/migrations/20260524000001_seed_ut_mock_profiles.sql` | 10 mock UT student/alumni profiles for QA |

---

## 4. Middleware (`src/middleware.ts`)

Rewritten to support three traffic classes:

| Class | Detection | Behavior |
|---|---|---|
| **Subdomain** | `ut.mamuncofoundr.com` → `getSubdomain()` | Resolves org from DB, rewrites path to `/school/{slug}/*` |
| **School user** | `organization_id` present in JWT | FERPA gate → onboarding gate → school dashboard |
| **General user** | No `organization_id` | Legacy onboarding → `/cofoundr-matching` |

Key gates:
- **FERPA:** If `org.ferpa_dpa_signed_at` is null, redirect to `/school/{slug}/pending-activation`.
- **Onboarding:** If `metadata.onboardingComplete` is false, redirect to `/school/{slug}/onboarding`.
- **Cross-org guard:** A signed-in user on a subdomain that doesn't match their org is redirected to apex.

---

## 5. Org Registry & Branding (`src/orgs/`)

A static config layer drives per-school theming without DB round-trips on every render.

- **`types.ts`** — `OrgBranding` (colors, logo, wordmark) + `OrgLanding` (headline, CTA labels, hero image).
- **`registry.ts`** — `ORG_REGISTRY` map keyed by slug. UT entry uses burnt orange (`#BF5700`), UT logo SVG, and school-specific copy. Fallback `DEFAULT_ORG_CONFIG` for general branding.
- **`SchoolContext.tsx`** — React context providing `slug`, `schoolName`, and `config` to all school pages.
- **`SchoolHeader.tsx`** — Authenticated school header with org logo/wordmark and nav links.
- **Layout** — `/school/[slug]/layout.tsx` injects CSS custom properties (`--org-primary`, `--org-accent`, etc.) from the config, with semantic light-mode overrides for white-background schools.

---

## 6. School Pages (`src/app/school/[slug]/`)

| Route | Description |
|---|---|
| `page.tsx` | Public landing page with hero, how-it-works, department mosaic, values pillars, CTA band, footer |
| `sign-up/` | Clerk `<SignUp>` with school-branded appearance and `.edu` domain enforcement |
| `sign-in/` | Clerk `<SignIn>` with school-branded appearance |
| `sso-callback/` | Clerk SSO callback handler |
| `sso-complete/` | Post-SSO redirect that syncs org metadata and routes to onboarding or dashboard |
| `onboarding/` | Multi-step school-specific onboarding (About You, Background, Startup, Interests, Photo, Review) |
| `dashboard/` | Card-based co-founder matching UI, scoped to the school tenant, with "New" badges and school-specific profile fields (college, major, degree, graduation year) |
| `matches/` | Mutual matches list for school users |
| `profile/` | Full profile view with school-specific data display |
| `admin/` | Admin dashboard (gated by `is_school_admin` claim) showing registered student list |
| `pending-activation/` | Holding page shown when FERPA DPA is not yet signed |

---

## 7. School Onboarding Forms (`src/app/onboarding/form-components/UT*.tsx`)

Six new form components tailored for UT Austin:

| Component | Fields |
|---|---|
| `UTAboutYouForm` | First/last name, title, city/state/country, student vs. alumni status, graduation year, college, degree type, major |
| `UTBackgroundAndSocialsForm` | Bio, LinkedIn, GitHub |
| `UTStartupForm` | Has startup?, name, description, stage, funding, team size, seeking co-founder |
| `UTInterestsForm` | Sector interests (multi-select pills), archetype selection |
| `UTProfilePhotoForm` | Photo upload with drag-and-drop |
| `UTReviewForm` | Summary card with edit-back links, submit |

All forms use UT branding via CSS custom properties from the layout and submit to `/api/ut-profile`.

---

## 8. API Routes

### New

| Route | Method | Description |
|---|---|---|
| `/api/ut-profile` | `POST` | Upserts both `profiles` and `school_profiles` rows. Validates school-required fields server-side. |
| `/api/profiles/seen` | `PATCH` | Marks a matching-queue entry as seen (sets `seen_at`), enabling the "New" badge. |
| `/api/school/students` | `GET` | Admin-only endpoint returning org-scoped student list. Gated by `is_school_admin` claim. |
| `/api/webhooks/clerk` | `POST` | Extended: on `user.created`, checks email domain against `organizations.allowed_email_domains` and auto-assigns `organization_id` in Clerk metadata if FERPA DPA is signed. |

### Modified

| Route | Change |
|---|---|
| `/api/profiles` | Scopes candidate queries by `organization_id`. School tenants additionally filter to `school_profiles` members. Enriches response with school fields. Adds `isNew` flag from `matching_queue.seen_at`. Mamun staff on apex host bypass org scoping. |
| `/api/messages/.../send` | Replaced inline React email template (`MessageDigestEmail`) with Resend template ID (`new-notification-design-trigger`) and variable-based rendering. |

---

## 9. Matching Pipeline Changes

- **Org-scoped candidates:** `GET /api/profiles` adds a hard `organization_id` filter (equality for school users, `IS NULL` for general pool).
- **School enrollment gate:** For school tenants, only users with a `school_profiles` row for the same org appear as candidates.
- **"New" badge:** `matching_queue.seen_at` is set on first card view via `PATCH /api/profiles/seen`. Profiles with `seen_at = NULL` show a "NEW" badge on the dashboard card.
- **Enriched profiles:** School candidates are enriched with `utStatus`, `utCollege`, `utMajor`, `utDegreeType`, `gradYear`, and `utSectorInterests` from `school_profiles`, displayed on the dashboard card and profile page.

---

## 10. PostHog & Analytics

- `PostHogProvider` now checks `suppress_tracking` from org settings. When true, PostHog is not initialized, and `posthog.opt_out_capturing()` is called (FERPA compliance).
- `trackEvent` calls are safe no-ops when PostHog is suppressed.

---

## 11. Other Notable Changes

| Area | Change |
|---|---|
| **Email templates** | Deleted `MessageDigestEmail.tsx` (inline React Email). Emails now use Resend hosted templates with variable substitution. |
| **Intro survey** | Added `IntroSurveyModal` component with Elfsight integration. |
| **Landing page** | Events section replaced with partnership showcase for UT. |
| **UI components** | Action buttons updated to dark minimalist style with colored hover glows. Message icon changed to paper airplane. |
| **Logo** | Replaced image-based logo with text rendering. |
| **Conditional shell** | New `ConditionalShell` wrapper that omits the general app header/footer for school org routes. |
| **Email domain utils** | `src/lib/auth/email-domain.ts` — domain extraction, allowlist check, and human-friendly domain formatting. |
| **UT reference data** | `src/lib/utSchoolsAndMajors.ts` — UT colleges, majors per college, degree types, sector interests, and display helpers. |
| **Global types** | Extended with `OrganizationFromDb`, `SchoolProfileFromDb`, `UTProfileData`, `MatchingQueueFields`, and updated `OnboardingData` to include school fields. |

---

## 12. Security Considerations

| Concern | Mitigation |
|---|---|
| Cross-tenant data leakage | RLS policies + API-layer `organization_id` filtering + middleware org-check |
| FERPA — data collection before DPA | Middleware blocks login until `ferpa_dpa_signed_at` is set; webhook skips org assignment if DPA is unsigned |
| FERPA — analytics | `suppress_tracking` disables PostHog initialization for school orgs |
| Admin endpoint access | `/api/school/students` checks `is_school_admin` JWT claim |
| Email domain spoofing | Domain validation uses `allowed_email_domains` array stored in DB; Clerk handles email verification |

---

## 13. Testing Notes

- **Mock data:** 10 realistic UT mock profiles seeded via migration for QA.
- **Subdomain testing locally:** Set `ut.localhost:3000` in `/etc/hosts` or use the path-based `/school/ut/` route.
- **FERPA gate:** Set `ferpa_dpa_signed_at = NULL` on the UT org row to verify the pending-activation redirect.
- **General pool isolation:** Verify that school profiles do not appear in `/cofoundr-matching` and vice versa.
- **Admin dashboard:** Set `is_school_admin: true` in a user's Clerk `publicMetadata` to access `/school/ut/admin`.
