### PR TITLE
MCFM-112 | We Match — mutual co-founder intent signal with email notification

### DIFF
--- a/src/app/api/we-match/route.ts
+++ b/src/app/api/we-match/route.ts
@@ -1,0 +1,341 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { Resend } from "resend";
+import { getOrgConfig } from "@/orgs/registry";
+
+type ProfileRow = {
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  title: string | null;
+  city: string | null;
+  state: string | null;
+  organization_id: string | null;
+  archetype: string | null;
+  is_technical: boolean | null;
+  personal_intro: string | null;
+  startup_funding: string | null;
+  cofounder_status: string | null;
+  startup_time_spent: string | null;
+  priority_areas: string[] | null;
+};
+
+type SchoolProfileRow = {
+  school_status: string | null;
+  graduation_year: number | null;
+  college: string | null;
+  degree_type: string | null;
+  major: string | null;
+};
+
+function supa() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function initials(first: string | null, last: string | null) {
+  return `${(first?.[0] ?? "").toUpperCase()}${(last?.[0] ?? "").toUpperCase()}`;
+}
+
+function schoolStatusLabel(s: SchoolProfileRow | null): string {
+  if (!s) return "";
+  const status = s.school_status === "alumni" ? "Alumni" : "Student";
+  const degree = (() => {
+    if (!s.degree_type) return "";
+    if (s.degree_type === "masters" && s.major?.toLowerCase().includes("business")) return "MBA";
+    if (s.degree_type === "bachelors") return "Bachelors";
+    if (s.degree_type === "masters") return "Masters";
+    if (s.degree_type === "professional") return s.major ?? "Professional";
+    return s.degree_type;
+  })();
+  const year = s.graduation_year ?? "";
+  return [status, [degree, year].filter(Boolean).join(" ")].filter(Boolean).join(" · ");
+}
+
+function archetypeLabel(p: ProfileRow): string {
+  return p.is_technical ? "Technical founder" : "Non-technical founder";
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { toUserId } = await request.json();
+    if (!toUserId) {
+      return NextResponse.json({ error: "Missing toUserId" }, { status: 400 });
+    }
+    if (toUserId === userId) {
+      return NextResponse.json(
+        { error: "Cannot we-match your own profile" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = supa();
+
+    const { data: fromProfile, error: fromErr } = await supabase
+      .from("profiles")
+      .select("user_id, organization_id, first_name, last_name")
+      .eq("user_id", userId)
+      .single();
+
+    if (fromErr || !fromProfile) {
+      return NextResponse.json(
+        { error: "Caller profile not found" },
+        { status: 404 },
+      );
+    }
+    if (!fromProfile.organization_id) {
+      return NextResponse.json(
+        { error: "We Match is only available for school-org users" },
+        { status: 403 },
+      );
+    }
+
+    const { data: toProfile, error: toErr } = await supabase
+      .from("profiles")
+      .select("user_id, organization_id")
+      .eq("user_id", toUserId)
+      .single();
+
+    if (toErr || !toProfile) {
+      return NextResponse.json(
+        { error: "Target profile not found" },
+        { status: 404 },
+      );
+    }
+    if (toProfile.organization_id !== fromProfile.organization_id) {
+      return NextResponse.json(
+        { error: "Cross-org match not allowed" },
+        { status: 403 },
+      );
+    }
+
+    const orgId = fromProfile.organization_id;
+
+    const { error: insertErr } = await supabase
+      .from("match_intents")
+      .upsert(
+        {
+          from_user_id: userId,
+          to_user_id: toUserId,
+          organization_id: orgId,
+        },
+        { onConflict: "from_user_id,to_user_id", ignoreDuplicates: true },
+      );
+
+    if (insertErr) {
+      console.error("[we-match] insert error:", insertErr);
+      return NextResponse.json(
+        { error: "Failed to record match intent" },
+        { status: 500 },
+      );
+    }
+
+    const { data: mutual, error: mutualErr } = await supabase
+      .from("match_intents")
+      .select("id, we_match_notified_at")
+      .eq("from_user_id", toUserId)
+      .eq("to_user_id", userId)
+      .eq("organization_id", orgId)
+      .maybeSingle();
+
+    if (mutualErr) {
+      console.error("[we-match] mutual check error:", mutualErr);
+      return NextResponse.json(
+        { error: "Failed to check mutual" },
+        { status: 500 },
+      );
+    }
+
+    if (!mutual) {
+      return NextResponse.json({ success: true, mutual: false });
+    }
+
+    if (mutual.we_match_notified_at) {
+      return NextResponse.json({ success: true, mutual: true, alreadyNotified: true });
+    }
+
+    await sendMutualMatchEmails({
+      supabase,
+      orgId,
+      userAId: userId,
+      userBId: toUserId,
+    });
+
+    const { error: markErr } = await supabase
+      .from("match_intents")
+      .update({ we_match_notified_at: new Date().toISOString() })
+      .eq("organization_id", orgId)
+      .or(
+        `and(from_user_id.eq.${userId},to_user_id.eq.${toUserId}),and(from_user_id.eq.${toUserId},to_user_id.eq.${userId})`,
+      );
+
+    if (markErr) {
+      console.error("[we-match] mark notified error:", markErr);
+    }
+
+    return NextResponse.json({ success: true, mutual: true });
+  } catch (error) {
+    console.error("[we-match] unhandled:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = supa();
+    const { data, error } = await supabase
+      .from("match_intents")
+      .select("to_user_id, we_match_notified_at")
+      .eq("from_user_id", userId);
+
+    if (error) {
+      console.error("[we-match GET] error:", error);
+      return NextResponse.json(
+        { error: "Failed to load match intents" },
+        { status: 500 },
+      );
+    }
+
+    const sent = data?.map((r) => r.to_user_id) ?? [];
+    const mutualNotified = data
+      ?.filter((r) => r.we_match_notified_at)
+      .map((r) => r.to_user_id) ?? [];
+
+    return NextResponse.json({ sent, mutualNotified });
+  } catch (error) {
+    console.error("[we-match GET] unhandled:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+async function sendMutualMatchEmails(args: {
+  supabase: ReturnType<typeof supa>;
+  orgId: string;
+  userAId: string;
+  userBId: string;
+}) {
+  const { supabase, orgId, userAId, userBId } = args;
+
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("[we-match] RESEND_API_KEY missing — skipping emails");
+    return;
+  }
+
+  const { data: org } = await supabase
+    .from("organizations")
+    .select("slug, name")
+    .eq("id", orgId)
+    .single();
+
+  const orgConfig = org?.slug ? getOrgConfig(org.slug) : null;
+  const primaryColor = orgConfig?.branding.primaryColor ?? "#BF5700";
+  const wordmark = orgConfig?.branding.wordmark ?? org?.name ?? "";
+
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select(
+      "user_id, first_name, last_name, title, city, state, organization_id, archetype, is_technical, personal_intro, startup_funding, cofounder_status, startup_time_spent, priority_areas",
+    )
+    .in("user_id", [userAId, userBId]);
+
+  const { data: schoolProfiles } = await supabase
+    .from("school_profiles")
+    .select("user_id, school_status, graduation_year, college, degree_type, major")
+    .in("user_id", [userAId, userBId]);
+
+  const profileMap = new Map<string, ProfileRow>(
+    (profiles ?? []).map((p) => [p.user_id, p as ProfileRow]),
+  );
+  const schoolMap = new Map<string, SchoolProfileRow>(
+    (schoolProfiles ?? []).map((s) => [
+      (s as SchoolProfileRow & { user_id: string }).user_id,
+      s as SchoolProfileRow,
+    ]),
+  );
+
+  const clerk = await clerkClient();
+  const [userA, userB] = await Promise.all([
+    clerk.users.getUser(userAId),
+    clerk.users.getUser(userBId),
+  ]);
+  const emailMap = new Map<string, string | undefined>([
+    [userAId, userA.emailAddresses[0]?.emailAddress],
+    [userBId, userB.emailAddresses[0]?.emailAddress],
+  ]);
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://mamuncofoundr.com";
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  const buildAndSend = async (recipientId: string, matchedId: string) => {
+    const recipientProfile = profileMap.get(recipientId);
+    const matchedProfile = profileMap.get(matchedId);
+    const matchedSchool = schoolMap.get(matchedId) ?? null;
+    const recipientEmail = emailMap.get(recipientId);
+
+    if (!recipientEmail || !recipientProfile || !matchedProfile) {
+      console.warn("[we-match] missing recipient/matched data, skipping send", {
+        recipientId,
+        matchedId,
+      });
+      return;
+    }
+
+    const variables: Record<string, string> = {
+      recipientName: `${recipientProfile.first_name ?? ""} ${recipientProfile.last_name ?? ""}`.trim(),
+      matchedName: `${matchedProfile.first_name ?? ""} ${matchedProfile.last_name ?? ""}`.trim(),
+      matchedInitials: initials(matchedProfile.first_name, matchedProfile.last_name),
+      matchedTitle: matchedProfile.title ?? "",
+      matchedCity: matchedProfile.city ?? "",
+      matchedState: matchedProfile.state ?? "",
+      schoolStatusLabel: schoolStatusLabel(matchedSchool),
+      archetypeLabel: archetypeLabel(matchedProfile),
+      stageLabel: matchedProfile.startup_funding ?? "",
+      bio: matchedProfile.personal_intro ?? "",
+      interestsCsv: (matchedProfile.priority_areas ?? []).join(", "),
+      lookingFor: matchedProfile.cofounder_status ?? "",
+      commitment: matchedProfile.startup_time_spent ?? "",
+      collegeLabel: matchedSchool?.college ?? "",
+      degreeLabel: matchedSchool?.degree_type ?? "",
+      major: matchedSchool?.major ?? "",
+      primaryColor,
+      wordmark,
+      schoolPill: wordmark,
+      messageUrl: `${appUrl}/messages?startWith=${matchedId}`,
+    };
+
+    await (resend.emails.send as unknown as (options: Record<string, unknown>) => Promise<unknown>)({
+      from: "Mamun Co-Foundr <mamun@mamuncofoundr.com>",
+      to: recipientEmail,
+      template: {
+        id: "we-match-mutual",
+        variables,
+      },
+    });
+  };
+
+  await Promise.all([
+    buildAndSend(userAId, userBId),
+    buildAndSend(userBId, userAId),
+  ]).catch((err) => {
+    console.error("[we-match] resend send error:", err);
+  });
+}

--- a/src/app/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/school/[slug]/matches/[conversationId]/page.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import { FaArrowLeft, FaEnvelope, FaUser } from "react-icons/fa6";
+import { FaArrowLeft, FaEnvelope, FaUser, FaHandshake } from "react-icons/fa6";
 import { motion } from "motion/react";
 import { useRouter } from "next/navigation";
 import { useSession } from "@clerk/nextjs";
@@ -13,6 +13,10 @@ import { Message } from "@/features/messages/messagesService";
 import AIWriter from "@/components/ui/AIWriter";
 import { trackEvent } from "@/lib/posthog-events";
 import ActivityIndicator from "@/components/ActivityIndicator";
+import ProfileDetailModal from "@/features/matches/ProfileDetailModal";
+import { useProfileByUserId } from "@/features/profile/useProfile";
+import { useWeMatch, useWeMatchStatus } from "@/features/matches/useWeMatch";
+import { useToggleLike } from "@/features/likes/useLikes";
 
 interface ConversationPageProps {
   params: Promise<{
@@ -30,6 +34,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
   const [isSending, setIsSending] = React.useState<boolean>(false);
   const [sendError, setSendError] = React.useState<string | null>(null);
   const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
+  const [showProfile, setShowProfile] = React.useState<boolean>(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -44,6 +49,14 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
   const { data: conversation, isLoading: isConversationLoading } =
     useConversation(conversationId);
   const currentUserId = session?.user?.id;
+
+  const otherUserId = conversation?.otherParticipant?.id ?? "";
+  const { data: otherProfile } = useProfileByUserId(otherUserId, !!otherUserId);
+  const weMatchMutation = useWeMatch();
+  const { data: weMatchStatus } = useWeMatchStatus();
+  const { toggleLike, isLoading: isUnliking } = useToggleLike();
+  const sentSet = new Set(weMatchStatus?.sent ?? []);
+  const mutualSet = new Set(weMatchStatus?.mutualNotified ?? []);
 
   React.useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -107,47 +120,81 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
           <span className="text-sm font-medium">Back</span>
         </button>
 
-        <div className="flex items-center gap-3">
-          <div className="relative h-10 w-10 overflow-hidden rounded-full">
-            {isConversationLoading ? (
-              <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
-                <FaUser className="h-5 w-5" />
-              </div>
-            ) : conversation?.otherParticipant?.pfp_url ? (
-              <Image
-                src={conversation.otherParticipant.pfp_url}
-                alt={`${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim()}
-                width={40}
-                height={40}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
-                <FaUser className="h-5 w-5" />
-              </div>
-            )}
-          </div>
-          <div>
-            <div className="flex items-center gap-2">
-              <h1 className="text-lg font-bold text-[var(--ui-text)]">
-                {isConversationLoading
-                  ? "Loading..."
-                  : conversation?.otherParticipant
-                    ? `${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim() || "Conversation"
-                    : "Conversation"}
-              </h1>
-              {!isConversationLoading && conversation?.otherParticipant && (
-                <ActivityIndicator
-                  lastActiveAt={conversation.otherParticipant.last_active_at}
-                  size="sm"
-                  showLabel={true}
+        <div className="flex flex-1 items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="relative h-10 w-10 overflow-hidden rounded-full">
+              {isConversationLoading ? (
+                <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
+                  <FaUser className="h-5 w-5" />
+                </div>
+              ) : conversation?.otherParticipant?.pfp_url ? (
+                <Image
+                  src={conversation.otherParticipant.pfp_url}
+                  alt={`${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim()}
+                  width={40}
+                  height={40}
+                  className="h-full w-full object-cover"
                 />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-[var(--ui-surface)] text-[var(--ui-text-muted)]">
+                  <FaUser className="h-5 w-5" />
+                </div>
               )}
             </div>
-            <p className="text-xs text-[var(--ui-text-muted)]">
-              {messages.length}/20 messages
-            </p>
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-lg font-bold text-[var(--ui-text)]">
+                  {isConversationLoading
+                    ? "Loading..."
+                    : conversation?.otherParticipant
+                      ? `${conversation.otherParticipant.first_name || ""} ${conversation.otherParticipant.last_name || ""}`.trim() || "Conversation"
+                      : "Conversation"}
+                </h1>
+                {!isConversationLoading && conversation?.otherParticipant && (
+                  <ActivityIndicator
+                    lastActiveAt={conversation.otherParticipant.last_active_at}
+                    size="sm"
+                    showLabel={true}
+                  />
+                )}
+              </div>
+              <p className="text-xs text-[var(--ui-text-muted)]">
+                {messages.length}/20 messages
+              </p>
+            </div>
           </div>
+
+          {!isConversationLoading && conversation?.otherParticipant && (
+            <div className="flex items-center gap-2">
+              {mutualSet.has(otherUserId) ? (
+                <span className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-3 py-1.5 text-xs font-semibold text-white">
+                  <FaHandshake className="h-3 w-3" />
+                  It&apos;s a Match!
+                </span>
+              ) : sentSet.has(otherUserId) ? (
+                <span className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)]">
+                  <FaHandshake className="h-3 w-3" />
+                  Matched ✓
+                </span>
+              ) : (
+                <button
+                  onClick={() => weMatchMutation.mutate({ toUserId: otherUserId })}
+                  disabled={weMatchMutation.isPending}
+                  className="flex items-center gap-1.5 rounded-full border border-[var(--org-primary)] px-3 py-1.5 text-xs font-medium text-[var(--org-primary)] transition hover:bg-[var(--org-primary)] hover:text-white disabled:opacity-50 cursor-pointer"
+                >
+                  <FaHandshake className="h-3 w-3" />
+                  We Match
+                </button>
+              )}
+              <button
+                onClick={() => setShowProfile(true)}
+                className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[var(--org-primary)] hover:text-[var(--org-primary)] cursor-pointer"
+              >
+                <FaUser className="h-3 w-3" />
+                View Profile
+              </button>
+            </div>
+          )}
         </div>
       </motion.div>
 
@@ -262,6 +309,23 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
           </form>
         </div>
       </motion.div>
+
+      <ProfileDetailModal
+        profile={showProfile ? (otherProfile ?? null) : null}
+        onClose={() => setShowProfile(false)}
+        sentSet={sentSet}
+        mutualSet={mutualSet}
+        onWeMatch={(userId) => weMatchMutation.mutate({ toUserId: userId })}
+        onMessage={() => setShowProfile(false)}
+        onUnlike={async (userId) => {
+          await toggleLike(userId, true);
+          setShowProfile(false);
+        }}
+        isWeMatchPending={weMatchMutation.isPending}
+        isMessagePending={false}
+        isUnlikePending={isUnliking}
+        weMatchPendingId={weMatchMutation.variables?.toUserId}
+      />
     </div>
   );
 }

--- a/src/app/school/[slug]/matches/page.tsx
+++ b/src/app/school/[slug]/matches/page.tsx
@@ -2,19 +2,21 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "@clerk/nextjs";
-import { FaEnvelope, FaHeart } from "react-icons/fa6";
+import { FaEnvelope, FaHeart, FaHandshake } from "react-icons/fa6";
 import { FaSync } from "react-icons/fa";
 import { motion } from "motion/react";
 import Image from "next/image";
 import ConversationItem from "@/components/ConversationItem";
 import { ConversationWithOtherParticipant } from "@/features/conversations/conversationService";
 import { useLikedProfilesData, useToggleLike } from "@/features/likes/useLikes";
+import { useWeMatch, useWeMatchStatus } from "@/features/matches/useWeMatch";
+import ProfileDetailModal from "@/features/matches/ProfileDetailModal";
 import { useCreateConversation } from "@/hooks/useConversations";
 import { getDegreeAbbreviation } from "@/lib/utSchoolsAndMajors";
 import React, { useState, useEffect, useCallback } from "react";
 import toast from "react-hot-toast";
 
-type Tab = "messages" | "liked";
+type Tab = "messages" | "liked" | "we-match";
 
 export default function SchoolMatchesPage({
   params,
@@ -41,10 +43,16 @@ export default function SchoolMatchesPage({
   const [error, setError] = useState<Error | null>(null);
   const currentUserId = session?.user?.id;
 
+  const [selectedProfile, setSelectedProfile] = useState<OnboardingData | null>(null);
+
   const { data: likedProfilesData, isLoading: isLikedLoading } =
     useLikedProfilesData();
   const { toggleLike, isLoading: isUnliking } = useToggleLike();
   const createConversationMutation = useCreateConversation();
+  const weMatchMutation = useWeMatch();
+  const { data: weMatchStatus } = useWeMatchStatus();
+  const sentSet = new Set(weMatchStatus?.sent ?? []);
+  const mutualSet = new Set(weMatchStatus?.mutualNotified ?? []);
 
   const likedProfiles = likedProfilesData?.profiles ?? [];
 
@@ -125,6 +133,11 @@ export default function SchoolMatchesPage({
       label: "Messages",
       icon: <FaEnvelope className="h-4 w-4" />,
       count: conversations.length,
+    },
+    {
+      id: "we-match",
+      label: "We Match",
+      icon: <FaHandshake className="h-4 w-4" />,
     },
   ];
 
@@ -243,39 +256,78 @@ export default function SchoolMatchesPage({
                     className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4"
                   >
                     <div className="flex items-center gap-3">
-                      {/* Avatar */}
-                      {profile.pfp_url ? (
-                        <Image
-                          src={profile.pfp_url}
-                          alt={`${profile.firstName} ${profile.lastName}`}
-                          width={48}
-                          height={48}
-                          className="h-12 w-12 rounded-full object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-sm font-bold text-[var(--ui-text)]">
-                          {initials}
-                        </div>
-                      )}
+                      {/* Avatar + name — clickable to open full profile */}
+                      <button
+                        onClick={() => setSelectedProfile(profile)}
+                        className="flex min-w-0 flex-1 items-center gap-3 text-left cursor-pointer"
+                      >
+                        {profile.pfp_url ? (
+                          <Image
+                            src={profile.pfp_url}
+                            alt={`${profile.firstName} ${profile.lastName}`}
+                            width={48}
+                            height={48}
+                            className="h-12 w-12 flex-shrink-0 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-sm font-bold text-[var(--ui-text)]">
+                            {initials}
+                          </div>
+                        )}
 
-                      {/* Name + details */}
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate font-semibold text-[var(--ui-text)]">
-                          {profile.firstName} {profile.lastName}
-                        </p>
-                        {degreeAbbrev && yearSuffix ? (
-                          <p className="text-sm text-[var(--ui-text-muted)]">
-                            {degreeAbbrev} {yearSuffix}
+                        <div className="min-w-0">
+                          <p className="truncate font-semibold text-[var(--ui-text)]">
+                            {profile.firstName} {profile.lastName}
                           </p>
-                        ) : profile.title ? (
-                          <p className="truncate text-sm text-[var(--ui-text-muted)]">
-                            {profile.title}
-                          </p>
-                        ) : null}
-                      </div>
+                          {degreeAbbrev && yearSuffix ? (
+                            <p className="text-sm text-[var(--ui-text-muted)]">
+                              {degreeAbbrev} {yearSuffix}
+                            </p>
+                          ) : profile.title ? (
+                            <p className="truncate text-sm text-[var(--ui-text-muted)]">
+                              {profile.title}
+                            </p>
+                          ) : null}
+                        </div>
+                      </button>
 
                       {/* Actions */}
                       <div className="flex items-center gap-2">
+                        {/* We Match button */}
+                        {profile.user_id && mutualSet.has(profile.user_id) ? (
+                          <button
+                            onClick={() => profile.user_id && handleMessage(profile.user_id)}
+                            disabled={createConversationMutation.isPending}
+                            className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                          >
+                            <FaHandshake className="h-3.5 w-3.5" />
+                            It&apos;s a Match!
+                          </button>
+                        ) : profile.user_id && sentSet.has(profile.user_id) ? (
+                          <button
+                            disabled
+                            className="flex items-center gap-1.5 rounded-full bg-[var(--ui-surface-active)] px-4 py-2 text-xs font-medium text-[var(--ui-text-muted)] cursor-not-allowed"
+                          >
+                            <FaHandshake className="h-3.5 w-3.5" />
+                            Matched ✓
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() =>
+                              profile.user_id &&
+                              weMatchMutation.mutate({ toUserId: profile.user_id })
+                            }
+                            disabled={
+                              weMatchMutation.isPending &&
+                              weMatchMutation.variables?.toUserId === profile.user_id
+                            }
+                            className="flex items-center gap-1.5 rounded-full border border-[var(--org-primary)] px-4 py-2 text-xs font-medium text-[var(--org-primary)] transition hover:bg-[var(--org-primary)] hover:text-white disabled:opacity-50 cursor-pointer"
+                          >
+                            <FaHandshake className="h-3.5 w-3.5" />
+                            We Match
+                          </button>
+                        )}
+
                         <button
                           onClick={() =>
                             profile.user_id && handleMessage(profile.user_id)
@@ -304,6 +356,97 @@ export default function SchoolMatchesPage({
           )}
         </>
       )}
+      {/* We Match info tab */}
+      {activeTab === "we-match" && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="space-y-4"
+        >
+          <div className="text-center">
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--ui-border)] bg-[var(--ui-surface-active)]">
+              <FaHandshake className="h-6 w-6 text-[var(--org-primary)]" />
+            </div>
+            <h2 className="text-lg font-bold text-[var(--ui-text)]">
+              How We Match Works
+            </h2>
+            <p className="mt-1 text-sm text-[var(--ui-text-muted)]">
+              A mutual signal. Stronger than a like, lighter than a message.
+            </p>
+          </div>
+
+          {/* Steps */}
+          <div className="space-y-3">
+            {[
+              {
+                step: 1,
+                title: "You click We Match",
+                body: "Tapping We Match on someone's profile records your intent. They don't see a notification yet. It's one-sided until they reciprocate.",
+              },
+              {
+                step: 2,
+                title: "They click We Match back",
+                body: "If they visit your profile and click We Match too, the app detects the mutual intent instantly.",
+              },
+              {
+                step: 3,
+                title: "It's a Match. You both get an email.",
+                body: "Once mutual, both of you receive an email with each other's profile highlights and a direct link to start a conversation outside Mamun.",
+              },
+            ].map(({ step, title, body }) => (
+              <div
+                key={step}
+                className="flex gap-4 rounded-xl border border-[var(--ui-border)] p-4"
+              >
+                <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-[var(--org-primary)] text-sm font-bold text-white">
+                  {step}
+                </div>
+                <div>
+                  <p className="font-semibold text-[var(--ui-text)]">{title}</p>
+                  <p className="mt-0.5 text-sm leading-relaxed text-[var(--ui-text-muted)]">
+                    {body}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Permanent action notice */}
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+            <p className="text-xs font-semibold text-amber-800">
+              We Match is permanent
+            </p>
+            <p className="mt-0.5 text-xs leading-relaxed text-amber-700">
+              Once sent, it can&apos;t be retracted. Only click We Match when
+              you genuinely want to co-found with someone.
+            </p>
+          </div>
+
+          {/* Footer note */}
+          <p className="rounded-lg border border-[var(--ui-border)] p-3 text-xs leading-relaxed text-[var(--ui-text-muted)]">
+            We Match is separate from messaging. Use it as a stronger signal
+            that you want to co-found together. The email gives you both
+            everything you need to connect directly.
+          </p>
+        </motion.div>
+      )}
+
+      <ProfileDetailModal
+        profile={selectedProfile}
+        onClose={() => setSelectedProfile(null)}
+        sentSet={sentSet}
+        mutualSet={mutualSet}
+        onWeMatch={(userId) => weMatchMutation.mutate({ toUserId: userId })}
+        onMessage={handleMessage}
+        onUnlike={async (userId) => {
+          await handleUnlike(userId);
+          setSelectedProfile(null);
+        }}
+        isWeMatchPending={weMatchMutation.isPending}
+        isMessagePending={createConversationMutation.isPending}
+        isUnlikePending={isUnliking}
+        weMatchPendingId={weMatchMutation.variables?.toUserId}
+      />
     </div>
   );
 }

--- a/src/components/school/landing/DepartmentMosaic.tsx
+++ b/src/components/school/landing/DepartmentMosaic.tsx
@@ -178,7 +178,7 @@ export default function DepartmentMosaic() {
         </p>
 
         <TierHeader
-          label="Tier 1 — Core Schools · Highest founder density"
+          label="Tier 1 — Core Schools"
           dotColor="#bf5700"
         />
         <div className="mb-8 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
@@ -188,7 +188,7 @@ export default function DepartmentMosaic() {
         </div>
 
         <TierHeader
-          label="Tier 2 — Partner Schools · Strong secondary pipeline"
+          label="Tier 2 — Partner Schools"
           dotColor="#9cadb7"
         />
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">

--- a/src/features/matches/ProfileDetailModal.tsx
+++ b/src/features/matches/ProfileDetailModal.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { motion, AnimatePresence } from "motion/react";
+import {
+  FaHeart,
+  FaHandshake,
+  FaLinkedin,
+  FaGithub,
+  FaTwitter,
+  FaGlobe,
+  FaCalendar,
+  FaEnvelope,
+} from "react-icons/fa6";
+import { FaTimes } from "react-icons/fa";
+import HiringBadge from "@/components/HiringBadge";
+import {
+  getDegreeAbbreviation,
+  getSchoolFullName,
+  SECTOR_INTEREST_LABELS,
+} from "@/lib/utSchoolsAndMajors";
+
+interface ProfileDetailModalProps {
+  profile: OnboardingData | null;
+  onClose: () => void;
+  sentSet: Set<string>;
+  mutualSet: Set<string>;
+  onWeMatch: (userId: string) => void;
+  onMessage: (userId: string) => void;
+  onUnlike: (userId: string) => void;
+  isWeMatchPending: boolean;
+  isMessagePending: boolean;
+  isUnlikePending: boolean;
+  weMatchPendingId?: string;
+}
+
+export default function ProfileDetailModal({
+  profile,
+  onClose,
+  sentSet,
+  mutualSet,
+  onWeMatch,
+  onMessage,
+  onUnlike,
+  isWeMatchPending,
+  isMessagePending,
+  isUnlikePending,
+  weMatchPendingId,
+}: ProfileDetailModalProps) {
+  if (!profile) return null;
+
+  const initials =
+    (profile.firstName?.[0] ?? "").toUpperCase() +
+    (profile.lastName?.[0] ?? "").toUpperCase();
+
+  const degreeAbbrev =
+    profile.utCollege && profile.utMajor
+      ? getDegreeAbbreviation(profile.utCollege, profile.utMajor)
+      : undefined;
+
+  const yearSuffix = profile.gradYear
+    ? `'${String(profile.gradYear).slice(-2)}`
+    : undefined;
+
+  const schoolFullName = profile.utCollege
+    ? getSchoolFullName(profile.utCollege)
+    : undefined;
+
+  const isOnline = profile.last_active_at
+    ? new Date().getTime() - new Date(profile.last_active_at).getTime() <
+      5 * 60 * 1000
+    : false;
+
+  const userId = profile.user_id ?? "";
+  const isMutual = mutualSet.has(userId);
+  const isSent = sentSet.has(userId);
+
+  const socialLinks = [
+    profile.linkedin && {
+      href: profile.linkedin,
+      icon: <FaLinkedin className="h-4 w-4" />,
+      label: "LinkedIn",
+    },
+    profile.twitter && {
+      href: profile.twitter,
+      icon: <FaTwitter className="h-4 w-4" />,
+      label: "Twitter / X",
+    },
+    profile.git && {
+      href: profile.git,
+      icon: <FaGithub className="h-4 w-4" />,
+      label: "GitHub",
+    },
+    profile.personalWebsite && {
+      href: profile.personalWebsite,
+      icon: <FaGlobe className="h-4 w-4" />,
+      label: "Website",
+    },
+    profile.schedulingUrl && {
+      href: profile.schedulingUrl,
+      icon: <FaCalendar className="h-4 w-4" />,
+      label: "Schedule a call",
+    },
+  ].filter(Boolean) as { href: string; icon: React.ReactNode; label: string }[];
+
+  return (
+    <AnimatePresence>
+      {profile && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="flex h-[92vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] shadow-2xl sm:rounded-2xl sm:h-[85vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Sticky header */}
+            <div className="flex-shrink-0 border-b border-[var(--ui-border)] p-5">
+              <div className="flex items-start gap-4">
+                {/* Avatar */}
+                <div className="relative flex-shrink-0">
+                  {profile.pfp_url ? (
+                    <Image
+                      src={profile.pfp_url}
+                      alt={`${profile.firstName} ${profile.lastName}`}
+                      width={72}
+                      height={72}
+                      className="h-18 w-18 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-[72px] w-[72px] items-center justify-center rounded-full bg-gray-100 text-xl font-bold text-gray-700">
+                      {initials}
+                    </div>
+                  )}
+                  <div
+                    className={`absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ${isOnline ? "bg-green-500" : "bg-gray-300"}`}
+                  />
+                </div>
+
+                {/* Name + badges */}
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1 flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-bold text-[var(--ui-text)]">
+                      {profile.firstName} {profile.lastName}
+                    </h2>
+                    {profile.isHiring && (
+                      <HiringBadge
+                        hiringEmail={profile.hiringEmail}
+                        companyName={profile.startupName}
+                        className="px-2 py-0.5 text-xs"
+                      />
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap gap-1.5">
+                    {profile.utStatus && (
+                      <span className="inline-flex items-center rounded-md border border-[var(--ui-border-strong)] px-2 py-0.5 text-xs font-medium text-[var(--ui-text-muted)]">
+                        {profile.utStatus === "student" ? "Student" : "Alumni"}
+                      </span>
+                    )}
+                    {profile.archetype && (
+                      <span className="inline-flex items-center rounded-md border border-[var(--org-primary)] px-2 py-0.5 text-xs font-medium text-[var(--org-primary)]">
+                        {profile.archetype === "the_scaler"
+                          ? "The Scaler"
+                          : profile.archetype === "the_steward"
+                            ? "The Steward"
+                            : "The Architect"}
+                      </span>
+                    )}
+                    {profile.isTechnical && (
+                      <span className="inline-flex items-center rounded-md border border-[var(--org-primary)] px-2 py-0.5 text-xs font-medium text-[var(--org-primary)]">
+                        {profile.isTechnical === "yes"
+                          ? "Technical founder"
+                          : "Non-technical founder"}
+                      </span>
+                    )}
+                  </div>
+
+                  {(degreeAbbrev || schoolFullName) && (
+                    <p className="mt-1.5 text-xs text-[var(--ui-text-muted)]">
+                      {degreeAbbrev && yearSuffix
+                        ? `${degreeAbbrev} ${yearSuffix}`
+                        : degreeAbbrev ?? ""}
+                      {schoolFullName && profile.utMajor
+                        ? ` · ${schoolFullName} — ${profile.utMajor}`
+                        : ""}
+                    </p>
+                  )}
+                </div>
+
+                {/* Close button */}
+                <button
+                  onClick={onClose}
+                  className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                >
+                  <FaTimes className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Scrollable body */}
+            <div className="flex-1 overflow-y-auto p-5">
+              <div className="space-y-5">
+                {/* About */}
+                {profile.personalIntro && (
+                  <Section title="About">
+                    <p className="text-sm leading-relaxed text-[var(--ui-text)]">
+                      {profile.personalIntro}
+                    </p>
+                  </Section>
+                )}
+
+                {/* Sector interests */}
+                {profile.utSectorInterests &&
+                  profile.utSectorInterests.length > 0 && (
+                    <Section title="Sector Interests">
+                      <div className="flex flex-wrap gap-1.5">
+                        {profile.utSectorInterests.map(
+                          (interest: string, i: number) => (
+                            <span
+                              key={interest}
+                              className="rounded-md px-2.5 py-1 text-xs font-medium"
+                              style={
+                                i < 2
+                                  ? {
+                                      backgroundColor: "var(--org-primary)",
+                                      color: "#fff",
+                                    }
+                                  : {
+                                      backgroundColor: "#f3f4f6",
+                                      color: "#6b7280",
+                                    }
+                              }
+                            >
+                              {SECTOR_INTEREST_LABELS[
+                                interest as keyof typeof SECTOR_INTEREST_LABELS
+                              ] || interest}
+                            </span>
+                          ),
+                        )}
+                      </div>
+                    </Section>
+                  )}
+
+                {/* Education */}
+                {profile.education && (
+                  <Section title="Education">
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      {profile.education}
+                    </p>
+                  </Section>
+                )}
+
+                {/* Experience */}
+                {profile.experience && (
+                  <Section title="Experience">
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      {profile.experience}
+                    </p>
+                  </Section>
+                )}
+
+                {/* Accomplishments */}
+                {profile.accomplishments && (
+                  <Section title="Accomplishments">
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      {profile.accomplishments}
+                    </p>
+                  </Section>
+                )}
+
+                {/* Startup */}
+                {profile.hasStartup === "yes" && profile.startupName && (
+                  <Section title="Startup">
+                    <p className="mb-1 font-medium text-[var(--ui-text)]">
+                      {profile.startupName}
+                    </p>
+                    {profile.startupDescription && (
+                      <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
+                        {profile.startupDescription}
+                      </p>
+                    )}
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {profile.startupTimeSpent && (
+                        <span className="rounded-md bg-gray-100 px-2.5 py-1 text-xs text-gray-500">
+                          {profile.startupTimeSpent}
+                        </span>
+                      )}
+                      {profile.startupFunding && (
+                        <span className="rounded-md bg-gray-100 px-2.5 py-1 text-xs text-gray-500">
+                          {profile.startupFunding}
+                        </span>
+                      )}
+                    </div>
+                  </Section>
+                )}
+
+                {/* Connect */}
+                {socialLinks.length > 0 && (
+                  <Section title="Connect">
+                    <div className="flex flex-wrap gap-2">
+                      {socialLinks.map(({ href, icon, label }) => (
+                        <a
+                          key={label}
+                          href={href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[var(--org-primary)] hover:text-[var(--org-primary)]"
+                        >
+                          {icon}
+                          {label}
+                        </a>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+              </div>
+            </div>
+
+            {/* Sticky footer actions */}
+            <div className="flex-shrink-0 border-t border-[var(--ui-border)] p-4">
+              <div className="flex items-center gap-2">
+                {/* We Match */}
+                {isMutual ? (
+                  <button
+                    onClick={() => onMessage(userId)}
+                    disabled={isMessagePending}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                  >
+                    <FaHandshake className="h-4 w-4" />
+                    It&apos;s a Match!
+                  </button>
+                ) : isSent ? (
+                  <button
+                    disabled
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-gray-100 px-4 py-2.5 text-sm font-medium text-gray-400 cursor-not-allowed"
+                  >
+                    <FaHandshake className="h-4 w-4" />
+                    Matched ✓
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => onWeMatch(userId)}
+                    disabled={isWeMatchPending && weMatchPendingId === userId}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full border border-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-[var(--org-primary)] transition hover:bg-[var(--org-primary)] hover:text-white disabled:opacity-50 cursor-pointer"
+                  >
+                    <FaHandshake className="h-4 w-4" />
+                    We Match
+                  </button>
+                )}
+
+                {/* Message */}
+                <button
+                  onClick={() => onMessage(userId)}
+                  disabled={isMessagePending}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                >
+                  <FaEnvelope className="h-4 w-4" />
+                  Message
+                </button>
+
+                {/* Unlike */}
+                <button
+                  onClick={() => onUnlike(userId)}
+                  disabled={isUnlikePending}
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-pink-500 text-white transition hover:bg-pink-600 disabled:opacity-50 cursor-pointer"
+                  title="Remove like"
+                >
+                  <FaHeart className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/src/features/matches/useWeMatch.ts
+++ b/src/features/matches/useWeMatch.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "@clerk/nextjs";
+import toast from "react-hot-toast";
+import { weMatch, getWeMatchStatus } from "./weMatchService";
+
+export function useWeMatchStatus() {
+  const { session } = useSession();
+
+  return useQuery({
+    queryKey: ["we-match-status"],
+    queryFn: async () => {
+      const token = await session?.getToken();
+      if (!token) throw new Error("No authentication token");
+      return getWeMatchStatus({ token });
+    },
+    enabled: !!session,
+  });
+}
+
+export function useWeMatch() {
+  const { session } = useSession();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ toUserId }: { toUserId: string }) => {
+      const token = await session?.getToken();
+      if (!token) throw new Error("No authentication token");
+      return weMatch({ toUserId, token });
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["we-match-status"] });
+
+      if (!data.success) {
+        toast.error(data.error || "Failed to send We Match", {
+          duration: 3000,
+          position: "bottom-right",
+        });
+        return;
+      }
+
+      if (data.mutual && !data.alreadyNotified) {
+        toast.success("🎉 It's a match! Check your email.", {
+          duration: 5000,
+          position: "bottom-right",
+        });
+      } else if (!data.mutual) {
+        toast.success("We Match sent — they'll be notified if they match back.", {
+          duration: 3000,
+          position: "bottom-right",
+        });
+      }
+    },
+    onError: (error) => {
+      console.error("[useWeMatch] error:", error);
+      toast.error("Something went wrong. Please try again.", {
+        duration: 3000,
+        position: "bottom-right",
+      });
+    },
+  });
+}

--- a/src/features/matches/weMatchService.ts
+++ b/src/features/matches/weMatchService.ts
@@ -1,0 +1,55 @@
+export type WeMatchResponse = {
+  success: boolean;
+  mutual?: boolean;
+  alreadyNotified?: boolean;
+  error?: string;
+};
+
+export async function weMatch({
+  toUserId,
+  token,
+}: {
+  toUserId: string;
+  token: string;
+}): Promise<WeMatchResponse> {
+  if (!toUserId) {
+    return { success: false, error: "Missing toUserId" };
+  }
+
+  const res = await fetch("/api/we-match", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ toUserId }),
+  });
+
+  const body = (await res.json().catch(() => ({}))) as WeMatchResponse;
+
+  if (!res.ok) {
+    return { success: false, error: body.error ?? "Failed to we-match" };
+  }
+  return body;
+}
+
+export type WeMatchStatus = {
+  sent: string[];
+  mutualNotified: string[];
+};
+
+export async function getWeMatchStatus({
+  token,
+}: {
+  token: string;
+}): Promise<WeMatchStatus> {
+  const res = await fetch("/api/we-match", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    return { sent: [], mutualNotified: [] };
+  }
+
+  return (await res.json()) as WeMatchStatus;
+}

--- a/supabase/migrations/20260525000001_create_match_intents.sql
+++ b/supabase/migrations/20260525000001_create_match_intents.sql
@@ -1,0 +1,98 @@
+-- Migration: Create match_intents table for the "We Match" feature
+--
+-- Each row = one user's explicit "We Match" click on another user's profile.
+-- Two reciprocal rows (A→B and B→A) constitute a mutual match, which fires a
+-- transactional email to both parties. `we_match_notified_at` gates the email
+-- so a retry of the mutual-creating request never double-sends.
+--
+-- Multi-tenancy: organization_id is denormalized onto every row. A BEFORE
+-- INSERT trigger enforces that both users belong to the same org as the row,
+-- so a cross-org we-match is impossible at the DB layer regardless of API
+-- correctness (the API also enforces this — defense in depth).
+--
+-- Indexes are (organization_id, …) so every per-user query stays inside its
+-- school's index partition.
+
+CREATE TABLE IF NOT EXISTS match_intents (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_user_id          text NOT NULL REFERENCES profiles(user_id) ON DELETE CASCADE,
+  to_user_id            text NOT NULL REFERENCES profiles(user_id) ON DELETE CASCADE,
+  organization_id       uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  we_match_notified_at  timestamptz,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (from_user_id, to_user_id),
+  CHECK (from_user_id <> to_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_match_intents_org_from
+  ON match_intents (organization_id, from_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_match_intents_org_mutual_lookup
+  ON match_intents (organization_id, to_user_id, from_user_id);
+
+-- ============================================================
+-- Enforce same-org membership for both users on the row
+-- ============================================================
+CREATE OR REPLACE FUNCTION match_intents_enforce_same_org()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  from_org uuid;
+  to_org   uuid;
+BEGIN
+  SELECT organization_id INTO from_org FROM profiles WHERE user_id = NEW.from_user_id;
+  SELECT organization_id INTO to_org   FROM profiles WHERE user_id = NEW.to_user_id;
+
+  IF from_org IS DISTINCT FROM NEW.organization_id
+     OR to_org IS DISTINCT FROM NEW.organization_id THEN
+    RAISE EXCEPTION
+      'match_intents.organization_id (%) must match both users'' organization_id (from=%, to=%)',
+      NEW.organization_id, from_org, to_org
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_match_intents_enforce_same_org'
+  ) THEN
+    CREATE TRIGGER trg_match_intents_enforce_same_org
+      BEFORE INSERT OR UPDATE ON match_intents
+      FOR EACH ROW EXECUTE FUNCTION match_intents_enforce_same_org();
+  END IF;
+END $$;
+
+-- ============================================================
+-- Row Level Security — org isolation (defense in depth)
+-- ============================================================
+-- Server routes use the SERVICE_ROLE_KEY and bypass RLS; these policies guard
+-- any client-side / anon-key access. Mirrors the convention in
+-- supabase-migrations/add_organization_rls_policies.sql but uses the local
+-- organization_id column instead of joining through profiles.
+
+-- The JWT lookup is inlined into the policy (instead of calling a helper like
+-- auth.organization_id()) because creating functions in the auth schema
+-- requires elevated permissions that the migration role doesn't always have.
+
+ALTER TABLE match_intents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "match_intents_org_isolation" ON match_intents;
+CREATE POLICY "match_intents_org_isolation" ON match_intents
+  FOR ALL
+  USING (
+    (
+      NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL
+    )
+    OR
+    (
+      NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid
+    )
+  );
+
+COMMENT ON TABLE match_intents IS
+  '"We Match" clicks. Each row = one user signaling explicit match intent on another. Mutual rows fire a transactional email; we_match_notified_at gates re-send.';


### PR DESCRIPTION
# MCFM-112 | We Match — mutual co-founder intent signal with email notification

## Summary

Adds "We Match" to the school matches page: an explicit opt-in signal that lets
a user tell a liked profile "I want to co-found with you." When both sides send
it, a transactional email goes to both parties and the UI reflects the mutual
state. This ships on top of the existing school-org matching infrastructure
already in staging.

---

## What Changed vs Staging

### API — `POST /api/we-match` (new)
- Accepts `{ toUserId }`, verifies both users belong to the same org
- Checks `match_intents` for a reciprocal row to determine mutuality
- If mutual and not yet notified: sends a branded Resend email to both users,
  stamps `we_match_notified_at` to prevent double-send on retries
- `GET /api/we-match` returns `{ sent: string[], mutualNotified: string[] }`
  so the UI can hydrate button states on load

### Feature layer — `src/features/matches/`
Three new files:
- `weMatchService.ts` — typed fetch wrappers for `POST` and `GET` above
- `useWeMatch.ts` — React Query mutation + status query; handles toast
  messaging ("sent", "mutual — check email", error states)
- `ProfileDetailModal.tsx` — full-screen profile detail modal surfaced from
  the Liked and We-Match tabs; includes the We Match CTA button

### Matches page — `src/app/school/[slug]/matches/page.tsx`
- Adds a third tab: **We-Match** alongside Liked and Messages
- We-Match tab shows profiles where a mutual intent exists
- Liked tab cards now open `ProfileDetailModal` and surface the We Match button
- Button state is derived from `useWeMatchStatus` — disabled once sent,
  shows "Matched!" when mutual

### Conversation page — `src/app/school/[slug]/matches/[conversationId]/page.tsx`
- Minor layout and header adjustments to align with the updated matches shell

### Migration — `supabase/migrations/20260525000001_create_match_intents.sql`
New `match_intents` table:
- `(from_user_id, to_user_id)` unique pair — one row per directional intent
- `we_match_notified_at` gates email re-send (idempotent on retries)
- `BEFORE INSERT` trigger enforces both users share the same `organization_id`
  at the DB layer (defense-in-depth; API also enforces this)
- RLS policy mirrors existing org-isolation convention — reads `organization_id`
  from the JWT `metadata` claim

---

## Testing
- [ ] Like a profile → open their card → send We Match → toast confirms "sent,
  they'll be notified if they match back"
- [ ] From the other account, send We Match back → both accounts receive email,
  button shows "Matched!", profile appears in We-Match tab
- [ ] Retry the second send → no duplicate email (check `we_match_notified_at`)
- [ ] Attempt We Match cross-org → API returns 403
- [ ] Messages and Liked tabs unaffected

## Migration

Idempotent (`CREATE TABLE IF NOT EXISTS`, trigger existence check). Safe to run
before or after deploy.
