### PR TITLE
MCFM-115 | UT Dashboard Filters, Meetup Flow & Branding Refresh

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -77,12 +77,44 @@ export async function GET(req: NextRequest) {
     // org). Acts as the "verified school user" filter. Must be scoped by
     // organization_id to avoid leaking cross-tenant existence.
     const inSchoolTenant = !useGeneralPool && !!orgId;
+
+    const collegeFilter = req.nextUrl.searchParams.get("college");
+    const sectorsParam = req.nextUrl.searchParams.get("sectors");
+    const gradYearParam = req.nextUrl.searchParams.get("gradYear");
+    const intentFilter = req.nextUrl.searchParams.get("intent");
+
+    const sectorFilters =
+      sectorsParam
+        ?.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean) ?? [];
+
+    const gradYearFilter =
+      gradYearParam && !Number.isNaN(Number(gradYearParam))
+        ? Number(gradYearParam)
+        : null;
+
     let schoolUserIds: string[] | null = null;
     if (inSchoolTenant) {
-      const { data: schoolRows } = await supabase
+      let schoolQuery = supabase
         .from("school_profiles")
         .select("user_id")
         .eq("organization_id", orgId);
+
+      if (collegeFilter) {
+        schoolQuery = schoolQuery.eq("college", collegeFilter);
+      }
+      if (gradYearFilter !== null) {
+        schoolQuery = schoolQuery.eq("graduation_year", gradYearFilter);
+      }
+      if (sectorFilters.length > 0) {
+        schoolQuery = schoolQuery.overlaps("sector_interests", sectorFilters);
+      }
+      if (intentFilter === "join_me" || intentFilter === "seeking_to_join") {
+        schoolQuery = schoolQuery.in("intent", [intentFilter, "no_preference"]);
+      }
+
+      const { data: schoolRows } = await schoolQuery;
       schoolUserIds = schoolRows?.map((r) => r.user_id) ?? [];
     }
 
@@ -145,7 +177,7 @@ export async function GET(req: NextRequest) {
     if (inSchoolTenant && candidateIds.length > 0) {
       const { data: schoolRows } = await supabase
         .from("school_profiles")
-        .select("user_id, school_status, graduation_year, college, degree_type, major, sector_interests")
+        .select("user_id, school_status, graduation_year, college, degree_type, major, sector_interests, intent")
         .eq("organization_id", orgId)
         .in("user_id", candidateIds);
 
@@ -159,6 +191,7 @@ export async function GET(req: NextRequest) {
             utDegreeType: row.degree_type,
             utMajor: row.major,
             utSectorInterests: row.sector_interests,
+            intent: row.intent,
           },
         ]) ?? [],
       );

