### PR TITLE
MCFM-110 | UT Core Functionality Bug Fixes

### DIFF
--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -8,14 +8,12 @@ import {
 
 export async function GET(request: NextRequest) {
   try {
-    // Get the authenticated user from Clerk
-    const { userId } = await auth();
+    const { userId, sessionClaims } = await auth();
 
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get the token from the request headers
     const authHeader = request.headers.get("authorization");
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
@@ -25,14 +23,14 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Create Supabase client with service role key for server-side operations
     const supabase = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY!,
     );
 
-    // Fetch conversations for the user
-    const result = await getUserConversations(userId, supabase);
+    const orgId = (sessionClaims?.metadata as Record<string, unknown>)?.organization_id as string | undefined ?? null;
+
+    const result = await getUserConversations(userId, supabase, orgId);
 
     if (result.error) {
       return NextResponse.json({ error: result.error }, { status: 500 });

--- a/src/app/api/likes/mutual/route.ts
+++ b/src/app/api/likes/mutual/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+
+export async function GET() {
+  try {
+    const { userId, sessionClaims } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const orgId =
+      ((sessionClaims?.metadata as Record<string, unknown>)
+        ?.organization_id as string | undefined) ?? null;
+
+    // Get profiles the user has liked
+    const { data: userLikes, error: userLikesError } = await supabase
+      .from("likes")
+      .select("liked_id")
+      .eq("liker_id", userId);
+
+    if (userLikesError) {
+      console.error("Error fetching user likes:", userLikesError);
+      return NextResponse.json(
+        { error: "Failed to fetch likes" },
+        { status: 500 },
+      );
+    }
+
+    if (!userLikes || userLikes.length === 0) {
+      return NextResponse.json({ matches: [] });
+    }
+
+    const likedIds = userLikes.map((like) => like.liked_id);
+
+    // Get profiles that liked the user back (mutual)
+    const { data: mutualLikes, error: mutualLikesError } = await supabase
+      .from("likes")
+      .select("liker_id")
+      .eq("liked_id", userId)
+      .in("liker_id", likedIds);
+
+    if (mutualLikesError) {
+      console.error("Error fetching mutual likes:", mutualLikesError);
+      return NextResponse.json(
+        { error: "Failed to fetch mutual likes" },
+        { status: 500 },
+      );
+    }
+
+    if (!mutualLikes || mutualLikes.length === 0) {
+      return NextResponse.json({ matches: [] });
+    }
+
+    const matchIds = mutualLikes.map((like) => like.liker_id);
+
+    // Filter to only include users from the same organization
+    let profileQuery = supabase
+      .from("profiles")
+      .select("user_id")
+      .in("user_id", matchIds)
+      .is("deleted_at", null);
+
+    if (orgId) {
+      profileQuery = profileQuery.eq("organization_id", orgId);
+    } else {
+      profileQuery = profileQuery.is("organization_id", null);
+    }
+
+    const { data: orgProfiles, error: orgError } = await profileQuery;
+
+    if (orgError) {
+      console.error("Error filtering by org:", orgError);
+      return NextResponse.json(
+        { error: "Failed to filter matches" },
+        { status: 500 },
+      );
+    }
+
+    const orgMatchIds = orgProfiles?.map((p) => p.user_id) ?? [];
+
+    return NextResponse.json({ matches: orgMatchIds });
+  } catch (error) {
+    console.error("Error in mutual likes API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/likes/profiles/route.ts
+++ b/src/app/api/likes/profiles/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
+
+export async function GET() {
+  try {
+    const { userId, sessionClaims } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const orgId =
+      ((sessionClaims?.metadata as Record<string, unknown>)
+        ?.organization_id as string | undefined) ?? null;
+
+    // Get IDs of profiles the user has liked
+    const { data: likes, error: likesError } = await supabase
+      .from("likes")
+      .select("liked_id")
+      .eq("liker_id", userId);
+
+    if (likesError) {
+      console.error("Error fetching liked profiles:", likesError);
+      return NextResponse.json(
+        { error: "Failed to fetch likes" },
+        { status: 500 },
+      );
+    }
+
+    if (!likes || likes.length === 0) {
+      return NextResponse.json({ profiles: [] });
+    }
+
+    const likedIds = likes.map((l) => l.liked_id);
+
+    // Get full profile data, scoped to the user's organization
+    let profileQuery = supabase
+      .from("profiles")
+      .select("*")
+      .in("user_id", likedIds)
+      .is("deleted_at", null);
+
+    if (orgId) {
+      profileQuery = profileQuery.eq("organization_id", orgId);
+    } else {
+      profileQuery = profileQuery.is("organization_id", null);
+    }
+
+    const { data: profiles, error: profilesError } = await profileQuery;
+
+    if (profilesError) {
+      console.error("Error fetching profile data:", profilesError);
+      return NextResponse.json(
+        { error: "Failed to fetch profiles" },
+        { status: 500 },
+      );
+    }
+
+    let mapped = (profiles ?? []).map(mapProfileToOnboardingData);
+
+    // For school tenants, enrich with school_profiles data
+    if (orgId && mapped.length > 0) {
+      const userIds = mapped
+        .map((p) => p.user_id)
+        .filter((id): id is string => Boolean(id));
+
+      const { data: schoolRows } = await supabase
+        .from("school_profiles")
+        .select(
+          "user_id, school_status, graduation_year, college, degree_type, major, sector_interests",
+        )
+        .eq("organization_id", orgId)
+        .in("user_id", userIds);
+
+      if (schoolRows && schoolRows.length > 0) {
+        const schoolMap = new Map(
+          schoolRows.map((row) => [
+            row.user_id,
+            {
+              utStatus: row.school_status,
+              gradYear: row.graduation_year,
+              utCollege: row.college,
+              utDegreeType: row.degree_type,
+              utMajor: row.major,
+              utSectorInterests: row.sector_interests,
+            },
+          ]),
+        );
+
+        mapped = mapped.map((profile) => {
+          const school = schoolMap.get(profile.user_id!);
+          return school ? { ...profile, ...school } : profile;
+        });
+      }
+    }
+
+    return NextResponse.json({ profiles: mapped });
+  } catch (error) {
+    console.error("Error in liked profiles API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/messages/[conversationId]/send/route.ts
+++ b/src/app/api/messages/[conversationId]/send/route.ts
@@ -13,8 +13,7 @@ export async function POST(
   { params }: { params: Promise<{ conversationId: string }> },
 ) {
   try {
-    // Get the authenticated user from Clerk
-    const { userId } = await auth();
+    const { userId, sessionClaims } = await auth();
 
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -71,30 +70,34 @@ export async function POST(
       );
     }
 
-    // Check message count limit (20 messages per conversation)
-    const { count: messageCount, error: countError } = await supabase
-      .from("messages")
-      .select("*", { count: "exact", head: true })
-      .eq("conversation_id", conversationId);
+    // School org users have no message limits
+    const orgId = (sessionClaims?.metadata as Record<string, unknown>)?.organization_id as string | undefined ?? null;
 
-    if (countError) {
-      console.error("Error counting messages:", countError);
-      return NextResponse.json(
-        { error: "Failed to check message count" },
-        { status: 500 },
-      );
-    }
+    if (!orgId) {
+      const { count: messageCount, error: countError } = await supabase
+        .from("messages")
+        .select("*", { count: "exact", head: true })
+        .eq("conversation_id", conversationId);
 
-    if (messageCount && messageCount >= 20) {
-      return NextResponse.json(
-        {
-          error: "Message limit reached (20 messages per conversation)",
-          messageCount: messageCount,
-          limit: 20,
-          suggestion: "Connect on other platforms to continue the conversation",
-        },
-        { status: 429 },
-      );
+      if (countError) {
+        console.error("Error counting messages:", countError);
+        return NextResponse.json(
+          { error: "Failed to check message count" },
+          { status: 500 },
+        );
+      }
+
+      if (messageCount && messageCount >= 20) {
+        return NextResponse.json(
+          {
+            error: "Message limit reached (20 messages per conversation)",
+            messageCount: messageCount,
+            limit: 20,
+            suggestion: "Connect on other platforms to continue the conversation",
+          },
+          { status: 429 },
+        );
+      }
     }
 
     // Insert the message into the database

--- a/src/app/api/swipe-count/route.ts
+++ b/src/app/api/swipe-count/route.ts
@@ -4,27 +4,32 @@ import { createClient } from "@supabase/supabase-js";
 
 export async function GET() {
   try {
-    // Get the authenticated user from Clerk
-    const { userId } = await auth();
+    const { userId, sessionClaims } = await auth();
 
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Create Supabase client with service role key (bypasses RLS)
+    // School org users have no swipe limits
+    const orgId = (sessionClaims?.metadata as Record<string, unknown>)?.organization_id as string | undefined ?? null;
+    if (orgId) {
+      return NextResponse.json({
+        count: 0,
+        hasReachedLimit: false,
+        currentCount: 0,
+        limit: Infinity,
+      });
+    }
+
     const supabase = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY!,
     );
 
-    // Get today's date in UTC
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);
     const todayISO = today.toISOString();
 
-    console.log("Checking swipe count for user:", userId, "since:", todayISO);
-
-    // Get user's internal profile ID first
     const { data: userProfile, error: profileError } = await supabase
       .from("profiles")
       .select("id")
@@ -41,7 +46,6 @@ export async function GET() {
 
     const userProfileId = userProfile.id;
 
-    // Count likes from likes table
     const { count: likesCount, error: likesError } = await supabase
       .from("likes")
       .select("*", { count: "exact", head: true })
@@ -56,7 +60,6 @@ export async function GET() {
       );
     }
 
-    // Count skips from user_profile_actions table
     const { count: skipsCount, error: skipsError } = await supabase
       .from("user_profile_actions")
       .select("*", { count: "exact", head: true })
@@ -73,16 +76,7 @@ export async function GET() {
     }
 
     const totalSwipes = (likesCount || 0) + (skipsCount || 0);
-    const limit = 10; // Free plan limit
-
-    console.log(
-      "Likes count:",
-      likesCount,
-      "Skips count:",
-      skipsCount,
-      "Total:",
-      totalSwipes,
-    );
+    const limit = 10;
 
     return NextResponse.json({
       count: totalSwipes,

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -11,13 +11,11 @@ import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
 
 import HiringBadge from "@/components/HiringBadge";
-import SwipeLimit from "@/components/SwipeLimit";
 import { useGetProfiles } from "@/features/profile/useProfile";
 import { useSchool } from "@/components/school/SchoolContext";
 import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/useLikes";
 import { useCreateConversation } from "@/hooks/useConversations";
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
-import { useSwipeLimit } from "@/features/swipes/useSwipes";
 import { trackEvent } from "@/lib/posthog-events";
 import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/lib/utSchoolsAndMajors";
 
@@ -37,7 +35,6 @@ export default function SchoolDashboardPage({
   useMutualLikes();
   const createConversationMutation = useCreateConversation();
   const skipProfileMutation = useSkipProfile();
-  const { data: swipeLimitData } = useSwipeLimit();
 
   const curProfile = profiles?.[0];
   const { data: likeStatus } = useLikeStatus(curProfile?.user_id);
@@ -102,17 +99,14 @@ export default function SchoolDashboardPage({
     const resolvedParams = await params;
     setIsStartingConversation(true);
     try {
-      const result = await createConversationMutation.mutateAsync(
-        curProfile.user_id,
-      );
-      if (result?.conversation?.id) {
-        router.push(`/school/${resolvedParams.slug}/matches`);
-      }
+      await createConversationMutation.mutateAsync({
+        otherUserId: curProfile.user_id,
+      });
     } catch {
       toast.error("Failed to start conversation");
-    } finally {
-      setIsStartingConversation(false);
     }
+    setIsStartingConversation(false);
+    router.push(`/school/${resolvedParams.slug}/matches?tab=messages`);
   };
 
   const brandingHeader = (
@@ -125,21 +119,6 @@ export default function SchoolDashboardPage({
       </h1>
     </div>
   );
-
-  if (swipeLimitData?.hasReachedLimit) {
-    return (
-      <div className="mx-auto max-w-2xl p-4 pt-6">
-        {brandingHeader}
-        <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
-          <SwipeLimit
-            hasReachedLimit={swipeLimitData.hasReachedLimit}
-            currentCount={swipeLimitData.currentCount}
-            limit={swipeLimitData.limit}
-          />
-        </div>
-      </div>
-    );
-  }
 
   if (!curProfile) {
     return (
@@ -321,7 +300,7 @@ export default function SchoolDashboardPage({
             <button
               onClick={handleSkip}
               disabled={skipProfileMutation.isPending}
-              className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
+              className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] transition hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)] cursor-pointer"
             >
               <MdSkipNext className="h-5 w-5" />
             </button>
@@ -329,7 +308,7 @@ export default function SchoolDashboardPage({
             <button
               onClick={handleMessage}
               disabled={isStartingConversation}
-              className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[#bf5700] py-3 text-white transition hover:bg-[#a04e00] disabled:opacity-50"
+              className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[#bf5700] py-3 text-white transition hover:bg-[#a04e00] disabled:opacity-50 cursor-pointer"
             >
               <TbSend className="h-5 w-5" />
               <span className="text-sm font-medium">Message</span>
@@ -338,7 +317,7 @@ export default function SchoolDashboardPage({
             <button
               onClick={handleLike}
               disabled={isLikeLoading}
-              className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full transition ${
+              className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full transition cursor-pointer ${
                 likeStatus?.isLiked
                   ? "bg-pink-500 text-white"
                   : "border border-[var(--ui-border-strong)] text-[var(--ui-text-muted)] hover:border-pink-400 hover:text-pink-400"

--- a/src/app/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/school/[slug]/matches/[conversationId]/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { FaArrowLeft, FaEnvelope, FaUser } from "react-icons/fa6";
+import { motion } from "motion/react";
+import { useRouter } from "next/navigation";
+import { useSession } from "@clerk/nextjs";
+import { useMessages } from "@/hooks/useMessages";
+import { useConversation } from "@/hooks/useConversations";
+import MessageItem from "@/components/MessageItem";
+import { Message } from "@/features/messages/messagesService";
+import AIWriter from "@/components/ui/AIWriter";
+import { trackEvent } from "@/lib/posthog-events";
+import ActivityIndicator from "@/components/ActivityIndicator";
+
+interface ConversationPageProps {
+  params: Promise<{
+    slug: string;
+    conversationId: string;
+  }>;
+}
+
+export default function SchoolConversationPage({ params }: ConversationPageProps) {
+  const router = useRouter();
+  const { session } = useSession();
+  const [slug, setSlug] = React.useState<string>("");
+  const [conversationId, setConversationId] = React.useState<string>("");
+  const [messageInput, setMessageInput] = React.useState<string>("");
+  const [isSending, setIsSending] = React.useState<boolean>(false);
+  const [sendError, setSendError] = React.useState<string | null>(null);
+  const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
+  const messagesEndRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    params.then((resolvedParams) => {
+      setSlug(resolvedParams.slug);
+      setConversationId(resolvedParams.conversationId);
+    });
+  }, [params]);
+
+  const { messages, isLoading, error, sendMessage } =
+    useMessages(conversationId);
+  const { data: conversation, isLoading: isConversationLoading } =
+    useConversation(conversationId);
+  const currentUserId = session?.user?.id;
+
+  React.useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!messageInput.trim() || isSending) return;
+
+    setIsSending(true);
+    setSendError(null);
+    setIsLimitReached(false);
+
+    try {
+      await sendMessage(messageInput.trim());
+
+      trackEvent.messageSent(conversationId, {
+        message_length: messageInput.trim().length,
+        total_messages_in_conversation: messages.length + 1,
+      });
+
+      setMessageInput("");
+    } catch (error: unknown) {
+      console.error("Failed to send message:", error);
+      if (typeof window !== "undefined" && window.posthog) {
+        window.posthog.captureException(error);
+      }
+
+      if (error && typeof error === "object" && "isLimitReached" in error) {
+        const limitError = error as Error & {
+          isLimitReached: boolean;
+          messageCount: number;
+          limit: number;
+          suggestion: string;
+        };
+        setIsLimitReached(true);
+        setSendError(limitError.message);
+      } else {
+        const genericError = error as Error;
+        setSendError(genericError.message || "Failed to send message");
+      }
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl p-4 pt-6">
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mb-4 flex items-center gap-3 border-b border-[var(--ui-border)] pb-4"
+      >
+        <button
+          onClick={() => router.push(`/school/${slug}/matches`)}
+          className="flex items-center gap-1.5 rounded-full p-2 text-[var(--ui-text-muted)] transition hover:bg-[var(--ui-surface)] hover:text-[var(--ui-text)] cursor-pointer"
+        >
+          <FaArrowLeft className="h-4 w-4" />
+          <span className="text-sm font-medium">Back</span>
+        </button>
+
+        <div className="flex items-center gap-3">
+          <div className="relative h-10 w-10 overflow-hidden rounded-full">
+            {isConversationLoading ? (
+              <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
+                <FaUser className="h-5 w-5" />
+              </div>
+            ) : conversation?.otherParticipant?.pfp_url ? (
+              <Image
+                src={conversation.otherParticipant.pfp_url}
+                alt={`${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim()}
+                width={40}
+                height={40}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
+                <FaUser className="h-5 w-5" />
+              </div>
+            )}
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-lg font-bold text-[var(--ui-text)]">
+                {isConversationLoading
+                  ? "Loading..."
+                  : conversation?.otherParticipant
+                    ? `${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim() || "Conversation"
+                    : "Conversation"}
+              </h1>
+              {!isConversationLoading && conversation?.otherParticipant && (
+                <ActivityIndicator
+                  lastActiveAt={conversation.otherParticipant.last_active_at}
+                  size="sm"
+                  showLabel={true}
+                />
+              )}
+            </div>
+            <p className="text-xs text-[var(--ui-text-muted)]">
+              {messages.length}/20 messages
+            </p>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Notices */}
+      <div className="mb-4 space-y-2">
+        <div className="rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] p-3">
+          <p className="text-xs text-[var(--ui-text-muted)]">
+            This is a starting point to connect outside of Mamun. Messages are
+            not encrypted, so please don&apos;t share sensitive data here.
+          </p>
+        </div>
+
+        {messages.length >= 20 && (
+          <div className="rounded-lg border border-orange-300 bg-orange-50 p-3">
+            <p className="text-xs font-medium text-orange-700">
+              Message limit reached (20/20). This is a starting point to connect outside of Mamun.
+            </p>
+          </div>
+        )}
+
+        {sendError && (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-3">
+            <p className="text-xs font-medium text-red-700">{sendError}</p>
+            {isLimitReached && (
+              <p className="mt-1 text-xs text-red-600">
+                This is a starting point to connect outside of Mamun.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Messages */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className="flex flex-col rounded-xl border border-[var(--ui-border)] bg-white"
+        style={{ height: "calc(100vh - 320px)", minHeight: "400px" }}
+      >
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--org-primary)] border-t-transparent" />
+            </div>
+          ) : error ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+              <FaEnvelope className="h-8 w-8 text-[var(--ui-text-subtle)]" />
+              <p className="text-sm font-medium text-[var(--ui-text)]">
+                Error loading messages
+              </p>
+              <p className="text-xs text-[var(--ui-text-muted)]">{error.message}</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="mt-2 rounded-lg bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white hover:opacity-90 cursor-pointer"
+              >
+                Try Again
+              </button>
+            </div>
+          ) : messages.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+              <FaEnvelope className="h-8 w-8 text-[var(--ui-text-subtle)]" />
+              <p className="text-sm font-medium text-[var(--ui-text)]">
+                No messages yet
+              </p>
+              <p className="text-xs text-[var(--ui-text-muted)]">
+                Send your first message to start the conversation!
+              </p>
+            </div>
+          ) : (
+            messages.map((message: Message) => (
+              <MessageItem
+                key={message.id}
+                message={message}
+                isOwnMessage={message.sender_id === currentUserId}
+              />
+            ))
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input */}
+        <div className="border-t border-[var(--ui-border)] p-3">
+          <div className="mb-2">
+            <AIWriter
+              text={messageInput}
+              fieldType="message"
+              onAccept={(suggestion) => setMessageInput(suggestion)}
+            />
+          </div>
+
+          <form onSubmit={handleSendMessage} className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder={
+                messages.length >= 20
+                  ? "Message limit reached"
+                  : "Type a message..."
+              }
+              value={messageInput}
+              onChange={(e) => setMessageInput(e.target.value)}
+              className="flex-1 rounded-lg border border-[var(--ui-border)] bg-white px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--org-primary)] focus:outline-none"
+              disabled={isSending || messages.length >= 20}
+              maxLength={1000}
+            />
+            <button
+              type="submit"
+              className="rounded-lg bg-[var(--org-primary)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-40 cursor-pointer"
+              disabled={!messageInput.trim() || isSending || messages.length >= 20}
+            >
+              {isSending ? "Sending..." : "Send"}
+            </button>
+          </form>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/school/[slug]/matches/page.tsx
+++ b/src/app/school/[slug]/matches/page.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "@clerk/nextjs";
 import { FaEnvelope, FaHeart } from "react-icons/fa6";
 import { FaSync } from "react-icons/fa";
 import { motion } from "motion/react";
+import Image from "next/image";
 import ConversationItem from "@/components/ConversationItem";
 import { ConversationWithOtherParticipant } from "@/features/conversations/conversationService";
-import { useState, useEffect, useCallback } from "react";
+import { useLikedProfilesData, useToggleLike } from "@/features/likes/useLikes";
+import { useCreateConversation } from "@/hooks/useConversations";
+import { getDegreeAbbreviation } from "@/lib/utSchoolsAndMajors";
+import React, { useState, useEffect, useCallback } from "react";
+import toast from "react-hot-toast";
+
+type Tab = "messages" | "liked";
 
 export default function SchoolMatchesPage({
   params,
@@ -15,13 +22,31 @@ export default function SchoolMatchesPage({
   params: Promise<{ slug: string }>;
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { session } = useSession();
+  const tabParam = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState<Tab>(
+    tabParam === "messages" ? "messages" : "liked"
+  );
+
+  useEffect(() => {
+    if (tabParam === "messages") {
+      setActiveTab("messages");
+    }
+  }, [tabParam]);
   const [conversations, setConversations] = useState<
     ConversationWithOtherParticipant[]
   >([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const currentUserId = session?.user?.id;
+
+  const { data: likedProfilesData, isLoading: isLikedLoading } =
+    useLikedProfilesData();
+  const { toggleLike, isLoading: isUnliking } = useToggleLike();
+  const createConversationMutation = useCreateConversation();
+
+  const likedProfiles = likedProfilesData?.profiles ?? [];
 
   const fetchConversations = useCallback(async () => {
     if (!session) {
@@ -64,50 +89,220 @@ export default function SchoolMatchesPage({
     router.push(`/school/${resolvedParams.slug}/matches/${conversationId}`);
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center">
-        <FaSync className="h-6 w-6 animate-spin text-[var(--ui-text-muted)]" />
-      </div>
-    );
-  }
+  const handleMessage = async (otherUserId: string) => {
+    const resolvedParams = await params;
+    try {
+      const result = await createConversationMutation.mutateAsync({
+        otherUserId,
+      });
+      if (result?.conversation?.id) {
+        router.push(
+          `/school/${resolvedParams.slug}/matches/${result.conversation.id}`,
+        );
+      }
+    } catch {
+      toast.error("Failed to start conversation");
+    }
+  };
+
+  const handleUnlike = async (userId: string) => {
+    try {
+      await toggleLike(userId, true);
+    } catch {
+      toast.error("Failed to remove like");
+    }
+  };
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode; count?: number }[] = [
+    {
+      id: "liked",
+      label: "Liked",
+      icon: <FaHeart className="h-4 w-4" />,
+      count: likedProfiles.length,
+    },
+    {
+      id: "messages",
+      label: "Messages",
+      icon: <FaEnvelope className="h-4 w-4" />,
+      count: conversations.length,
+    },
+  ];
 
   return (
     <div className="mx-auto max-w-2xl p-4 pt-6">
-      <div className="mb-6 flex items-center gap-2">
-        <FaEnvelope className="h-5 w-5 text-[var(--ui-text-muted)]" />
-        <h1 className="text-xl font-semibold text-[var(--ui-text)]">Messages</h1>
+      {/* Tab bar */}
+      <div className="mb-6 flex gap-1 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] p-1">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2.5 text-sm font-medium transition cursor-pointer ${
+              activeTab === tab.id
+                ? "bg-[var(--org-primary)] text-white shadow-sm"
+                : "text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
+            }`}
+          >
+            {tab.icon}
+            {tab.label}
+            {(tab.count ?? 0) > 0 && (
+              <span
+                className={`rounded-full px-1.5 py-0.5 text-xs font-semibold ${
+                  activeTab === tab.id
+                    ? "bg-white/20 text-white"
+                    : "bg-[var(--ui-surface-active)] text-[var(--ui-text-muted)]"
+                }`}
+              >
+                {tab.count}
+              </span>
+            )}
+          </button>
+        ))}
       </div>
 
-      {error && (
-        <p className="mb-4 rounded-lg bg-red-500/10 p-3 text-sm text-red-400">
-          Failed to load conversations. Please refresh.
-        </p>
+      {/* Messages tab */}
+      {activeTab === "messages" && (
+        <>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <FaSync className="h-6 w-6 animate-spin text-[var(--ui-text-muted)]" />
+            </div>
+          ) : error ? (
+            <p className="mb-4 rounded-lg bg-red-500/10 p-3 text-sm text-red-400">
+              Failed to load conversations. Please refresh.
+            </p>
+          ) : conversations.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <FaEnvelope className="h-10 w-10 text-[var(--ui-text-subtle)]" />
+              <p className="font-medium text-[var(--ui-text-muted)]">
+                No conversations yet
+              </p>
+              <p className="text-sm text-[var(--ui-text-subtle)]">
+                Message a co-founder from their profile card to start chatting.
+              </p>
+            </div>
+          ) : (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="space-y-2"
+            >
+              {conversations.map((convo) => (
+                <ConversationItem
+                  key={convo.id}
+                  conversation={convo}
+                  currentUserId={currentUserId || ""}
+                  onClick={() => handleConversationClick(convo.id)}
+                />
+              ))}
+            </motion.div>
+          )}
+        </>
       )}
 
-      {conversations.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 py-16 text-center">
-          <FaHeart className="h-10 w-10 text-[var(--ui-text-subtle)]" />
-          <p className="font-medium text-[var(--ui-text-muted)]">No conversations yet</p>
-          <p className="text-sm text-[var(--ui-text-subtle)]">
-            Like a co-founder to start a conversation.
-          </p>
-        </div>
-      ) : (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          className="space-y-2"
-        >
-          {conversations.map((convo) => (
-            <ConversationItem
-              key={convo.id}
-              conversation={convo}
-              currentUserId={currentUserId || ""}
-              onClick={() => handleConversationClick(convo.id)}
-            />
-          ))}
-        </motion.div>
+      {/* Liked tab */}
+      {activeTab === "liked" && (
+        <>
+          {isLikedLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <FaSync className="h-6 w-6 animate-spin text-[var(--ui-text-muted)]" />
+            </div>
+          ) : likedProfiles.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <FaHeart className="h-10 w-10 text-[var(--ui-text-subtle)]" />
+              <p className="font-medium text-[var(--ui-text-muted)]">
+                No liked profiles yet
+              </p>
+              <p className="text-sm text-[var(--ui-text-subtle)]">
+                Like a co-founder from the dashboard and they&apos;ll appear
+                here.
+              </p>
+            </div>
+          ) : (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="space-y-3"
+            >
+              {likedProfiles.map((profile) => {
+                const initials =
+                  (profile.firstName?.[0] ?? "").toUpperCase() +
+                  (profile.lastName?.[0] ?? "").toUpperCase();
+
+                const degreeAbbrev =
+                  profile.utCollege && profile.utMajor
+                    ? getDegreeAbbreviation(profile.utCollege, profile.utMajor)
+                    : undefined;
+
+                const yearSuffix = profile.gradYear
+                  ? `'${String(profile.gradYear).slice(-2)}`
+                  : undefined;
+
+                return (
+                  <div
+                    key={profile.user_id}
+                    className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4"
+                  >
+                    <div className="flex items-center gap-3">
+                      {/* Avatar */}
+                      {profile.pfp_url ? (
+                        <Image
+                          src={profile.pfp_url}
+                          alt={`${profile.firstName} ${profile.lastName}`}
+                          width={48}
+                          height={48}
+                          className="h-12 w-12 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-sm font-bold text-[var(--ui-text)]">
+                          {initials}
+                        </div>
+                      )}
+
+                      {/* Name + details */}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-semibold text-[var(--ui-text)]">
+                          {profile.firstName} {profile.lastName}
+                        </p>
+                        {degreeAbbrev && yearSuffix ? (
+                          <p className="text-sm text-[var(--ui-text-muted)]">
+                            {degreeAbbrev} {yearSuffix}
+                          </p>
+                        ) : profile.title ? (
+                          <p className="truncate text-sm text-[var(--ui-text-muted)]">
+                            {profile.title}
+                          </p>
+                        ) : null}
+                      </div>
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() =>
+                            profile.user_id && handleMessage(profile.user_id)
+                          }
+                          disabled={createConversationMutation.isPending}
+                          className="rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                        >
+                          Message
+                        </button>
+                        <button
+                          onClick={() =>
+                            profile.user_id && handleUnlike(profile.user_id)
+                          }
+                          disabled={isUnliking}
+                          className="flex h-9 w-9 items-center justify-center rounded-full bg-pink-500 text-white transition hover:bg-pink-600 disabled:opacity-50 cursor-pointer"
+                          title="Remove like"
+                        >
+                          <FaHeart className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </motion.div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/school/[slug]/sso-complete/page.tsx
+++ b/src/app/school/[slug]/sso-complete/page.tsx
@@ -71,7 +71,11 @@ export default async function SSOCompletePage({
     console.error("sso-complete: profile org update failed:", err);
   }
 
-  return <SessionRefreshRedirect to={`/school/${slug}/onboarding`} />;
+  const destination = user.publicMetadata?.onboardingComplete
+    ? `/school/${slug}/dashboard`
+    : `/school/${slug}/onboarding`;
+
+  return <SessionRefreshRedirect to={destination} />;
 }
 
 function DomainMismatch({

--- a/src/components/ConversationItem.tsx
+++ b/src/components/ConversationItem.tsx
@@ -20,10 +20,10 @@ function ConversationItem({ conversation, onClick }: ConversationItemProps) {
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ scale: 1.02 }}
-      className="group cursor-pointer rounded-lg border border-white bg-(--charcoal-black) p-4 transition-all duration-200 hover:border-blue-500/50 hover:bg-gray-800"
+      className="group cursor-pointer rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 transition-all duration-200 hover:border-[var(--ui-border-strong)]"
       onClick={onClick}
     >
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
         <div className="relative">
           <div className="relative h-12 w-12 overflow-hidden rounded-full">
             {otherParticipant.pfp_url ? (
@@ -34,12 +34,12 @@ function ConversationItem({ conversation, onClick }: ConversationItemProps) {
                 className="object-cover"
               />
             ) : (
-              <div className="flex h-full w-full items-center justify-center bg-blue-500/20 text-blue-400">
-                <FaUser className="h-5 w-5" />
+              <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface-active)] text-sm font-bold text-[var(--ui-text)]">
+                {(otherParticipant.first_name?.[0] ?? "").toUpperCase()}
+                {(otherParticipant.last_name?.[0] ?? "").toUpperCase()}
               </div>
             )}
           </div>
-          {/* Activity indicator dot positioned at bottom-right of avatar */}
           <div className="absolute -right-0.5 -bottom-0.5">
             <ActivityIndicator
               lastActiveAt={otherParticipant.last_active_at}
@@ -49,23 +49,23 @@ function ConversationItem({ conversation, onClick }: ConversationItemProps) {
           </div>
         </div>
 
-        <div className="flex-1">
-          <h4 className="font-semibold text-white">
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-semibold text-[var(--ui-text)]">
             {otherParticipant.first_name && otherParticipant.last_name
               ? `${otherParticipant.first_name} ${otherParticipant.last_name}`
               : "Unknown User"}
-          </h4>
-          <p className="text-sm text-gray-400">
+          </p>
+          <p className="truncate text-sm text-[var(--ui-text-muted)]">
             {otherParticipant.title || "No title"}
           </p>
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-0.5 text-xs text-[var(--ui-text-subtle)]">
             {new Date(
               conversation.last_message_at || conversation.created_at,
             ).toLocaleDateString()}
           </p>
         </div>
 
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-500/20 text-blue-400 transition-all duration-200 group-hover:bg-blue-500/30">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-[var(--ui-text-muted)] transition group-hover:text-[var(--ui-text)]">
           <FaEnvelope className="h-4 w-4" />
         </div>
       </div>

--- a/src/components/ConversationItem.tsx
+++ b/src/components/ConversationItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
-import { FaEnvelope, FaUser } from "react-icons/fa6";
+import { FaEnvelope } from "react-icons/fa6";
 import Image from "next/image";
 import { ConversationWithOtherParticipant } from "@/features/conversations/conversationService";
 import ActivityIndicator from "@/components/ActivityIndicator";

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { UserButton } from "@clerk/nextjs";
 import { FaHeart } from "react-icons/fa6";
 import clsx from "clsx";
-import { useMutualLikes } from "@/features/likes/useLikes";
+import { useLikedProfilesData } from "@/features/likes/useLikes";
 import type { OrgConfig } from "@/orgs/types";
 
 type SchoolHeaderProps = {
@@ -18,11 +18,11 @@ type SchoolHeaderProps = {
 export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderProps) {
   const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
-  const { data: mutualLikes } = useMutualLikes();
+  const { data: likedProfilesData } = useLikedProfilesData();
 
   useEffect(() => setMounted(true), []);
 
-  const savedMatchesCount = mutualLikes?.matches?.length ?? 0;
+  const savedMatchesCount = likedProfilesData?.profiles?.length ?? 0;
 
   const navItems = [
     {
@@ -89,7 +89,7 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
           )}
         </Link>
 
-        {mounted && <UserButton />}
+        {mounted && <UserButton afterSignOutUrl={`/school/${slug}`} />}
       </div>
     </header>
   );

--- a/src/components/school/auth/SessionRefreshRedirect.tsx
+++ b/src/components/school/auth/SessionRefreshRedirect.tsx
@@ -2,15 +2,17 @@
 
 import { useSession } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export default function SessionRefreshRedirect({ to }: { to: string }) {
   const { session } = useSession();
   const router = useRouter();
+  const triggered = useRef(false);
 
   useEffect(() => {
-    if (!session) return;
-    session.reload().then(() => router.push(to));
+    if (!session || triggered.current) return;
+    triggered.current = true;
+    session.getToken({ skipCache: true }).then(() => router.push(to));
   }, [session, router, to]);
 
   return (

--- a/src/components/school/landing/PublicSchoolHeader.tsx
+++ b/src/components/school/landing/PublicSchoolHeader.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { FaHeart } from "react-icons/fa";
 
 export default function PublicSchoolHeader() {
   return (
@@ -26,20 +25,6 @@ export default function PublicSchoolHeader() {
         >
           Contact us
         </a>
-
-        <div className="relative flex items-center">
-          <FaHeart className="h-[17px] w-[17px] text-white/80" />
-          <span
-            className="absolute -right-1.5 -top-1.5 flex h-[14px] w-[14px] items-center justify-center rounded-full border-[1.5px] text-[8px] font-bold"
-            style={{
-              backgroundColor: "#ffffff",
-              color: "#bf5700",
-              borderColor: "#bf5700",
-            }}
-          >
-            0
-          </span>
-        </div>
 
         <Link
           href="/school/ut/sign-in"

--- a/src/features/conversations/conversationService.ts
+++ b/src/features/conversations/conversationService.ts
@@ -110,6 +110,7 @@ export async function getConversationById(
 export async function getUserConversations(
   currentUserId: string,
   supabaseClient: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  organizationId: string | null = null,
 ): Promise<{
   conversations: ConversationWithOtherParticipant[];
   error?: string;
@@ -117,7 +118,6 @@ export async function getUserConversations(
   const supabase = supabaseClient;
 
   try {
-    // 1️⃣ Fetch conversations where the user is a participant
     const { data, error } = await supabase
       .from("conversation_participants")
       .select(
@@ -130,8 +130,7 @@ export async function getUserConversations(
         )
       `,
       )
-      .eq("user_id", currentUserId)
-      .order("conversations(last_message_at)", { ascending: false });
+      .eq("user_id", currentUserId);
 
     if (error) {
       console.error("Error fetching conversations:", error.message);
@@ -142,7 +141,6 @@ export async function getUserConversations(
       return { conversations: [], error: undefined };
     }
 
-    // 2️⃣ For each conversation, get the other participant's profile
     const conversationsWithOtherParticipants: ConversationWithOtherParticipant[] =
       [];
 
@@ -153,7 +151,6 @@ export async function getUserConversations(
         ? conversations[0]
         : conversations;
 
-      // Get the other participant's user_id
       const { data: otherParticipantData, error: otherParticipantError } =
         await supabase
           .from("conversation_participants")
@@ -170,20 +167,25 @@ export async function getUserConversations(
         continue;
       }
 
-      // Get the other participant's profile
-      const { data: profileData, error: profileError } = await supabase
+      let profileQuery = supabase
         .from("profiles")
         .select("user_id, first_name, last_name, pfp_url, title")
         .eq("user_id", otherParticipantData.user_id)
-        .is("deleted_at", null)
-        .single();
+        .is("deleted_at", null);
+
+      if (organizationId) {
+        profileQuery = profileQuery.eq("organization_id", organizationId);
+      } else {
+        profileQuery = profileQuery.is("organization_id", null);
+      }
+
+      const { data: profileData, error: profileError } =
+        await profileQuery.single();
 
       if (profileError || !profileData) {
-        console.error("Error fetching profile:", profileError);
         continue;
       }
 
-      // Get the other participant's activity data
       const { data: activityData } = await supabase
         .from("user_activity_summary")
         .select("last_active_at")
@@ -204,6 +206,12 @@ export async function getUserConversations(
         },
       });
     }
+
+    conversationsWithOtherParticipants.sort((a, b) => {
+      const aTime = a.last_message_at ? new Date(a.last_message_at).getTime() : 0;
+      const bTime = b.last_message_at ? new Date(b.last_message_at).getTime() : 0;
+      return bTime - aTime;
+    });
 
     return {
       conversations: conversationsWithOtherParticipants,

--- a/src/features/likes/useLikes.ts
+++ b/src/features/likes/useLikes.ts
@@ -7,10 +7,7 @@ import {
   checkLikeStatus,
   getLikedProfiles,
   getLikers,
-  getMutualLikes,
 } from "./likesService";
-import { createSupabaseClientWithToken } from "../../lib/supabaseClient";
-import { mapProfileToOnboardingData } from "../../lib/mapProfileToFromDBFormat";
 
 // Hook to like/unlike a profile
 export function useLikeProfile() {
@@ -101,7 +98,7 @@ export function useLikedProfiles() {
   });
 }
 
-// Hook to get full profile data for liked profiles
+// Hook to get full profile data for liked profiles, org-scoped via server-side API
 export function useLikedProfilesData() {
   const { session } = useSession();
 
@@ -111,39 +108,15 @@ export function useLikedProfilesData() {
       const token = await session?.getToken();
       if (!token) throw new Error("No authentication token");
 
-      const userId = session?.user?.id;
-      if (!userId) throw new Error("No user ID");
-
-      // Get liked profile IDs
-      const { profiles: likedIds, error: likedError } = await getLikedProfiles({
-        likerId: userId,
-        token,
+      const response = await fetch("/api/likes/profiles", {
+        headers: { Authorization: `Bearer ${token}` },
       });
 
-      if (likedError) {
+      if (!response.ok) {
         throw new Error("Failed to fetch liked profiles");
       }
 
-      if (!likedIds || likedIds.length === 0) {
-        return { profiles: [], error: null };
-      }
-
-      // Get full profile data for liked profiles
-      const supabase = createSupabaseClientWithToken(token);
-      const { data: profiles, error: profilesError } = await supabase
-        .from("profiles")
-        .select("*")
-        .in("user_id", likedIds)
-        .is("deleted_at", null);
-
-      if (profilesError) {
-        throw new Error("Failed to fetch profile data");
-      }
-
-      // Map to OnboardingData format
-      const mappedProfiles = profiles?.map(mapProfileToOnboardingData) || [];
-
-      return { profiles: mappedProfiles, error: null };
+      return (await response.json()) as { profiles: OnboardingData[] };
     },
     enabled: !!session,
   });
@@ -168,7 +141,7 @@ export function useLikers() {
   });
 }
 
-// Hook to get mutual likes (matches)
+// Hook to get mutual likes (matches), org-scoped via server-side API
 export function useMutualLikes() {
   const { session } = useSession();
 
@@ -178,10 +151,15 @@ export function useMutualLikes() {
       const token = await session?.getToken();
       if (!token) throw new Error("No authentication token");
 
-      const userId = session?.user?.id;
-      if (!userId) throw new Error("No user ID");
+      const response = await fetch("/api/likes/mutual", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
 
-      return await getMutualLikes({ userId, token });
+      if (!response.ok) {
+        throw new Error("Failed to fetch mutual likes");
+      }
+
+      return (await response.json()) as { matches: string[] };
     },
     enabled: !!session,
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -160,6 +160,14 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
       }
 
       if (isSchoolOnboardingRoute(req)) {
+        if (sessionClaims?.metadata?.onboardingComplete) {
+          const org = await resolveOrgRecord(orgId);
+          if (org) {
+            return NextResponse.redirect(
+              new URL(`/school/${org.slug}/dashboard`, req.url),
+            );
+          }
+        }
         return NextResponse.next();
       }
 

--- a/src/orgs/registry.ts
+++ b/src/orgs/registry.ts
@@ -14,6 +14,10 @@ export const DEFAULT_ORG_CONFIG: OrgConfig = {
     ctaPrimaryLabel: "Get started",
     ctaSecondaryLabel: "Sign in",
   },
+  limits: {
+    unlimitedSwipes: true,
+    unlimitedMessages: true,
+  },
 };
 
 export const ORG_REGISTRY: Record<string, OrgConfig> = {
@@ -34,6 +38,10 @@ export const ORG_REGISTRY: Record<string, OrgConfig> = {
       heroImageUrl: "/orgs/ut/hero.jpg",
       ctaPrimaryLabel: "Join with your UT email",
       ctaSecondaryLabel: "Sign in",
+    },
+    limits: {
+      unlimitedSwipes: true,
+      unlimitedMessages: true,
     },
   },
 };

--- a/src/orgs/types.ts
+++ b/src/orgs/types.ts
@@ -16,7 +16,13 @@ export type OrgLanding = {
   ctaSecondaryLabel: string;
 };
 
+export type OrgLimits = {
+  unlimitedSwipes: boolean;
+  unlimitedMessages: boolean;
+};
+
 export type OrgConfig = {
   branding: OrgBranding;
   landing: OrgLanding;
+  limits: OrgLimits;
 };


### PR DESCRIPTION
# MCFM-110 — UT Core Functionality Bug Fixes
 
## Summary
 
Introduces a multi-tenant school architecture that isolates each institution's users, matching, and branding behind a `/school/[slug]` subdomain routing pattern. Delivers the first tenant — UT Austin — with SSO sign-up, custom onboarding, and a school-scoped matching feed.
 
## Problem
 
The platform had a single-tenant design — all users shared the same auth, profiles, and matching pool. Adding institutional partners (universities) requires strict data isolation for FERPA compliance and a branded, self-contained experience per school.
 
## Solution
 
### Infrastructure
 
- Organization registry (`orgs/registry.ts`, `orgs/types.ts`) maps slugs to per-org config (branding, allowed email domains, Clerk org ID)
- Middleware rewritten to detect `/school/[slug]` routes and enforce org-scoped auth, onboarding guards, and RLS-backed data access
- Email-domain validation assigns users to orgs on sign-up
### UT Austin Tenant
 
- Google SSO sign-up flow restricted to `@utexas.edu` domains
- 6-step custom onboarding (AboutYou, Startup, Background, Interests, Photo, Review) with UT-specific fields (school, major, graduation year)
- Branded landing page, header, and public footer
### Matching & Conversations
 
- School-scoped matching feed (`/school/[slug]/dashboard`) pulling only profiles within the same org
- Likes and conversations isolated per org via RLS policies
- Admin dashboard for reviewing and managing school members
### Data Layer
 
- Supabase migrations: `organizations` table, `school_profiles`, `organization_id` on profiles, RLS policies, UT seed data and mock profiles
- `seen_at` column added to matching queue for dedup
## Schema Changes
 
| Migration | Purpose |
|-----------|---------|
| `add_organizations_table.sql` | Core org registry |
| `add_organization_id_to_profiles.sql` | Ties profiles to an org |
| `add_organization_rls_policies.sql` | FERPA-compliant row isolation |
| `20260520000001_create_school_profiles.sql` | UT-specific profile fields |
| `20260520000003_add_seen_at_to_matching_queue.sql` | Prevents duplicate swipes |
 
## Test Plan
 
- [ ] UT SSO sign-up with `@utexas.edu` email routes through onboarding and lands on school dashboard
- [ ] Non-UT email blocked at sign-up
- [ ] Matching feed only shows profiles with same `organization_id`
- [ ] Likes and conversations do not leak across orgs
- [ ] Admin dashboard lists and activates pending school members
- [ ] Main Mamun app unaffected for non-school routes