--- a/src/app/api/ut-profile/route.ts
+++ b/src/app/api/ut-profile/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
-import { mapOnboardingDatatoProfileDB } from "@/lib/mapProfileToFromDBFormat";
+import {
+  mapOnboardingDatatoProfileDB,
+  mapUTDataToSchoolProfileRow,
+} from "@/lib/mapProfileToFromDBFormat";
 
 export async function POST(request: NextRequest) {
   try {
@@ -91,20 +94,9 @@ export async function POST(request: NextRequest) {
     //    translated to generic column names here.
     const { error: schoolError } = await supabase
       .from("school_profiles")
-      .upsert(
-        {
-          user_id: userId,
-          organization_id: orgId,
-          school_status: body.utStatus,
-          graduation_year: body.gradYear ?? null,
-          college: body.utCollege ?? null,
-          degree_type: body.utDegreeType ?? null,
-          major: body.utMajor ?? null,
-          sector_interests: body.utSectorInterests ?? null,
-          additional_education: body.additionalEducation ?? null,
-        },
-        { onConflict: "user_id" },
-      );
+      .upsert(mapUTDataToSchoolProfileRow(body, userId, orgId), {
+        onConflict: "user_id",
+      });
 
     if (schoolError) {
       console.error("Supabase school_profiles upsert error:", schoolError);

--- a/src/app/onboarding/form-components/UTReviewForm.tsx
+++ b/src/app/onboarding/form-components/UTReviewForm.tsx
@@ -87,6 +87,17 @@ export default function UTReviewForm({
             { label: "Time Spent", value: data.startupTimeSpent || "—" },
             { label: "Funding Status", value: data.startupFunding || "—" },
             { label: "Co-Founder Status", value: data.coFounderStatus || "—" },
+            {
+              label: "Matching Intent",
+              value:
+                data.intent === "join_me"
+                  ? "Join me"
+                  : data.intent === "seeking_to_join"
+                    ? "Seeking to join"
+                    : data.intent === "no_preference"
+                      ? "No preference"
+                      : "—",
+            },
             { label: "Equity Expectation", value: data.equityExpectation ? `${data.equityExpectation}%` : "—" },
           ]}
           onEdit={() => onEdit(3)}

--- a/src/app/onboarding/form-components/UTStartupForm.tsx
+++ b/src/app/onboarding/form-components/UTStartupForm.tsx
@@ -13,6 +13,7 @@ type UTStartupFormData = {
   startupTimeSpent?: string;
   startupFunding?: string;
   coFounderStatus?: string;
+  intent?: "join_me" | "seeking_to_join" | "no_preference";
   equityExpectation?: number;
 };
 
@@ -199,6 +200,49 @@ function UTStartupForm({
               </div>
               {errors.coFounderStatus && (
                 <p className="text-xs text-red-400">{errors.coFounderStatus.message}</p>
+              )}
+            </div>
+
+            {/* ── Co-founder intent ── */}
+            <div className="flex flex-col gap-y-3">
+              <label className={LABEL_CLS}>Co-Founder Matching Intent *</label>
+              <div className="flex flex-col gap-y-2">
+                {[
+                  {
+                    value: "join_me" as const,
+                    label: "Join me — I have a startup/idea",
+                  },
+                  {
+                    value: "seeking_to_join" as const,
+                    label: "Seeking to join — I want to join someone else's project",
+                  },
+                  {
+                    value: "no_preference" as const,
+                    label: "No preference — open to either",
+                  },
+                ].map(({ value, label }) => (
+                  <label key={value} className={PILL_RADIO_CLS}>
+                    <input
+                      type="radio"
+                      value={value}
+                      {...register("intent", {
+                        required: "Please select your matching intent",
+                      })}
+                      className="sr-only"
+                    />
+                    <span
+                      className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                        watch("intent") === value
+                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                          : "border-[var(--ui-border-strong)] bg-transparent"
+                      }`}
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+              {errors.intent && (
+                <p className="text-xs text-red-400">{errors.intent.message}</p>
               )}
             </div>
 

--- a/src/app/school/[slug]/contact-us/page.tsx
+++ b/src/app/school/[slug]/contact-us/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import { getOrganizationBySlug } from "@/lib/organizations";
+import UtContactTabs from "@/components/school/contact/UtContactTabs";
+import PublicFooter from "@/components/school/landing/PublicFooter";
+
+export default async function UtContactPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const org = await getOrganizationBySlug(slug);
+
+  if (!org || slug !== "ut") notFound();
+
+  return (
+    <>
+      <section className="section-padding min-h-[calc(100vh-64px)] px-6 pt-16 pb-24" style={{ backgroundColor: "#d6d2c4" }}>
+        <div className="mx-auto max-w-3xl space-y-8">
+          <header className="space-y-2">
+            <h1 className="text-3xl font-semibold sm:text-4xl" style={{ color: "#333f48" }}>Contact</h1>
+            <p style={{ color: "rgba(51,63,72,0.65)" }}>
+              Get in touch with the UT co-foundr team.
+            </p>
+          </header>
+          <UtContactTabs />
+        </div>
+      </section>
+      <PublicFooter />
+    </>
+  );
+}

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { FaPaperPlane, FaLinkedin, FaGithub, FaTwitter, FaGlobe, FaCalendar } from "react-icons/fa6";
 import { MdSkipNext } from "react-icons/md";
-import { IoSearchOutline, IoCloseOutline } from "react-icons/io5";
+import { IoSearchOutline, IoCloseOutline, IoFilterOutline } from "react-icons/io5";
 import { motion, AnimatePresence } from "motion/react";
 import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
@@ -16,6 +16,15 @@ import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/u
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
 import { trackEvent } from "@/lib/posthog-events";
 import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/lib/utSchoolsAndMajors";
+import FilterSidebar, { getFilterChipLabels } from "@/components/school/dashboard/FilterSidebar";
+import {
+  type DashboardFilters,
+  EMPTY_DASHBOARD_FILTERS,
+  hasActiveFilters,
+  getDashboardPanelHeightClass,
+  loadDashboardFilters,
+  saveDashboardFilters,
+} from "@/lib/dashboardFilters";
 
 // ─── Search result card ────────────────────────────────────────────────────────
 
@@ -154,17 +163,30 @@ function SearchResultCard({
 export default function SchoolDashboardPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const [filters, setFilters] = useState<DashboardFilters>(EMPTY_DASHBOARD_FILTERS);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const queryClient = useQueryClient();
   const cardRef = useRef<HTMLDivElement>(null);
 
   const { schoolName } = useSchool();
-  const { data: profiles } = useGetProfiles();
+  const { data: profiles, isLoading: isLoadingProfiles } = useGetProfiles(filters);
+
+  useEffect(() => {
+    setFilters(loadDashboardFilters());
+  }, []);
+
+  const updateFilters = (next: DashboardFilters) => {
+    setFilters(next);
+    saveDashboardFilters(next);
+  };
   const { data: searchResults, isFetching: isSearching } = useSearchProfiles(searchQuery);
   const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
   useMutualLikes();
   const skipProfileMutation = useSkipProfile();
 
   const isSearchActive = searchQuery.trim().length >= 2;
+  const filtersActive = hasActiveFilters(filters);
+  const filterChips = getFilterChipLabels(filters);
   const curProfile = profiles?.[0];
   const { data: likeStatus } = useLikeStatus(curProfile?.user_id);
 
@@ -229,12 +251,22 @@ export default function SchoolDashboardPage() {
           Co-Founder Matching
         </h1>
       </div>
-      <button
-        onClick={() => setSearchOpen(true)}
-        className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--ui-text-muted)] hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] transition cursor-pointer"
-      >
-        <IoSearchOutline className="h-4 w-4" />
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => setFilterDrawerOpen(true)}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--ui-text-muted)] hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] transition cursor-pointer lg:hidden"
+          aria-label="Open filters"
+        >
+          <IoFilterOutline className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => setSearchOpen(true)}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--ui-text-muted)] hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] transition cursor-pointer"
+          aria-label="Open search"
+        >
+          <IoSearchOutline className="h-4 w-4" />
+        </button>
+      </div>
     </div>
   );
 
@@ -260,9 +292,41 @@ export default function SchoolDashboardPage() {
     ? getSchoolFullName(curProfile.utCollege)
     : undefined;
 
+  const panelHeightClass = getDashboardPanelHeightClass(searchOpen);
+
+  const activeFilterChipsRow =
+    filtersActive && !isSearchActive ? (
+      <div className="mb-4">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+          Active filters
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {filterChips.map((chip) => (
+            <button
+              key={chip.key}
+              type="button"
+              onClick={() => updateFilters(chip.onRemove())}
+              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:opacity-90"
+            >
+              {chip.label}
+              <span aria-hidden>&times;</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : null;
+
   return (
-    <div className="mx-auto max-w-2xl p-4 pt-6">
+    <div className="mx-auto max-w-5xl px-4 pt-6">
       {brandingHeader}
+
+      <FilterSidebar
+        variant="drawer"
+        filters={filters}
+        onChange={updateFilters}
+        isOpen={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+      />
 
       {/* Search bar — only shown when open */}
       {searchOpen && (
@@ -285,6 +349,17 @@ export default function SchoolDashboardPage() {
         </div>
       )}
 
+      {activeFilterChipsRow}
+
+      <div className="flex items-stretch gap-6">
+        <FilterSidebar
+          variant="sidebar"
+          filters={filters}
+          onChange={updateFilters}
+          panelHeightClass={panelHeightClass}
+        />
+
+        <div className="mx-auto w-full min-w-0 max-w-2xl flex-1">
       {/* Search results */}
       {isSearchActive ? (
         <div>
@@ -317,14 +392,38 @@ export default function SchoolDashboardPage() {
         </div>
       ) : (
         /* Swipe card */
-        !curProfile ? (
+        isLoadingProfiles ? (
           <div className="flex min-h-[calc(100vh-260px)] flex-col items-center justify-center gap-4 text-center">
-            <p className="text-xl font-semibold text-[var(--ui-text)]">
-              No more co-founders to show right now
-            </p>
-            <p className="text-sm text-[var(--ui-text-muted)]">
-              Check back later — more students from your program will be joining.
-            </p>
+            <p className="text-sm text-[var(--ui-text-muted)]">Loading profiles…</p>
+          </div>
+        ) : !curProfile ? (
+          <div className="flex min-h-[calc(100vh-260px)] flex-col items-center justify-center gap-4 text-center">
+            {filtersActive ? (
+              <>
+                <p className="text-xl font-semibold text-[var(--ui-text)]">
+                  No matches for these filters
+                </p>
+                <p className="text-sm text-[var(--ui-text-muted)]">
+                  Try adjusting your filters or clear them to see more co-founders.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => updateFilters(EMPTY_DASHBOARD_FILTERS)}
+                  className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"
+                >
+                  Clear filters
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-xl font-semibold text-[var(--ui-text)]">
+                  No more co-founders to show right now
+                </p>
+                <p className="text-sm text-[var(--ui-text-muted)]">
+                  Check back later — more students from your program will be joining.
+                </p>
+              </>
+            )}
           </div>
         ) : (
           <AnimatePresence mode="wait">
@@ -335,7 +434,7 @@ export default function SchoolDashboardPage() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -16 }}
               transition={{ duration: 0.25 }}
-              className={`flex flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] ${searchOpen ? "max-h-[calc(100vh-210px)]" : "max-h-[calc(100vh-150px)]"}`}
+              className={`flex flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] ${panelHeightClass}`}
             >
               {/* Card header with avatar, name, badges */}
               <div className="flex-1 overflow-y-auto p-5">
@@ -550,6 +649,8 @@ export default function SchoolDashboardPage() {
           </AnimatePresence>
         )
       )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/school/[slug]/matches/[conversationId]/page.tsx
@@ -14,6 +14,7 @@ import AIWriter from "@/components/ui/AIWriter";
 import { trackEvent } from "@/lib/posthog-events";
 import ActivityIndicator from "@/components/ActivityIndicator";
 import ProfileDetailModal from "@/features/matches/ProfileDetailModal";
+import MeetupCard from "@/features/matches/MeetupCard";
 import { useProfileByUserId } from "@/features/profile/useProfile";
 import { useWeMatch, useWeMatchStatus } from "@/features/matches/useWeMatch";
 import { useToggleLike } from "@/features/likes/useLikes";
@@ -225,6 +226,8 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
             )}
           </div>
         )}
+
+        {slug === "ut" && mutualSet.has(otherUserId) && <MeetupCard />}
       </div>
 
       {/* Messages */}

--- a/src/app/school/[slug]/matches/page.tsx
+++ b/src/app/school/[slug]/matches/page.tsx
@@ -190,7 +190,7 @@ export default function SchoolMatchesPage({
                 No conversations yet
               </p>
               <p className="text-sm text-[var(--ui-text-subtle)]">
-                Message a co-founder from their profile card to start chatting.
+                Message someone from their profile card to start chatting.
               </p>
             </div>
           ) : (
@@ -226,7 +226,7 @@ export default function SchoolMatchesPage({
                 No liked profiles yet
               </p>
               <p className="text-sm text-[var(--ui-text-subtle)]">
-                Like a co-founder from the dashboard and they&apos;ll appear
+                Like someone from the dashboard and they&apos;ll appear
                 here.
               </p>
             </div>
@@ -418,14 +418,14 @@ export default function SchoolMatchesPage({
             </p>
             <p className="mt-0.5 text-xs leading-relaxed text-amber-700">
               Once sent, it can&apos;t be retracted. Only click We Match when
-              you genuinely want to co-found with someone.
+              you genuinely want to work with someone.
             </p>
           </div>
 
           {/* Footer note */}
           <p className="rounded-lg border border-[var(--ui-border)] p-3 text-xs leading-relaxed text-[var(--ui-text-muted)]">
             We Match is separate from messaging. Use it as a stronger signal
-            that you want to co-found together. The email gives you both
+            that you want to work together. The email gives you both
             everything you need to connect directly.
           </p>
         </motion.div>

--- a/src/app/school/[slug]/matches/page.tsx
+++ b/src/app/school/[slug]/matches/page.tsx
@@ -11,6 +11,7 @@ import { ConversationWithOtherParticipant } from "@/features/conversations/conve
 import { useLikedProfilesData, useToggleLike } from "@/features/likes/useLikes";
 import { useWeMatch, useWeMatchStatus } from "@/features/matches/useWeMatch";
 import ProfileDetailModal from "@/features/matches/ProfileDetailModal";
+import MeetupCard from "@/features/matches/MeetupCard";
 import { useCreateConversation } from "@/hooks/useConversations";
 import { getDegreeAbbreviation } from "@/lib/utSchoolsAndMajors";
 import React, { useState, useEffect, useCallback } from "react";
@@ -30,6 +31,11 @@ export default function SchoolMatchesPage({
   const [activeTab, setActiveTab] = useState<Tab>(
     tabParam === "messages" ? "messages" : "liked"
   );
+  const [slug, setSlug] = useState<string>("");
+
+  useEffect(() => {
+    params.then((resolvedParams) => setSlug(resolvedParams.slug));
+  }, [params]);
 
   useEffect(() => {
     if (tabParam === "messages") {
@@ -363,6 +369,8 @@ export default function SchoolMatchesPage({
           animate={{ opacity: 1 }}
           className="space-y-4"
         >
+          {slug === "ut" && <MeetupCard />}
+
           <div className="text-center">
             <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--ui-border)] bg-[var(--ui-surface-active)]">
               <FaHandshake className="h-6 w-6 text-[var(--org-primary)]" />

--- a/src/app/school/[slug]/onboarding/page.tsx
+++ b/src/app/school/[slug]/onboarding/page.tsx
@@ -45,8 +45,15 @@ function getCompletedSteps(
   if (isUT) {
     if (step2BaseFields && data.utStatus) completed.add(2);
     // Step 3: Startup details (has startup field required)
-    if (data.hasStartup && data.coFounderStatus !== undefined && data.equityExpectation !== undefined)
+    if (
+      data.hasStartup === "no" ||
+      (data.hasStartup === "yes" &&
+        data.coFounderStatus !== undefined &&
+        data.intent !== undefined &&
+        data.equityExpectation !== undefined)
+    ) {
       completed.add(3);
+    }
   } else {
     if (
       step2BaseFields &&

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -55,7 +55,7 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
     },
   ];
 
-  const headerText = config.branding.wordmark ? `${config.branding.wordmark} McCombs Co-Foundr` : schoolName;
+  const headerText = config.branding.wordmark ? `${config.branding.wordmark} Co-Foundr` : schoolName;
 
   return (
     <header

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -45,9 +45,8 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
       label: "Find a co-foundr",
     },
     {
-      href: "https://www.mccombs.utexas.edu/about/contact/",
+      href: `/school/${slug}/contact-us`,
       label: "Contact us",
-      external: true,
     },
     {
       href: "/privacy-policy",
@@ -71,29 +70,20 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
 
       {/* Desktop nav */}
       <nav className="hidden flex-1 items-center justify-end gap-8 md:flex">
-        {navItems.map(({ href, label, external }) => {
-          const classes = clsx(
-            "text-sm font-medium transition-opacity border-b-2",
-            !external && pathname.startsWith(href)
-              ? "opacity-100 border-white"
-              : "opacity-70 hover:opacity-90 border-transparent",
-          );
-          return external ? (
-            <a
-              key={href}
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={classes}
-            >
-              {label}
-            </a>
-          ) : (
-            <Link key={href} href={href} className={classes}>
-              {label}
-            </Link>
-          );
-        })}
+        {navItems.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className={clsx(
+              "text-sm font-medium transition-opacity border-b-2",
+              pathname.startsWith(href)
+                ? "opacity-100 border-white"
+                : "opacity-70 hover:opacity-90 border-transparent",
+            )}
+          >
+            {label}
+          </Link>
+        ))}
       </nav>
 
       <div className="ml-4 flex items-center gap-4 md:ml-8 md:gap-6">
@@ -129,31 +119,17 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
           style={{ backgroundColor: config.branding.primaryColor }}
         >
           <ul className="p-2 space-y-0.5">
-            {navItems.map(({ href, label, external }) =>
-              external ? (
-                <li key={href}>
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block rounded-lg px-3 py-2 text-sm font-medium text-white/80 hover:bg-white/10 hover:text-white"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    {label}
-                  </a>
-                </li>
-              ) : (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="block rounded-lg px-3 py-2 text-sm font-medium text-white/80 hover:bg-white/10 hover:text-white"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    {label}
-                  </Link>
-                </li>
-              )
-            )}
+            {navItems.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="block rounded-lg px-3 py-2 text-sm font-medium text-white/80 hover:bg-white/10 hover:text-white"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
       )}

--- a/src/components/school/auth/SchoolSignIn.tsx
+++ b/src/components/school/auth/SchoolSignIn.tsx
@@ -120,8 +120,8 @@ export default function SchoolSignIn({
             className="mb-1 text-xl md:text-2xl font-semibold tracking-tight"
             style={{ color: "#333f48" }}
           >
-            <span className="md:hidden">Create your McCombs co-foundr matching account</span>
-            <span className="hidden md:inline">Sign into McCombs Co-foundr Matching Engine</span>
+            <span className="md:hidden">Sign into your University of Texas at Austin co-foundr matching account</span>
+            <span className="hidden md:inline">Sign into University of Texas at Austin Co-foundr Matching Engine</span>
           </h1>
           <p className="text-sm" style={{ color: "#9cadb7" }}>
             Use your {allowedCopy} account.

--- a/src/components/school/auth/SchoolSignUp.tsx
+++ b/src/components/school/auth/SchoolSignUp.tsx
@@ -150,8 +150,8 @@ export default function SchoolSignUp({
           >
             {pendingVerification ? "Verify your email" : (
               <>
-                <span className="md:hidden">Create your McCombs co-foundr matching account</span>
-                <span className="hidden md:inline">Create McCombs Co-foundr Matching Engine account</span>
+                <span className="md:hidden">Create your University of Texas at Austin co-foundr matching account</span>
+                <span className="hidden md:inline">Create University of Texas at Austin Co-foundr Matching Engine account</span>
               </>
             )}
           </h1>

--- a/src/components/school/contact/UtAboutPanel.tsx
+++ b/src/components/school/contact/UtAboutPanel.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function UtAboutPanel() {
+  return (
+    <motion.div
+      className="overflow-hidden rounded-2xl text-center"
+      style={{ backgroundColor: "#bf5700" }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+    >
+      <div className="px-6 py-10 sm:px-12 sm:py-14">
+        <p
+          className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
+          style={{ color: "rgba(255,255,255,0.55)" }}
+        >
+          University of Texas at Austin
+        </p>
+        <h2 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
+          Have a school question?
+        </h2>
+        <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed text-white/80">
+          For questions about UT programs, events, or anything school-related
+          that isn&apos;t about the co-foundr platform, reach out to McCombs
+          directly.
+        </p>
+        <a
+          href="https://www.mccombs.utexas.edu/about/contact/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block rounded-md px-7 py-3 text-sm font-semibold transition-transform hover:scale-105"
+          style={{ backgroundColor: "#ffffff", color: "#bf5700" }}
+        >
+          Contact McCombs →
+        </a>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/school/contact/UtContactTabs.tsx
+++ b/src/components/school/contact/UtContactTabs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import UtSupportPanel from "./UtSupportPanel";
+import UtAboutPanel from "./UtAboutPanel";
+
+type Tab = "support" | "about";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "support", label: "Platform support" },
+  { id: "about", label: "UT inquiries" },
+];
+
+export default function UtContactTabs() {
+  const [active, setActive] = useState<Tab>("support");
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Contact options"
+        className="mb-6 inline-flex rounded-full p-1"
+        style={{ backgroundColor: "rgba(51,63,72,0.1)" }}
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={active === tab.id}
+            onClick={() => setActive(tab.id)}
+            className="relative rounded-full px-5 py-2 text-sm font-medium transition-colors"
+            style={{
+              color: active === tab.id ? "#ffffff" : "rgba(51,63,72,0.6)",
+            }}
+          >
+            {active === tab.id && (
+              <motion.span
+                layoutId="tab-pill"
+                className="absolute inset-0 rounded-full"
+                style={{ backgroundColor: "#bf5700" }}
+                transition={{ type: "spring", stiffness: 400, damping: 30 }}
+              />
+            )}
+            <span className="relative z-10">{tab.label}</span>
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        aria-label={TABS.find((t) => t.id === active)?.label}
+      >
+        {active === "support" ? <UtSupportPanel /> : <UtAboutPanel />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/school/contact/UtSupportPanel.tsx
+++ b/src/components/school/contact/UtSupportPanel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { MdCalendarToday } from "react-icons/md";
+
+export default function UtSupportPanel() {
+  return (
+    <motion.div
+      className="rounded-lg border border-black/5 bg-white p-6 text-center sm:p-10"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+    >
+      <h2 className="mb-3 text-2xl font-semibold sm:text-3xl" style={{ color: "#333f48" }}>
+        Need help with the platform?
+      </h2>
+      <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed sm:text-base" style={{ color: "#9cadb7" }}>
+        Book time with the Mamun team for help with your account, matches, or
+        anything else technical on the co-foundr platform.
+      </p>
+
+      <Link
+        href="https://calendly.com/mcfm-mamuncofoundr/30min"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mb-6 inline-flex items-center gap-2 rounded-md px-7 py-3 text-sm font-semibold text-white transition-all duration-200 hover:scale-105 hover:shadow-lg"
+        style={{ backgroundColor: "#bf5700" }}
+      >
+        <MdCalendarToday className="text-lg" />
+        Schedule a call
+      </Link>
+
+      <div className="border-t pt-6" style={{ borderColor: "rgba(0,0,0,0.06)" }}>
+        <p className="mb-1 text-sm" style={{ color: "#9cadb7" }}>
+          Or email us at{" "}
+          <a
+            href="mailto:mamun@mamuncofoundr.com"
+            className="font-semibold hover:underline"
+            style={{ color: "#bf5700" }}
+          >
+            mamun@mamuncofoundr.com
+          </a>
+        </p>
+        <p className="text-sm" style={{ color: "#9cadb7" }}>
+          Leave your full name and we will get back to you within 1–2 business
+          days.
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/school/dashboard/FilterSidebar.tsx
+++ b/src/components/school/dashboard/FilterSidebar.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useEffect, useMemo, type ChangeEvent, type ReactNode } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { IoCloseOutline, IoChevronDown } from "react-icons/io5";
+import {
+  UT_SCHOOLS_AND_PROGRAMS,
+  SECTOR_INTEREST_LABELS,
+  getSchoolLabel,
+} from "@/lib/utSchoolsAndMajors";
+import {
+  type DashboardFilters,
+  EMPTY_DASHBOARD_FILTERS,
+  hasActiveFilters,
+} from "@/lib/dashboardFilters";
+
+const SELECT_CLS =
+  "box-border w-full min-w-0 appearance-none rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] " +
+  "py-2.5 pl-4 pr-10 text-sm text-[var(--ui-text)] " +
+  "transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none " +
+  "hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+
+function FilterSelect({
+  value,
+  onChange,
+  children,
+}: {
+  value: string | number;
+  onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="relative w-full min-w-0">
+      <select value={value} onChange={onChange} className={SELECT_CLS}>
+        {children}
+      </select>
+      <IoChevronDown
+        className="pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-[var(--ui-text-muted)]"
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+type FilterSidebarProps = {
+  filters: DashboardFilters;
+  onChange: (filters: DashboardFilters) => void;
+  isOpen?: boolean;
+  onClose?: () => void;
+  variant?: "sidebar" | "drawer";
+  /** Desktop sidebar height — should match the profile card */
+  panelHeightClass?: string;
+};
+
+const INTENT_OPTIONS = [
+  { value: null, label: "Any" },
+  { value: "join_me" as const, label: "Join me" },
+  { value: "seeking_to_join" as const, label: "Seeking to join" },
+];
+
+function FilterPanel({
+  filters,
+  onChange,
+  onClose,
+  showClose,
+  scrollable = false,
+}: {
+  filters: DashboardFilters;
+  onChange: (filters: DashboardFilters) => void;
+  onClose?: () => void;
+  showClose?: boolean;
+  scrollable?: boolean;
+}) {
+  const currentYear = new Date().getFullYear();
+  const gradYears = useMemo(() => {
+    const years: number[] = [];
+    for (let y = currentYear - 6; y <= currentYear + 6; y++) {
+      years.push(y);
+    }
+    return years;
+  }, [currentYear]);
+
+  const toggleSector = (sector: string) => {
+    const next = filters.sectors.includes(sector)
+      ? filters.sectors.filter((s) => s !== sector)
+      : [...filters.sectors, sector];
+    onChange({ ...filters, sectors: next });
+  };
+
+  const clearAll = () => onChange(EMPTY_DASHBOARD_FILTERS);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--ui-text)]">Filters</h2>
+        <div className="flex items-center gap-2">
+          {hasActiveFilters(filters) && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs font-medium text-[#bf5700] hover:underline cursor-pointer"
+            >
+              Clear all
+            </button>
+          )}
+          {showClose && onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--ui-text-muted)] hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] cursor-pointer"
+              aria-label="Close filters"
+            >
+              <IoCloseOutline className="h-5 w-5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div
+        className={`flex min-h-0 flex-1 flex-col gap-4 ${scrollable ? "overflow-y-auto" : "overflow-hidden"}`}
+      >
+        {/* School department */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+            School Department
+          </label>
+          <FilterSelect
+            value={filters.college ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                college: e.target.value || null,
+              })
+            }
+          >
+            <option value="">All schools</option>
+            {Object.keys(UT_SCHOOLS_AND_PROGRAMS).map((key) => (
+              <option key={key} value={key}>
+                {getSchoolLabel(key as UTCollege)}
+              </option>
+            ))}
+          </FilterSelect>
+        </div>
+
+        {/* Industry / interest */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+            Industry / Interest
+          </label>
+          <div className="flex flex-wrap gap-1">
+            {(
+              Object.keys(SECTOR_INTEREST_LABELS) as UTSectorInterest[]
+            ).map((sector) => {
+              const selected = filters.sectors.includes(sector);
+              return (
+                <button
+                  key={sector}
+                  type="button"
+                  onClick={() => toggleSector(sector)}
+                  className={`rounded-md px-2 py-0.5 text-[11px] font-medium transition cursor-pointer ${
+                    selected
+                      ? "bg-[#bf5700] text-white"
+                      : "bg-[var(--ui-surface-active)] text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
+                  }`}
+                >
+                  {SECTOR_INTEREST_LABELS[sector]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Graduation year */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+            Graduation Year
+          </label>
+          <FilterSelect
+            value={filters.gradYear ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                gradYear: e.target.value ? Number(e.target.value) : null,
+              })
+            }
+          >
+            <option value="">Any year</option>
+            {gradYears.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </FilterSelect>
+        </div>
+
+        {/* Intent */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <label className="text-xs font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+            Intent
+          </label>
+          <div className="flex flex-col gap-1.5">
+            {INTENT_OPTIONS.map(({ value, label }) => (
+              <label
+                key={label}
+                className="flex cursor-pointer items-center gap-2.5 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-2 text-sm text-[var(--ui-text)] transition hover:border-[var(--ui-border-strong)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)]"
+              >
+                <input
+                  type="radio"
+                  name="intent-filter"
+                  checked={filters.intent === value}
+                  onChange={() => onChange({ ...filters, intent: value })}
+                  className="sr-only"
+                />
+                <span
+                  className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                    filters.intent === value
+                      ? "border-[#bf5700] bg-[#bf5700]"
+                      : "border-[var(--ui-border-strong)] bg-transparent"
+                  }`}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function FilterSidebar({
+  filters,
+  onChange,
+  isOpen = false,
+  onClose,
+  variant = "sidebar",
+  panelHeightClass = "h-[calc(100vh-150px)] max-h-[calc(100vh-150px)]",
+}: FilterSidebarProps) {
+  useEffect(() => {
+    if (variant !== "drawer" || !isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [variant, isOpen]);
+
+  if (variant === "sidebar") {
+    return (
+      <aside
+        className={`hidden w-64 shrink-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 lg:flex ${panelHeightClass}`}
+      >
+        <FilterPanel filters={filters} onChange={onChange} scrollable={false} />
+      </aside>
+    );
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-40 bg-black/50"
+            onClick={onClose}
+            aria-hidden
+          />
+          <motion.aside
+            initial={{ x: "-100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "-100%" }}
+            transition={{ type: "spring", damping: 28, stiffness: 320 }}
+            className="fixed left-0 top-0 z-50 flex h-full w-[85vw] max-w-sm flex-col border-r border-[var(--ui-border)] bg-[var(--ui-popover-bg,var(--org-bg,#ffffff))] p-4 shadow-xl"
+          >
+            <FilterPanel
+              filters={filters}
+              onChange={onChange}
+              onClose={onClose}
+              showClose
+              scrollable
+            />
+          </motion.aside>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export function getFilterChipLabels(filters: DashboardFilters): {
+  key: string;
+  label: string;
+  onRemove: () => DashboardFilters;
+}[] {
+  const chips: {
+    key: string;
+    label: string;
+    onRemove: () => DashboardFilters;
+  }[] = [];
+
+  if (filters.college) {
+    chips.push({
+      key: `college-${filters.college}`,
+      label: getSchoolLabel(filters.college as UTCollege),
+      onRemove: () => ({ ...filters, college: null }),
+    });
+  }
+
+  for (const sector of filters.sectors) {
+    chips.push({
+      key: `sector-${sector}`,
+      label:
+        SECTOR_INTEREST_LABELS[sector as UTSectorInterest] ?? sector,
+      onRemove: () => ({
+        ...filters,
+        sectors: filters.sectors.filter((s) => s !== sector),
+      }),
+    });
+  }
+
+  if (filters.gradYear !== null) {
+    chips.push({
+      key: `grad-${filters.gradYear}`,
+      label: `Class of ${filters.gradYear}`,
+      onRemove: () => ({ ...filters, gradYear: null }),
+    });
+  }
+
+  if (filters.intent === "join_me") {
+    chips.push({
+      key: "intent-join_me",
+      label: "Join me",
+      onRemove: () => ({ ...filters, intent: null }),
+    });
+  } else if (filters.intent === "seeking_to_join") {
+    chips.push({
+      key: "intent-seeking",
+      label: "Seeking to join",
+      onRemove: () => ({ ...filters, intent: null }),
+    });
+  }
+
+  return chips;
+}

--- a/src/components/school/landing/CtaBand.tsx
+++ b/src/components/school/landing/CtaBand.tsx
@@ -35,7 +35,7 @@ export default function CtaBand() {
           className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
           style={{ color: "rgba(255,255,255,0.5)" }}
         >
-          Texas McCombs School of Business
+          University of Texas at Austin
         </motion.div>
         <motion.h2
           variants={item}
@@ -47,7 +47,7 @@ export default function CtaBand() {
           variants={item}
           className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white/70"
         >
-          Join the McCombs co-foundr community — verified, value-aligned, and
+          Join the University of Texas at Austin co-foundr community — verified, value-aligned, and
           ready to build something that changes the world.
         </motion.p>
         <motion.div variants={item}>
@@ -60,7 +60,7 @@ export default function CtaBand() {
           </Link>
         </motion.div>
         <motion.div variants={item} className="text-xs text-white/40">
-          Exclusively for McCombs students, alumni, and faculty
+          Exclusively for University of Texas at Austin students, alumni, and faculty
         </motion.div>
       </motion.div>
     </section>

--- a/src/components/school/landing/DepartmentMosaic.tsx
+++ b/src/components/school/landing/DepartmentMosaic.tsx
@@ -149,21 +149,6 @@ function Card({ dept, featured }: { dept: Dept; featured?: boolean }) {
   );
 }
 
-function TierHeader({ label, dotColor }: { label: string; dotColor: string }) {
-  return (
-    <div
-      className="mb-3 flex items-center gap-2 border-b pb-2 text-[11px] font-semibold uppercase tracking-[0.08em]"
-      style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
-    >
-      <span
-        className="inline-block h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: dotColor }}
-      />
-      {label}
-    </div>
-  );
-}
-
 export default function DepartmentMosaic() {
   return (
     <section
@@ -186,20 +171,12 @@ export default function DepartmentMosaic() {
           platform, one mission.
         </p>
 
-        <TierHeader
-          label="Tier 1 — Core Schools"
-          dotColor="#bf5700"
-        />
         <div className="mb-8 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
           {TIER_1.map((d, i) => (
             <Card key={d.name} dept={d} featured={i === 0} />
           ))}
         </div>
 
-        <TierHeader
-          label="Tier 2 — Partner Schools"
-          dotColor="#9cadb7"
-        />
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
           {TIER_2.map((d) => (
             <Card key={d.name} dept={d} />

--- a/src/components/school/landing/Hero.tsx
+++ b/src/components/school/landing/Hero.tsx
@@ -42,7 +42,7 @@ export default function Hero() {
           variants={item}
           className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white/70 sm:text-base"
         >
-          The McCombs co-foundr matching platform connects value-aligned students,
+          The University of Texas at Austin co-foundr matching platform connects value-aligned students,
           alumni, and faculty ready to build something that changes the world.
         </motion.p>
         <motion.div variants={item}>

--- a/src/components/school/landing/HowItWorks.tsx
+++ b/src/components/school/landing/HowItWorks.tsx
@@ -15,8 +15,13 @@ const STEPS = [
   },
   {
     n: 3,
+    title: "Meetup",
+    desc: "Connect and message to learn more about each other in person or over video.",
+  },
+  {
+    n: 4,
     title: "Start building",
-    desc: "Connect, message, and find the person you want to build the next decade with.",
+    desc: "Find the person you want to build the next decade with and get started.",
   },
 ];
 
@@ -50,10 +55,10 @@ export default function HowItWorks() {
           className="mb-10 text-center text-2xl font-semibold sm:text-3xl"
           style={{ color: "#333f48" }}
         >
-          Three steps to your ideal founding partner
+          Four steps to your ideal founding partner
         </motion.h2>
         <motion.div
-          className="grid gap-4 sm:grid-cols-3"
+          className="grid gap-4 sm:grid-cols-4"
           variants={container}
           initial="hidden"
           whileInView="visible"

--- a/src/components/school/landing/HowItWorks.tsx
+++ b/src/components/school/landing/HowItWorks.tsx
@@ -11,7 +11,7 @@ const STEPS = [
   {
     n: 2,
     title: "Get matched",
-    desc: "Engine surfaces verified McCombs founders with complementary skills and aligned values.",
+    desc: "Engine surfaces verified University of Texas at Austin founders with complementary skills and aligned values.",
   },
   {
     n: 3,

--- a/src/components/school/landing/PublicFooter.tsx
+++ b/src/components/school/landing/PublicFooter.tsx
@@ -19,7 +19,7 @@ export default function PublicFooter() {
         >
           <div>
             <div className="mb-1 text-sm font-semibold text-white">
-              Texas McCombs Co-Foundr
+              University of Texas at Austin Co-Foundr
             </div>
             <div className="text-xs" style={{ color: "#9cadb7" }}>
               Co-Foundr Matching Platform
@@ -94,7 +94,7 @@ export default function PublicFooter() {
             color: "rgba(255,255,255,0.25)",
           }}
         >
-          © 2026 Texas McCombs Co-Foundr. Powered by Mamun. All rights
+          © 2026 University of Texas at Austin Co-Foundr. Powered by Mamun. All rights
           reserved.
         </div>
       </div>

--- a/src/components/school/landing/PublicFooter.tsx
+++ b/src/components/school/landing/PublicFooter.tsx
@@ -18,7 +18,7 @@ export default function PublicFooter() {
           viewport={{ once: true }}
         >
           <div>
-            <div className="mb-1 text-sm font-semibold text-white">
+            <div className="mb-1 text-sm font-semibold" style={{ color: "#bf5700" }}>
               University of Texas at Austin Co-Foundr
             </div>
             <div className="text-xs" style={{ color: "#9cadb7" }}>

--- a/src/components/school/landing/PublicFooter.tsx
+++ b/src/components/school/landing/PublicFooter.tsx
@@ -73,16 +73,15 @@ export default function PublicFooter() {
                   Privacy Policy
                 </Link>
               </motion.div>
-              <motion.a
-                href="https://www.mccombs.utexas.edu/about/contact/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block text-xs hover:text-white transition-colors"
-                style={{ color: "#9cadb7" }}
-                whileHover={{ color: "#ffffff" }}
-              >
-                Contact Us
-              </motion.a>
+              <motion.div whileHover={{ color: "#ffffff" }}>
+                <Link
+                  href="/school/ut/contact-us"
+                  className="block text-xs hover:text-white transition-colors"
+                  style={{ color: "#9cadb7" }}
+                >
+                  Contact Us
+                </Link>
+              </motion.div>
             </div>
           </div>
         </motion.div>

--- a/src/components/school/landing/PublicSchoolHeader.tsx
+++ b/src/components/school/landing/PublicSchoolHeader.tsx
@@ -7,7 +7,7 @@ export default function PublicSchoolHeader() {
       style={{ backgroundColor: "#bf5700" }}
     >
       <Link href="/" className="text-xs sm:text-sm font-semibold text-white text-center sm:text-left">
-        Texas McCombs Co-Foundr
+        University of Texas at Austin Co-Foundr
       </Link>
 
       <nav className="flex flex-wrap items-center justify-center gap-3 sm:gap-5">

--- a/src/components/school/landing/PublicSchoolHeader.tsx
+++ b/src/components/school/landing/PublicSchoolHeader.tsx
@@ -17,14 +17,12 @@ export default function PublicSchoolHeader() {
         >
           Find a co-foundr
         </a>
-        <a
-          href="https://www.mccombs.utexas.edu/about/contact/"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          href="/school/ut/contact-us"
           className="text-xs sm:text-sm font-medium text-white/75 hover:text-white whitespace-nowrap"
         >
           Contact us
-        </a>
+        </Link>
 
         <Link
           href="/school/ut/sign-in"

--- a/src/components/school/landing/ValuesPillars.tsx
+++ b/src/components/school/landing/ValuesPillars.tsx
@@ -51,7 +51,7 @@ export default function ValuesPillars() {
           viewport={{ once: true }}
           className="mb-1.5 text-center text-2xl font-semibold text-white sm:text-3xl"
         >
-          Built on McCombs values
+          Built on University of Texas at Austin values
         </motion.h2>
         <motion.p
           initial={{ opacity: 0 }}

--- a/src/features/matches/MeetupCard.tsx
+++ b/src/features/matches/MeetupCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { FaCalendar } from "react-icons/fa6";
+import { FaExternalLinkAlt } from "react-icons/fa";
+
+const LUMA_MEETUP_URL = "https://luma.com/mamun?period=past";
+const LUMA_FOOTER_URL = "https://lu.ma/mamun";
+
+interface MeetupCardProps {
+  className?: string;
+}
+
+export default function MeetupCard({ className = "" }: MeetupCardProps) {
+  return (
+    <div
+      className={`rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 ${className}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-[var(--ui-text)]">
+          Make sure you and your potential partner coordinate which time and
+          day to RSVP your meetup at UT via Luma Events.
+        </p>
+        <a
+          href={LUMA_MEETUP_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex flex-shrink-0 items-center justify-center gap-2 rounded-full bg-[var(--org-primary)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+        >
+          <FaCalendar className="h-3.5 w-3.5" />
+          Schedule meet up
+        </a>
+      </div>
+      <div className="mt-3 flex justify-end">
+        <a
+          href={LUMA_FOOTER_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--ui-border)] px-2.5 py-1 text-xs text-[var(--ui-text-muted)] transition hover:text-[var(--ui-text)]"
+        >
+          <FaExternalLinkAlt className="h-2.5 w-2.5" />
+          Powered by Mamun Luma Events · lu.ma/mamun
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -2,8 +2,12 @@ import { useState, useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth, useSession } from "@clerk/nextjs";
 import toast from "react-hot-toast";
+import {
+  type DashboardFilters,
+  buildProfilesQueryString,
+} from "@/lib/dashboardFilters";
 
-export function useGetProfiles() {
+export function useGetProfiles(filters?: DashboardFilters) {
   const { userId } = useAuth();
   const { session } = useSession();
 
@@ -12,7 +16,7 @@ export function useGetProfiles() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["profiles"],
+    queryKey: ["profiles", filters],
     queryFn: async () => {
       const token = await session?.getToken();
 
@@ -24,8 +28,10 @@ export function useGetProfiles() {
         throw { message: "No user id. Please log in." };
       }
 
+      const queryString = filters ? buildProfilesQueryString(filters) : "";
+
       try {
-        const response = await fetch("/api/profiles", {
+        const response = await fetch(`/api/profiles${queryString}`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/src/lib/dashboardFilters.ts
+++ b/src/lib/dashboardFilters.ts
@@ -1,0 +1,73 @@
+export type ProfileIntentFilter = "join_me" | "seeking_to_join";
+
+export type DashboardFilters = {
+  college: string | null;
+  sectors: string[];
+  gradYear: number | null;
+  intent: ProfileIntentFilter | null;
+};
+
+export const EMPTY_DASHBOARD_FILTERS: DashboardFilters = {
+  college: null,
+  sectors: [],
+  gradYear: null,
+  intent: null,
+};
+
+const STORAGE_KEY = "school-dashboard-filters";
+
+export function loadDashboardFilters(): DashboardFilters {
+  if (typeof window === "undefined") return EMPTY_DASHBOARD_FILTERS;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_DASHBOARD_FILTERS;
+    const parsed = JSON.parse(raw) as DashboardFilters;
+    return {
+      college: parsed.college ?? null,
+      sectors: Array.isArray(parsed.sectors) ? parsed.sectors : [],
+      gradYear:
+        typeof parsed.gradYear === "number" ? parsed.gradYear : null,
+      intent:
+        parsed.intent === "join_me" || parsed.intent === "seeking_to_join"
+          ? parsed.intent
+          : null,
+    };
+  } catch {
+    return EMPTY_DASHBOARD_FILTERS;
+  }
+}
+
+export function saveDashboardFilters(filters: DashboardFilters): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+}
+
+export function hasActiveFilters(filters: DashboardFilters): boolean {
+  return (
+    filters.college !== null ||
+    filters.sectors.length > 0 ||
+    filters.gradYear !== null ||
+    filters.intent !== null
+  );
+}
+
+/** Matches the swipe card / filter sidebar viewport height on desktop */
+export function getDashboardPanelHeightClass(searchOpen: boolean): string {
+  return searchOpen
+    ? "h-[calc(100vh-210px)] max-h-[calc(100vh-210px)]"
+    : "h-[calc(100vh-150px)] max-h-[calc(100vh-150px)]";
+}
+
+export function buildProfilesQueryString(filters: DashboardFilters): string {
+  const params = new URLSearchParams();
+  if (filters.college) params.set("college", filters.college);
+  if (filters.sectors.length > 0) {
+    params.set("sectors", filters.sectors.join(","));
+  }
+  if (filters.gradYear !== null) {
+    params.set("gradYear", String(filters.gradYear));
+  }
+  if (filters.intent) params.set("intent", filters.intent);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}

--- a/src/lib/mapProfileToFromDBFormat.ts
+++ b/src/lib/mapProfileToFromDBFormat.ts
@@ -109,3 +109,37 @@ export function mapOnboardingDatatoProfileDB(data: OnboardingData) {
     onboarding_complete: true,
   };
 }
+
+export function mapSchoolProfileToUTData(
+  row: SchoolProfileFromDb,
+): Partial<UTProfileData> {
+  return {
+    utStatus: row.school_status,
+    gradYear: row.graduation_year ?? undefined,
+    utCollege: (row.college as UTCollege | null) ?? undefined,
+    utDegreeType: row.degree_type ?? undefined,
+    utMajor: row.major ?? undefined,
+    utSectorInterests: (row.sector_interests as UTSectorInterest[] | null) ?? undefined,
+    intent: row.intent ?? undefined,
+    additionalEducation: row.additional_education ?? undefined,
+  };
+}
+
+export function mapUTDataToSchoolProfileRow(
+  data: OnboardingData,
+  userId: string,
+  organizationId: string,
+) {
+  return {
+    user_id: userId,
+    organization_id: organizationId,
+    school_status: data.utStatus,
+    graduation_year: data.gradYear ?? null,
+    college: data.utCollege ?? null,
+    degree_type: data.utDegreeType ?? null,
+    major: data.utMajor ?? null,
+    sector_interests: data.utSectorInterests ?? null,
+    additional_education: data.additionalEducation ?? null,
+    intent: data.intent ?? null,
+  };
+}

--- a/supabase/migrations/20260528000001_add_intent_to_school_profiles.sql
+++ b/supabase/migrations/20260528000001_add_intent_to_school_profiles.sql
@@ -1,0 +1,23 @@
+-- Add explicit cofounder intent to school_profiles (Join me vs Seeking to join)
+
+ALTER TABLE school_profiles
+  ADD COLUMN IF NOT EXISTS intent text
+  CHECK (intent IN ('join_me', 'seeking_to_join', 'no_preference'));
+
+CREATE INDEX IF NOT EXISTS idx_school_profiles_intent
+  ON school_profiles (organization_id, intent);
+
+-- Backfill from profiles.cofounder_status (stored from startup onboarding)
+UPDATE school_profiles sp
+SET intent = CASE
+  WHEN p.cofounder_status IN ('Solo founder', 'Have co-founder(s)') THEN 'join_me'
+  WHEN p.cofounder_status = 'Seeking co-founder' THEN 'seeking_to_join'
+  ELSE 'no_preference'
+END
+FROM profiles p
+WHERE sp.user_id = p.user_id
+  AND sp.intent IS NULL;
+
+UPDATE school_profiles
+SET intent = 'no_preference'
+WHERE intent IS NULL;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -107,6 +107,7 @@ declare global {
     degree_type: "bachelors" | "masters" | "professional" | "other" | null;
     major: string | null;
     sector_interests: string[] | null;
+    intent: "join_me" | "seeking_to_join" | "no_preference" | null;
     additional_education: string | null;
     school_data: Record<string, unknown>;
     created_at: string;
@@ -139,6 +140,7 @@ declare global {
     utDegreeType?: UTDegreeType;
     utMajor?: string;
     utSectorInterests?: UTSectorInterest[];
+    intent?: "join_me" | "seeking_to_join" | "no_preference";
     additionalEducation?: string;
   };
 


### PR DESCRIPTION
 # MCFM-115 | UT Dashboard Filters, Meetup Flow & Branding Refresh

**Branch:** `MCFM-115`  
**Base:** `main` (includes MCFM-114)  
**Status:** Ready for review  
**Diff:** 29 files changed, +1,015 / −148 lines  

---

## 1. Motivation

The UT Austin school portal is live, but three gaps remain before it feels complete for students:

1. **Discovery is too broad** — the swipe dashboard surfaces every verified UT user with no way to narrow by school, industry, graduation year, or co-founder intent.
2. **Meetup is invisible after a match** — mutual We Match users have no in-app guidance toward scheduling an in-person UT meetup via Luma.
3. **Branding is McCombs-centric** — copy, footer, and contact links still reference Texas McCombs rather than the university-wide program, and the landing page omits meetup as a step in the journey.

This PR addresses all three: dashboard filtering with persisted intent, meetup surfacing on mutual match, a dedicated contact page, and UT-wide copy updates.

---

## 2. Summary of Changes

| Area | What changed |
|---|---|
| **Dashboard filters** | Sidebar (desktop) + drawer (mobile) for college, sector, grad year, and intent; filter chips; empty state when no results |
| **Intent data model** | New `school_profiles.intent` column; collected at onboarding; backfilled from existing `cofounder_status` |
| **Meetup UX** | `MeetupCard` on We Match tab and in 1:1 conversations when both users have mutually matched (UT only) |
| **Landing page** | "How It Works" expanded to 4 steps (adds Meetup); McCombs → UT Austin copy; tier headers removed from department mosaic |
| **Contact** | New `/school/ut/contact-us` page with two tabs: platform support (Mamun) vs UT inquiries (McCombs) |
| **Copy refresh** | "Co-found" → "work with" in We Match messaging; header wordmark simplified |

---

## 3. Architecture — Dashboard Filtering

```
┌─────────────────┐   sessionStorage    ┌──────────────────────┐
│  FilterSidebar   │ ◀────────────────▶ │  dashboardFilters.ts  │
│  (sidebar/drawer)│                     │  load / save / build  │
└────────┬────────┘                     └──────────┬───────────┘
         │ onChange(filters)                        │ buildProfilesQueryString()
         ▼                                          ▼
┌─────────────────┐   ?college=&sectors=&   ┌──────────────────────┐
│  dashboard/page  │ ──gradYear=&intent=──▶  │  GET /api/profiles    │
└─────────────────┘                         └──────────┬───────────┘
                                                     │
                                          ┌──────────▼───────────┐
                                          │  school_profiles      │
                                          │  (pre-filter user_ids)│
                                          └──────────────────────┘
```

### Filter dimensions

| Filter | Query param | DB column | Notes |
|---|---|---|---|
| School department | `college` | `school_profiles.college` | Exact match on UT college key |
| Industry / interest | `sectors` (comma-separated) | `school_profiles.sector_interests` | PostgreSQL `overlaps` — any selected sector matches |
| Graduation year | `gradYear` | `school_profiles.graduation_year` | Exact match |
| Intent | `intent` | `school_profiles.intent` | Includes profiles with `no_preference` in results |

### Intent filter semantics

When filtering for `join_me` or `seeking_to_join`, the API returns users whose intent is **either the selected value or `no_preference`**. Users with the opposite explicit intent are excluded. This keeps open-minded users discoverable without forcing a binary choice at filter time.

### Client persistence

Filters are stored in `sessionStorage` under `school-dashboard-filters` so they survive page refreshes within a session but reset on new browser sessions.

---

## 4. Database Changes

### Migration: `20260528000001_add_intent_to_school_profiles.sql`

```sql
ALTER TABLE school_profiles
  ADD COLUMN intent text
  CHECK (intent IN ('join_me', 'seeking_to_join', 'no_preference'));

CREATE INDEX idx_school_profiles_intent ON school_profiles (organization_id, intent);
```

**Backfill logic:**

| `profiles.cofounder_status` | → `intent` |
|---|---|
| `Solo founder`, `Have co-founder(s)` | `join_me` |
| `Seeking co-founder` | `seeking_to_join` |
| anything else / NULL | `no_preference` |

---

## 5. API Changes

### `GET /api/profiles`

Accepts optional query params: `college`, `sectors`, `gradYear`, `intent`.

In school tenants, filtering runs against `school_profiles` **before** the matching queue query, narrowing `schoolUserIds` to eligible candidates. Response payloads now include `intent` on each profile's school metadata.

### `POST /api/ut-profile`

School profile upsert refactored to use `mapUTDataToSchoolProfileRow()`, which now persists `intent` from onboarding data.

---

## 6. Onboarding Changes

**`UTStartupForm`** — new required field: **Co-Founder Matching Intent**

- **Join me** — I have a startup/idea  
- **Seeking to join** — I want to join someone else's project  
- **No preference** — open to either  

**`UTReviewForm`** — displays selected intent on the review step before submission.

Types updated in `global.d.ts` (`SchoolProfileFromDb`, `UTProfileData`).

---

## 7. UI Changes

### Dashboard (`/school/[slug]/dashboard`)

- Desktop: fixed-width filter sidebar aligned to profile card height  
- Mobile: filter icon opens animated drawer overlay  
- Active filter chips with per-chip remove  
- Empty state: "No matches for these filters" with clear-all action  

### Meetup (`MeetupCard`)

Rendered when `slug === "ut"`:

- **We Match tab** — always visible at top of tab content  
- **Conversation view** — shown when the other participant is in the user's `mutualNotified` set  

Links to [Luma events](https://luma.com/mamun?period=past) for RSVP scheduling.

### Contact page (`/school/ut/contact-us`)

| Tab | Purpose | CTA |
|---|---|---|
| Platform support | Mamun account/matching help | Calendly + `mamun@mamuncofoundr.com` |
| UT inquiries | School/program questions | McCombs contact page |

Header and footer "Contact Us" links now route to this page instead of external McCombs URL.

### Landing page

- Hero, footer, and header wordmark: McCombs → **University of Texas at Austin**  
- Footer title styled in UT burnt orange (`#bf5700`)  
- `HowItWorks`: 3 steps → **4 steps** (Build profile → Get matched → **Meetup** → Start building)  
- `DepartmentMosaic`: tier 1 / tier 2 section headers removed  

### Copy tone

We Match messaging softened from "co-found" to **"work with"** to reflect broader collaboration intent (project partners, not only co-founders).

---

## 8. Files Changed (by area)

| Area | Key files |
|---|---|
| Filtering | `FilterSidebar.tsx`, `dashboardFilters.ts`, `dashboard/page.tsx`, `useProfile.ts`, `profiles/route.ts` |
| Intent | `20260528000001_add_intent_to_school_profiles.sql`, `UTStartupForm.tsx`, `UTReviewForm.tsx`, `mapProfileToFromDBFormat.ts`, `global.d.ts` |
| Meetup | `MeetupCard.tsx`, `matches/page.tsx`, `matches/[conversationId]/page.tsx`, `HowItWorks.tsx` |
| Contact | `contact-us/page.tsx`, `UtContactTabs.tsx`, `UtSupportPanel.tsx`, `UtAboutPanel.tsx`, `SchoolHeader.tsx`, `PublicFooter.tsx` |
| Branding | `Hero.tsx`, `CtaBand.tsx`, `ValuesPillars.tsx`, `DepartmentMosaic.tsx`, `PublicSchoolHeader.tsx`, `SchoolSignIn.tsx`, `SchoolSignUp.tsx` |

---

## 9. Test Plan

- [ ] Run migration locally; confirm existing profiles backfill to expected intent values  
- [ ] Complete UT onboarding; verify intent is required and persisted to `school_profiles`  
- [ ] Dashboard: apply each filter individually and in combination; confirm swipe queue updates  
- [ ] Dashboard: confirm filter chips render and remove correctly  
- [ ] Dashboard: confirm filters persist across page refresh (same session)  
- [ ] Dashboard: confirm empty state when filters exclude all candidates  
- [ ] Mobile: open/close filter drawer; confirm body scroll lock  
- [ ] We Match tab: confirm `MeetupCard` renders for UT slug  
- [ ] Conversation: confirm `MeetupCard` appears only after mutual We Match  
- [ ] Visit `/school/ut/contact-us`; switch tabs; verify Calendly and McCombs links  
- [ ] Landing page: verify 4-step How It Works and updated hero/footer copy  
- [ ] Header/footer Contact Us links route to internal contact page  

---

## 10. Rollout Notes

- **Migration required** before deploy — `intent` column must exist before onboarding writes or dashboard filters run.  
- **No breaking API changes** — filter query params are optional; unfiltered behavior is unchanged.  
- **Meetup is UT-only** — gated on `slug === "ut"`; other school tenants are unaffected.  
- **Intent filter is inclusive of `no_preference`** — existing users without explicit intent (backfilled or default) remain visible in both intent filter modes.
