### PR TITLE
MCFM-118 | Semantic Search Feature

### DIFF
--- a/docs/v3-llm-query-parsing-concerns.md
+++ b/docs/v3-llm-query-parsing-concerns.md
@@ -1,0 +1,29 @@
+# UT CoFoundr Search — v3 (Phase B): LLM Query Parsing (Concerns & Edge Cases)
+
+This document outlines critical inconsistencies, edge cases, and potential regressions identified in the v3 LLM Query Parsing plan (`on-the-ut-cofoundr-velvet-yeti.md`).
+
+### 1. Inconsistency: Parallel Execution is Architecturally Impossible as Proposed
+**The Issue:** Under "Latency mitigation", the plan states the LLM call happens "in parallel with the embedding call". However, in "Step 3 — Hook & dashboard wiring", the flow is strictly sequential: 1) fetch `/api/search/parse`, 2) once it resolves, fetch `/api/profiles/search` passing the `semanticQuery`. The search route cannot embed `semanticQuery` until the parse route returns it.
+**The Fix:** You have two options:
+- **Sequential (Frontend Orchestrated):** Accept the latency hit. Frontend calls parse, waits, then calls search.
+- **Parallel (Backend Orchestrated):** The frontend calls `/api/profiles/search` with raw `q`. The Next.js route calls Groq and the Supabase Edge Function (for embedding) simultaneously using `Promise.all`. The Next.js route performs the filter intersection and returns BOTH the profiles and the `inferredFilters`. The frontend renders the chips from the search response.
+
+### 2. Regression Risk: Groq Free Tier TPM & RPM Limits on Debounced Keystrokes
+**The Issue:** The plan relies on a 300ms debounce and estimates 3-5 parse calls per search. Groq's free tier has a limit of **30 RPM (Requests Per Minute)** and **12,000 TPM (Tokens Per Minute)**. If the system prompt includes `UT_SCHOOLS_AND_PROGRAMS`, `SECTOR_INTEREST_LABELS`, and few-shot examples, it could easily be 500-1000 tokens. At 1,000 tokens per prompt, you will hit the TPM limit in just 12 keystrokes per minute across your entire app. A single user typing slowly could exhaust this and receive HTTP 429 Too Many Requests.
+**The Fix:** 
+- Increase the debounce to 750ms - 1000ms for the parse call (while keeping 300ms for pure keyword/embedding search), OR
+- Only trigger the parse call on `Enter`/blur, OR
+- Introduce a caching layer (e.g. Redis/KV) to cache exact query parses, OR
+- Immediately upgrade to a paid Groq tier to lift the TPM/RPM limits.
+
+### 3. Edge Case: Chip Dismissal UX and Re-fetching
+**The Issue:** The plan says "Dismissing a chip adds that field to a local 'dismissed for this query' set, which is passed back into the parse call...". If dismissing a chip triggers a re-parse, you waste tokens and latency on an LLM call when you already have the correct `semanticQuery` and `ftsTerms`.
+**The Fix:** When a user dismisses a chip, the frontend should NOT call `/api/search/parse` again. It should simply remove that filter from local state and re-fetch `/api/profiles/search` using the previously cached `semanticQuery` and `ftsTerms` from the current query, just minus the dismissed filter.
+
+### 4. Edge Case: All-or-Nothing Zod Validation
+**The Issue:** "We validate post-parse and discard the LLM output entirely on any schema mismatch." If Llama 3.3 hallucinates a single key (e.g., returns `sector: ["fintech"]` instead of `sectors: ["fintech"]`, or hallucinates an invalid college enum), the entire Zod parse fails, and the user gets no inferred filters or semantic extraction at all.
+**The Fix:** Use `.catch()` or `.optional()` on the Zod schema fields so that a failure in one field doesn't discard a perfectly valid `semanticQuery` or `ftsTerms` extraction. Extract what you can, drop the invalid keys, and fall back safely per-field.
+
+### 5. Inconsistency: HTTP Method Change Implications
+**The Issue:** Step 2 says "Switch to POST with a body". If `useSearchProfiles` currently relies on SWR or React Query with a `GET` request (as the current `route.ts` is `export async function GET`), switching to `POST` might break caching, deduplication, and refetch-on-focus behaviors unless the fetching library is properly configured to treat the POST body as part of the cache key.
+**The Fix:** Ensure the frontend fetcher explicitly hashes the POST body as the cache key, OR keep using a GET request and pass the payload via `encodeURIComponent(JSON.stringify(payload))` into a `?payload=` parameter, which preserves native GET caching semantics.

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -1,13 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
+import { parseSearchQuery, type ParsedQuery } from "@/lib/searchQueryParser";
+import {
+  type DashboardFilters,
+  type RelaxDimension,
+  type RelaxSuggestion,
+  normalizeDashboardFilters,
+} from "@/lib/dashboardFilters";
+import {
+  getSchoolLabel,
+  SECTOR_INTEREST_LABELS,
+} from "@/lib/utSchoolsAndMajors";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const EMBED_FN_URL = `${SUPABASE_URL}/functions/v1/embed`;
 
+type CachedParse = {
+  /** The original AI-inferred filters, so Mode B can re-merge survivors. */
+  filters?: Partial<DashboardFilters>;
+  semanticQuery: string;
+  ftsTerms: string[];
+};
+
+type SearchRequest = {
+  q: string;
+  userFilters?: Partial<DashboardFilters>;
+  cachedParse?: CachedParse;
+  dismissedFilterKeys?: string[];
+};
+
 async function getQueryEmbedding(q: string): Promise<number[] | null> {
+  if (!q.trim()) return null;
   try {
     const res = await fetch(EMBED_FN_URL, {
       method: "POST",
@@ -26,83 +52,289 @@ async function getQueryEmbedding(q: string): Promise<number[] | null> {
   }
 }
 
-export async function GET(req: NextRequest) {
+function mergeFilters(
+  user: DashboardFilters,
+  inferred: Partial<DashboardFilters>,
+  dismissed: Set<string>,
+): DashboardFilters {
+  const merged: DashboardFilters = { ...user };
+
+  if (!merged.college && inferred.college && !dismissed.has("college")) {
+    merged.college = inferred.college;
+  }
+  if (merged.sectors.length === 0 && inferred.sectors && inferred.sectors.length > 0) {
+    const kept = inferred.sectors.filter((s) => !dismissed.has(`sector:${s}`));
+    if (kept.length > 0) merged.sectors = kept;
+  }
+  if (merged.gradYear === null && typeof inferred.gradYear === "number" && !dismissed.has("gradYear")) {
+    merged.gradYear = inferred.gradYear;
+  }
+  if (!merged.intent && inferred.intent && !dismissed.has("intent")) {
+    merged.intent = inferred.intent;
+  }
+
+  return merged;
+}
+
+function buildTsquery(terms: string[], fallbackQ: string): string {
+  const source = terms.length > 0 ? terms : fallbackQ.split(/\s+/);
+  return source
+    .map((w) => w.trim().replace(/[^\w]/g, ""))
+    .filter((w) => w.length > 0)
+    .map((w) => `${w}:*`)
+    .join(" | ");
+}
+
+async function fetchEligibleUserIds(
+  supabase: SupabaseClient,
+  userId: string,
+  orgId: string,
+  filters: DashboardFilters,
+): Promise<string[]> {
+  const { data: likedProfiles } = await supabase
+    .from("likes")
+    .select("liked_id")
+    .eq("liker_id", userId);
+  const likedIds = new Set(likedProfiles?.map((l) => l.liked_id) ?? []);
+
+  let schoolQuery = supabase
+    .from("school_profiles")
+    .select("user_id")
+    .eq("organization_id", orgId);
+
+  if (filters.college) {
+    schoolQuery = schoolQuery.eq("college", filters.college);
+  }
+  if (filters.sectors.length > 0) {
+    schoolQuery = schoolQuery.overlaps("sector_interests", filters.sectors);
+  }
+  if (filters.gradYear !== null) {
+    schoolQuery = schoolQuery.eq("graduation_year", filters.gradYear);
+  }
+  if (filters.intent) {
+    schoolQuery = schoolQuery.in("intent", [filters.intent, "no_preference"]);
+  }
+
+  const { data: schoolRows } = await schoolQuery;
+  const ids = schoolRows?.map((r) => r.user_id) ?? [];
+
+  return ids.filter((id) => id !== userId && !likedIds.has(id));
+}
+
+/**
+ * Build the `inferred` payload the client renders as chips: the AI-inferred
+ * filters that the user did NOT set themselves and did NOT dismiss. Works for
+ * both Mode A (fresh Groq parse) and Mode B (cached parse + dismissed keys).
+ */
+function buildInferredResponse(
+  parsedFilters: Partial<DashboardFilters>,
+  semanticQuery: string,
+  ftsTerms: string[],
+  userFilters: DashboardFilters,
+  dismissed: Set<string>,
+): ParsedQuery {
+  const filters: Partial<DashboardFilters> = {};
+
+  if (parsedFilters.college && !userFilters.college && !dismissed.has("college")) {
+    filters.college = parsedFilters.college;
+  }
+  if (parsedFilters.sectors?.length && userFilters.sectors.length === 0) {
+    const kept = parsedFilters.sectors.filter(
+      (s) => !dismissed.has(`sector:${s}`),
+    );
+    if (kept.length > 0) filters.sectors = kept;
+  }
+  if (
+    typeof parsedFilters.gradYear === "number" &&
+    userFilters.gradYear === null &&
+    !dismissed.has("gradYear")
+  ) {
+    filters.gradYear = parsedFilters.gradYear;
+  }
+  if (parsedFilters.intent && !userFilters.intent && !dismissed.has("intent")) {
+    filters.intent = parsedFilters.intent;
+  }
+
+  return { filters, semanticQuery, ftsTerms };
+}
+
+const RELAX_DIMENSIONS: RelaxDimension[] = [
+  "college",
+  "sectors",
+  "gradYear",
+  "intent",
+];
+
+function activeDimensions(f: DashboardFilters): RelaxDimension[] {
+  return RELAX_DIMENSIONS.filter((d) => {
+    if (d === "sectors") return f.sectors.length > 0;
+    return f[d] !== null;
+  });
+}
+
+function withoutDimension(
+  f: DashboardFilters,
+  d: RelaxDimension,
+): DashboardFilters {
+  const next: DashboardFilters = { ...f, sectors: [...f.sectors] };
+  if (d === "sectors") next.sectors = [];
+  else next[d] = null;
+  return next;
+}
+
+function relaxLabel(d: RelaxDimension, f: DashboardFilters): string {
+  switch (d) {
+    case "college":
+      return getSchoolLabel(f.college as UTCollege);
+    case "sectors":
+      return f.sectors
+        .map((s) => SECTOR_INTEREST_LABELS[s as UTSectorInterest] ?? s)
+        .join(", ");
+    case "gradYear":
+      return `Class of ${f.gradYear}`;
+    case "intent":
+      return f.intent === "join_me" ? "Join me" : "Seeking to join";
+  }
+}
+
+function dismissKeysFor(d: RelaxDimension, f: DashboardFilters): string[] {
+  if (d === "sectors") return f.sectors.map((s) => `sector:${s}`);
+  return [d];
+}
+
+function sourceOf(
+  d: RelaxDimension,
+  userFilters: DashboardFilters,
+): "user" | "inferred" {
+  if (d === "sectors") return userFilters.sectors.length > 0 ? "user" : "inferred";
+  return userFilters[d] !== null ? "user" : "inferred";
+}
+
+/**
+ * When a search returns zero candidates purely because of hard filters, probe
+ * each active dimension to see how many candidates re-enter if it's dropped.
+ * Only relaxations that would actually surface someone are returned. Runs only
+ * on the empty path, so the extra (cheap) queries don't affect normal latency.
+ */
+async function diagnoseRelaxations(
+  supabase: SupabaseClient,
+  userId: string,
+  orgId: string,
+  merged: DashboardFilters,
+  userFilters: DashboardFilters,
+): Promise<RelaxSuggestion[]> {
+  const dims = activeDimensions(merged);
+  if (dims.length === 0) return [];
+
+  const suggestions = await Promise.all(
+    dims.map(async (d) => {
+      const relaxed = withoutDimension(merged, d);
+      const count = (
+        await fetchEligibleUserIds(supabase, userId, orgId, relaxed)
+      ).length;
+      return {
+        dimension: d,
+        label: relaxLabel(d, merged),
+        source: sourceOf(d, userFilters),
+        dismissKeys: dismissKeysFor(d, merged),
+        countIfRelaxed: count,
+      } satisfies RelaxSuggestion;
+    }),
+  );
+
+  return suggestions
+    .filter((s) => s.countIfRelaxed > 0)
+    .sort((a, b) => b.countIfRelaxed - a.countIfRelaxed);
+}
+
+export async function POST(req: NextRequest) {
   try {
     const { userId, sessionClaims } = await auth();
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { searchParams } = new URL(req.url);
-    const q = searchParams.get("q")?.trim() ?? "";
+    const body = (await req.json().catch(() => null)) as SearchRequest | null;
+    if (!body || typeof body.q !== "string") {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
+    const q = body.q.trim();
     if (q.length < 2) {
-      return NextResponse.json({ profiles: [] });
+      return NextResponse.json({ profiles: [], inferred: null });
     }
 
     const orgId = sessionClaims?.metadata?.organization_id ?? null;
     if (!orgId) {
-      return NextResponse.json({ profiles: [] });
+      return NextResponse.json({ profiles: [], inferred: null });
     }
 
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+    const userFilters = normalizeDashboardFilters(body.userFilters);
+    const dismissed = new Set(body.dismissedFilterKeys ?? []);
 
-    // Get IDs of profiles the current user has already liked
-    const { data: likedProfiles } = await supabase
-      .from("likes")
-      .select("liked_id")
-      .eq("liker_id", userId);
-    const likedIds = likedProfiles?.map((l) => l.liked_id) ?? [];
+    const parsedPromise: Promise<ParsedQuery> = body.cachedParse
+      ? Promise.resolve({
+          filters: body.cachedParse.filters ?? {},
+          semanticQuery: body.cachedParse.semanticQuery,
+          ftsTerms: body.cachedParse.ftsTerms,
+        })
+      : parseSearchQuery(q);
 
-    // Restrict candidates to users who have completed school onboarding for this org
-    const { data: schoolRows } = await supabase
-      .from("school_profiles")
-      .select("user_id")
-      .eq("organization_id", orgId);
-    const schoolUserIds = schoolRows?.map((r) => r.user_id) ?? [];
+    const [parsed] = await Promise.all([parsedPromise]);
 
-    if (schoolUserIds.length === 0) {
-      return NextResponse.json({ profiles: [] });
-    }
+    const mergedFilters = mergeFilters(userFilters, parsed.filters, dismissed);
 
-    // Eligible: in school org, not self, not already liked
-    const eligible = schoolUserIds.filter(
-      (id) => id !== userId && !likedIds.includes(id),
+    // The chips the client renders: AI-inferred filters the user didn't set or
+    // dismiss. Computed once and reused across every return path.
+    const inferred = buildInferredResponse(
+      parsed.filters,
+      parsed.semanticQuery,
+      parsed.ftsTerms,
+      userFilters,
+      dismissed,
     );
 
+    const [embedding, eligible] = await Promise.all([
+      getQueryEmbedding(parsed.semanticQuery || q),
+      fetchEligibleUserIds(supabase, userId, orgId, mergedFilters),
+    ]);
+
+    console.log("[search] q=%s eligible=%d mergedFilters=%j parsedFilters=%j", q, eligible.length, mergedFilters, parsed.filters);
+
+    // Hard-filter wall: nobody passes the filters. Offer per-dimension relaxations.
     if (eligible.length === 0) {
-      return NextResponse.json({ profiles: [] });
+      const relaxations = await diagnoseRelaxations(
+        supabase,
+        userId,
+        orgId,
+        mergedFilters,
+        userFilters,
+      );
+      return NextResponse.json({
+        profiles: [],
+        inferred,
+        emptyReason: relaxations.length > 0 ? { relaxations } : null,
+      });
     }
 
-    // Build a prefix tsquery: each word gets :* so "fin" matches "finance"
-    // Sanitise each token to alphanumeric to prevent tsquery injection
-    const tsquery = q
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((w) => w.replace(/[^\w]/g, ""))
-      .filter((w) => w.length > 0)
-      .map((w) => `${w}:*`)
-      .join(" & ");
+    const tsquery = buildTsquery(parsed.ftsTerms, q);
+    if (!tsquery && !embedding) {
+      return NextResponse.json({ profiles: [], inferred, emptyReason: null });
+    }
 
-    // Get semantic embedding for the query — fetch in parallel with nothing else blocked on it
-    const queryEmbedding = await getQueryEmbedding(q);
-
-    // Single RPC: runs FTS, school-FTS, vector, and name-ILIKE branches,
-    // combines via RRF, returns top 30 user_ids in ranked order.
-    // Profiles without an embedding still appear via the FTS and name branches.
     const { data: ranked, error: rpcError } = await supabase.rpc(
       "search_profiles_hybrid",
       {
         eligible_ids: eligible,
-        query_text: tsquery,
-        query_vec: queryEmbedding,
+        query_text: tsquery || "x",
+        query_vec: embedding,
       },
     );
 
     if (rpcError) {
       console.error("RPC error:", rpcError);
-      return NextResponse.json({ profiles: [] });
+      return NextResponse.json({ profiles: [], inferred, emptyReason: null });
     }
 
     const matchedIds = (ranked ?? []).map(
@@ -110,10 +342,9 @@ export async function GET(req: NextRequest) {
     );
 
     if (matchedIds.length === 0) {
-      return NextResponse.json({ profiles: [] });
+      return NextResponse.json({ profiles: [], inferred, emptyReason: null });
     }
 
-    // Fetch full profiles for matched IDs, preserving RRF order
     const { data: profilesData, error } = await supabase
       .from("profiles")
       .select("*")
@@ -122,22 +353,23 @@ export async function GET(req: NextRequest) {
       .eq("organization_id", orgId);
 
     if (error || !profilesData || profilesData.length === 0) {
-      return NextResponse.json({ profiles: [] });
+      return NextResponse.json({ profiles: [], inferred, emptyReason: null });
     }
 
     const mapped = profilesData.map(mapProfileToOnboardingData);
 
-    // Re-sort to preserve RRF ranking order (Supabase .in() doesn't guarantee order)
-    const rankIndex = new Map<string, number>(matchedIds.map((id: string, i: number) => [id, i]));
+    const rankIndex = new Map<string, number>(
+      matchedIds.map((id: string, i: number) => [id, i]),
+    );
     mapped.sort(
-      (a, b) => (rankIndex.get(a.user_id!) ?? 999) - (rankIndex.get(b.user_id!) ?? 999),
+      (a, b) =>
+        (rankIndex.get(a.user_id!) ?? 999) - (rankIndex.get(b.user_id!) ?? 999),
     );
 
     const candidateIds = mapped
       .map((p) => p.user_id)
       .filter((id): id is string => Boolean(id));
 
-    // Enrich with school-specific fields
     const { data: schoolEnrichRows } = await supabase
       .from("school_profiles")
       .select(
@@ -165,7 +397,7 @@ export async function GET(req: NextRequest) {
       return school ? { ...profile, ...school } : profile;
     });
 
-    return NextResponse.json({ profiles: enriched });
+    return NextResponse.json({ profiles: enriched, inferred, emptyReason: null });
   } catch (error) {
     console.error("Error in profiles search API:", error);
     return NextResponse.json(

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -355,8 +355,6 @@ export async function POST(req: NextRequest) {
       fetchEligibleUserIds(supabase, userId, orgId, mergedFilters),
     ]);
 
-    console.log("[search] q=%s eligible=%d mergedFilters=%j parsedFilters=%j", q, eligible.length, mergedFilters, parsed.filters);
-
     // Hard-filter wall: nobody passes the filters. Offer per-dimension relaxations.
     if (eligible.length === 0) {
       const relaxations = await diagnoseRelaxations(

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -3,6 +3,29 @@ import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
 
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const EMBED_FN_URL = `${SUPABASE_URL}/functions/v1/embed`;
+
+async function getQueryEmbedding(q: string): Promise<number[] | null> {
+  try {
+    const res = await fetch(EMBED_FN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SERVICE_KEY}`,
+      },
+      body: JSON.stringify({ mode: "query", text: q }),
+    });
+
+    if (!res.ok) return null;
+    const { embedding } = await res.json();
+    return embedding ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function GET(req: NextRequest) {
   try {
     const { userId, sessionClaims } = await auth();
@@ -19,14 +42,10 @@ export async function GET(req: NextRequest) {
 
     const orgId = sessionClaims?.metadata?.organization_id ?? null;
     if (!orgId) {
-      // Search is scoped to school tenants only
       return NextResponse.json({ profiles: [] });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
 
     // Get IDs of profiles the current user has already liked
     const { data: likedProfiles } = await supabase
@@ -55,7 +74,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ profiles: [] });
     }
 
-    // Build a prefix tsquery: each word gets :* so "fin" matches "finance", "eng" matches "engineering"
+    // Build a prefix tsquery: each word gets :* so "fin" matches "finance"
     // Sanitise each token to alphanumeric to prevent tsquery injection
     const tsquery = q
       .trim()
@@ -66,57 +85,54 @@ export async function GET(req: NextRequest) {
       .map((w) => `${w}:*`)
       .join(" & ");
 
-    // FTS with prefix matching on profiles (name, bio, startup, interests, title, city)
-    // Omitting `type` uses to_tsquery which accepts raw tsquery syntax including :*
-    const { data: profileMatches } = await supabase
-      .from("profiles")
-      .select("user_id")
-      .in("user_id", eligible)
-      .is("deleted_at", null)
-      .textSearch("search_tsv", tsquery, { config: "english" });
+    // Get semantic embedding for the query — fetch in parallel with nothing else blocked on it
+    const queryEmbedding = await getQueryEmbedding(q);
 
-    // FTS with prefix matching on school_profiles (major, college, sector_interests)
-    const { data: schoolMatches } = await supabase
-      .from("school_profiles")
-      .select("user_id")
-      .eq("organization_id", orgId)
-      .in("user_id", eligible)
-      .textSearch("search_tsv", tsquery, { config: "english" });
+    // Single RPC: runs FTS, school-FTS, vector, and name-ILIKE branches,
+    // combines via RRF, returns top 30 user_ids in ranked order.
+    // Profiles without an embedding still appear via the FTS and name branches.
+    const { data: ranked, error: rpcError } = await supabase.rpc(
+      "search_profiles_hybrid",
+      {
+        eligible_ids: eligible,
+        query_text: tsquery,
+        query_vec: queryEmbedding,
+      },
+    );
 
-    // ilike fallback for partial name matches (e.g. "Jo" → "John")
-    const { data: nameMatches } = await supabase
-      .from("profiles")
-      .select("user_id")
-      .in("user_id", eligible)
-      .is("deleted_at", null)
-      .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%`);
+    if (rpcError) {
+      console.error("RPC error:", rpcError);
+      return NextResponse.json({ profiles: [] });
+    }
 
-    // Union matched user IDs from all sources
-    const matchedSet = new Set([
-      ...(profileMatches?.map((r) => r.user_id) ?? []),
-      ...(schoolMatches?.map((r) => r.user_id) ?? []),
-      ...(nameMatches?.map((r) => r.user_id) ?? []),
-    ]);
-    const matchedIds = Array.from(matchedSet);
+    const matchedIds = (ranked ?? []).map(
+      (r: { user_id: string }) => r.user_id,
+    );
 
     if (matchedIds.length === 0) {
       return NextResponse.json({ profiles: [] });
     }
 
-    // Fetch full profiles for matched IDs
+    // Fetch full profiles for matched IDs, preserving RRF order
     const { data: profilesData, error } = await supabase
       .from("profiles")
       .select("*")
       .in("user_id", matchedIds)
       .is("deleted_at", null)
-      .eq("organization_id", orgId)
-      .limit(30);
+      .eq("organization_id", orgId);
 
     if (error || !profilesData || profilesData.length === 0) {
       return NextResponse.json({ profiles: [] });
     }
 
     const mapped = profilesData.map(mapProfileToOnboardingData);
+
+    // Re-sort to preserve RRF ranking order (Supabase .in() doesn't guarantee order)
+    const rankIndex = new Map<string, number>(matchedIds.map((id: string, i: number) => [id, i]));
+    mapped.sort(
+      (a, b) => (rankIndex.get(a.user_id!) ?? 999) - (rankIndex.get(b.user_id!) ?? 999),
+    );
+
     const candidateIds = mapped
       .map((p) => p.user_id)
       .filter((id): id is string => Boolean(id));

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -247,6 +247,61 @@ async function diagnoseRelaxations(
     .sort((a, b) => b.countIfRelaxed - a.countIfRelaxed);
 }
 
+async function enrichWithSchoolData(
+  supabase: SupabaseClient,
+  mapped: OnboardingData[],
+  orgId: string,
+): Promise<OnboardingData[]> {
+  const candidateIds = mapped
+    .map((p) => p.user_id)
+    .filter((id): id is string => Boolean(id));
+
+  const { data: schoolEnrichRows } = await supabase
+    .from("school_profiles")
+    .select(
+      "user_id, school_status, graduation_year, college, degree_type, major, sector_interests",
+    )
+    .eq("organization_id", orgId)
+    .in("user_id", candidateIds);
+
+  const schoolMap = new Map(
+    schoolEnrichRows?.map((row) => [
+      row.user_id,
+      {
+        utStatus: row.school_status,
+        gradYear: row.graduation_year,
+        utCollege: row.college,
+        utDegreeType: row.degree_type,
+        utMajor: row.major,
+        utSectorInterests: row.sector_interests,
+      },
+    ]) ?? [],
+  );
+
+  return mapped.map((profile) => {
+    const school = schoolMap.get(profile.user_id!);
+    return school ? { ...profile, ...school } : profile;
+  });
+}
+
+async function fetchAndEnrichProfiles(
+  supabase: SupabaseClient,
+  eligibleIds: string[],
+  orgId: string,
+): Promise<OnboardingData[]> {
+  const { data: profilesData, error } = await supabase
+    .from("profiles")
+    .select("*")
+    .in("user_id", eligibleIds)
+    .is("deleted_at", null)
+    .eq("organization_id", orgId);
+
+  if (error || !profilesData || profilesData.length === 0) return [];
+
+  const mapped = profilesData.map(mapProfileToOnboardingData);
+  return enrichWithSchoolData(supabase, mapped, orgId);
+}
+
 export async function POST(req: NextRequest) {
   try {
     const { userId, sessionClaims } = await auth();
@@ -318,6 +373,16 @@ export async function POST(req: NextRequest) {
       });
     }
 
+    // Pure filter query: Groq returned no semantic content worth embedding/FTS-ing.
+    // The eligibility filter already identified the right people — just return them.
+    const hasSemanticContent =
+      parsed.semanticQuery.trim().length > 0 || parsed.ftsTerms.length > 0;
+
+    if (!hasSemanticContent) {
+      const enriched = await fetchAndEnrichProfiles(supabase, eligible, orgId);
+      return NextResponse.json({ profiles: enriched, inferred, emptyReason: null });
+    }
+
     const tsquery = buildTsquery(parsed.ftsTerms, q);
     if (!tsquery && !embedding) {
       return NextResponse.json({ profiles: [], inferred, emptyReason: null });
@@ -366,37 +431,7 @@ export async function POST(req: NextRequest) {
         (rankIndex.get(a.user_id!) ?? 999) - (rankIndex.get(b.user_id!) ?? 999),
     );
 
-    const candidateIds = mapped
-      .map((p) => p.user_id)
-      .filter((id): id is string => Boolean(id));
-
-    const { data: schoolEnrichRows } = await supabase
-      .from("school_profiles")
-      .select(
-        "user_id, school_status, graduation_year, college, degree_type, major, sector_interests",
-      )
-      .eq("organization_id", orgId)
-      .in("user_id", candidateIds);
-
-    const schoolMap = new Map(
-      schoolEnrichRows?.map((row) => [
-        row.user_id,
-        {
-          utStatus: row.school_status,
-          gradYear: row.graduation_year,
-          utCollege: row.college,
-          utDegreeType: row.degree_type,
-          utMajor: row.major,
-          utSectorInterests: row.sector_interests,
-        },
-      ]) ?? [],
-    );
-
-    const enriched = mapped.map((profile) => {
-      const school = schoolMap.get(profile.user_id!);
-      return school ? { ...profile, ...school } : profile;
-    });
-
+    const enriched = await enrichWithSchoolData(supabase, mapped, orgId);
     return NextResponse.json({ profiles: enriched, inferred, emptyReason: null });
   } catch (error) {
     console.error("Error in profiles search API:", error);

--- a/src/app/school/[slug]/dashboard/page.tsx
+++ b/src/app/school/[slug]/dashboard/page.tsx
@@ -19,10 +19,12 @@ import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from
 import FilterSidebar, { getFilterChipLabels } from "@/components/school/dashboard/FilterSidebar";
 import {
   type DashboardFilters,
+  type RelaxSuggestion,
   EMPTY_DASHBOARD_FILTERS,
   hasActiveFilters,
   getDashboardPanelHeightClass,
   loadDashboardFilters,
+  normalizeDashboardFilters,
   saveDashboardFilters,
 } from "@/lib/dashboardFilters";
 
@@ -179,7 +181,20 @@ export default function SchoolDashboardPage() {
     setFilters(next);
     saveDashboardFilters(next);
   };
-  const { data: searchResults, isFetching: isSearching } = useSearchProfiles(searchQuery);
+  const { data: searchResults, isFetching: isSearching, inferred, emptyReason, dismissFilter } = useSearchProfiles(searchQuery, filters);
+
+  // Relax a single binding filter from the empty-results state. Inferred filters
+  // are dismissed (Mode B re-search); user filters are cleared from the sidebar.
+  const handleRelax = (s: RelaxSuggestion) => {
+    if (s.source === "inferred") {
+      s.dismissKeys.forEach((key) => dismissFilter(key));
+      return;
+    }
+    const next: DashboardFilters = { ...filters, sectors: [...filters.sectors] };
+    if (s.dimension === "sectors") next.sectors = [];
+    else next[s.dimension] = null;
+    updateFilters(next);
+  };
   const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
   useMutualLikes();
   const skipProfileMutation = useSkipProfile();
@@ -318,6 +333,27 @@ export default function SchoolDashboardPage() {
       </div>
     ) : null;
 
+  const inferredFilterChipsRow = isSearchActive && inferred && inferred.filters && Object.keys(inferred.filters).length > 0 ? (
+    <div className="mb-3">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+        ✨ Understood as
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {getFilterChipLabels(normalizeDashboardFilters(inferred.filters)).map((chip) => (
+          <button
+            key={chip.key}
+            type="button"
+            onClick={() => dismissFilter(chip.dismissKey)}
+            className="inline-flex items-center gap-1 rounded-md bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-800 cursor-pointer hover:bg-blue-200 transition"
+          >
+            {chip.label}
+            <span aria-hidden>&times;</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="mx-auto max-w-5xl px-4 pt-6">
       {brandingHeader}
@@ -352,6 +388,7 @@ export default function SchoolDashboardPage() {
       )}
 
       {activeFilterChipsRow}
+      {inferredFilterChipsRow}
 
       <div className="flex items-stretch gap-6">
         <FilterSidebar
@@ -372,10 +409,33 @@ export default function SchoolDashboardPage() {
           )}
           {!isSearching && searchResults && searchResults.length === 0 && (
             <div className="flex flex-col items-center gap-3 py-16 text-center">
-              <p className="text-base font-semibold text-[var(--ui-text)]">No matches found</p>
-              <p className="text-sm text-[var(--ui-text-muted)]">
-                Try different keywords — skills, majors, industries, or city names work well.
-              </p>
+              <p className="text-base font-semibold text-[var(--ui-text)]">No exact matches</p>
+              {emptyReason && emptyReason.relaxations.length > 0 ? (
+                <>
+                  <p className="text-sm text-[var(--ui-text-muted)]">
+                    Nobody fits all of your criteria. Relax one to see more:
+                  </p>
+                  <div className="mt-1 flex w-full max-w-xs flex-col items-stretch gap-2">
+                    {emptyReason.relaxations.map((s) => (
+                      <button
+                        key={s.dimension}
+                        type="button"
+                        onClick={() => handleRelax(s)}
+                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#bf5700] transition hover:bg-[#ffe8d6] cursor-pointer"
+                      >
+                        <span className="font-medium">Drop &ldquo;{s.label}&rdquo;</span>
+                        <span className="flex-shrink-0 rounded-full bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
+                          +{s.countIfRelaxed}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-[var(--ui-text-muted)]">
+                  Try different keywords — skills, majors, industries, or city names work well.
+                </p>
+              )}
               <button
                 onClick={() => setSearchQuery("")}
                 className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"

--- a/src/components/school/dashboard/FilterSidebar.tsx
+++ b/src/components/school/dashboard/FilterSidebar.tsx
@@ -289,20 +289,21 @@ export default function FilterSidebar({
   );
 }
 
-export function getFilterChipLabels(filters: DashboardFilters): {
+export type FilterChipLabel = {
   key: string;
+  /** Key used by search inferred-filter dismiss (e.g. `sector:fintech`, `college`) */
+  dismissKey: string;
   label: string;
   onRemove: () => DashboardFilters;
-}[] {
-  const chips: {
-    key: string;
-    label: string;
-    onRemove: () => DashboardFilters;
-  }[] = [];
+};
+
+export function getFilterChipLabels(filters: DashboardFilters): FilterChipLabel[] {
+  const chips: FilterChipLabel[] = [];
 
   if (filters.college) {
     chips.push({
       key: `college-${filters.college}`,
+      dismissKey: "college",
       label: getSchoolLabel(filters.college as UTCollege),
       onRemove: () => ({ ...filters, college: null }),
     });
@@ -311,6 +312,7 @@ export function getFilterChipLabels(filters: DashboardFilters): {
   for (const sector of filters.sectors) {
     chips.push({
       key: `sector-${sector}`,
+      dismissKey: `sector:${sector}`,
       label:
         SECTOR_INTEREST_LABELS[sector as UTSectorInterest] ?? sector,
       onRemove: () => ({
@@ -323,6 +325,7 @@ export function getFilterChipLabels(filters: DashboardFilters): {
   if (filters.gradYear !== null) {
     chips.push({
       key: `grad-${filters.gradYear}`,
+      dismissKey: "gradYear",
       label: `Class of ${filters.gradYear}`,
       onRemove: () => ({ ...filters, gradYear: null }),
     });
@@ -331,12 +334,14 @@ export function getFilterChipLabels(filters: DashboardFilters): {
   if (filters.intent === "join_me") {
     chips.push({
       key: "intent-join_me",
+      dismissKey: "intent",
       label: "Join me",
       onRemove: () => ({ ...filters, intent: null }),
     });
   } else if (filters.intent === "seeking_to_join") {
     chips.push({
       key: "intent-seeking",
+      dismissKey: "intent",
       label: "Seeking to join",
       onRemove: () => ({ ...filters, intent: null }),
     });

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -4,8 +4,10 @@ import { useAuth, useSession } from "@clerk/nextjs";
 import toast from "react-hot-toast";
 import {
   type DashboardFilters,
+  type SearchEmptyReason,
   buildProfilesQueryString,
 } from "@/lib/dashboardFilters";
+import type { ParsedQuery } from "@/lib/searchQueryParser";
 
 export function useGetProfiles(filters?: DashboardFilters) {
   const { userId } = useAuth();
@@ -141,37 +143,108 @@ export function useProfileByUserId(userId: string, enabled: boolean = true) {
   });
 }
 
-export function useSearchProfiles(query: string) {
+export function useSearchProfiles(query: string, userFilters: DashboardFilters) {
   const { session } = useSession();
   const [debouncedQuery, setDebouncedQuery] = useState(query);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  // Last-good Mode A parse, kept so chip dismissals (Mode B) can re-search
+  // without paying for another Groq parse.
+  const [inferred, setInferred] = useState<ParsedQuery | null>(null);
 
+  // Parse-mode debounce: 750ms (TPM mitigation)
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedQuery(query), 300);
+    const t = setTimeout(() => setDebouncedQuery(query), 750);
     return () => clearTimeout(t);
   }, [query]);
 
-  return useQuery<OnboardingData[], { message: string }>({
-    queryKey: ["profiles-search", debouncedQuery],
+  // Reset per-query state whenever the raw query changes
+  useEffect(() => {
+    setDismissed(new Set());
+    setInferred(null);
+  }, [query]);
+
+  const dismissFilter = (key: string) => {
+    setDismissed((prev) => new Set([...prev, key]));
+  };
+
+  // Mode B = we have a cached parse AND the user dismissed at least one chip.
+  // Backend skips Groq and re-merges the surviving inferred filters itself.
+  const isDismissMode = inferred !== null && dismissed.size > 0;
+  const dismissedKeys = [...dismissed].sort();
+  const cachedParse = inferred
+    ? {
+        filters: inferred.filters,
+        semanticQuery: inferred.semanticQuery,
+        ftsTerms: inferred.ftsTerms,
+      }
+    : undefined;
+
+  const queryKey = [
+    "profiles-search",
+    debouncedQuery,
+    userFilters,
+    dismissedKeys.join(","),
+    isDismissMode,
+  ];
+
+  const searchQuery = useQuery<
+    {
+      profiles: OnboardingData[];
+      inferred: ParsedQuery | null;
+      emptyReason: SearchEmptyReason;
+    },
+    { message: string }
+  >({
+    queryKey,
     queryFn: async () => {
       const token = await session?.getToken();
-      if (!token) throw { message: "Authentication failed. Please log in again." };
+      if (!token)
+        throw { message: "Authentication failed. Please log in again." };
 
-      const res = await fetch(
-        `/api/profiles/search?q=${encodeURIComponent(debouncedQuery)}`,
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
+      const body = {
+        q: debouncedQuery,
+        userFilters,
+        ...(isDismissMode && {
+          cachedParse,
+          dismissedFilterKeys: dismissedKeys,
+        }),
+      };
+
+      const res = await fetch("/api/profiles/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
 
       if (!res.ok) {
         const errorData = await res.json();
         throw { message: errorData.error || "Search failed" };
       }
 
-      const data = await res.json();
-      return data.profiles;
+      const result = await res.json();
+
+      // Cache the parse only on Mode A so later dismissals can reuse it.
+      if (result.inferred && !isDismissMode) {
+        setInferred(result.inferred);
+      }
+
+      return result;
     },
     enabled: debouncedQuery.trim().length >= 2 && !!session,
     retry: 1,
   });
+
+  return {
+    data: searchQuery.data?.profiles ?? [],
+    inferred: searchQuery.data?.inferred ?? null,
+    emptyReason: searchQuery.data?.emptyReason ?? null,
+    isFetching: searchQuery.isFetching,
+    error: searchQuery.error,
+    dismissFilter,
+  };
 }
 
 export function useProfileUpsert() {

--- a/src/lib/dashboardFilters.ts
+++ b/src/lib/dashboardFilters.ts
@@ -14,6 +14,42 @@ export const EMPTY_DASHBOARD_FILTERS: DashboardFilters = {
   intent: null,
 };
 
+export type RelaxDimension = "college" | "sectors" | "gradYear" | "intent";
+
+/**
+ * A single "relax this filter" suggestion returned when a search produces zero
+ * matches purely because hard filters cut everyone out. `countIfRelaxed` is how
+ * many candidates re-enter the pool if this one dimension is dropped.
+ */
+export type RelaxSuggestion = {
+  dimension: RelaxDimension;
+  label: string;
+  /** Whether this filter came from the user's sidebar or was AI-inferred. */
+  source: "user" | "inferred";
+  /** Inferred-dismiss keys for this dimension (e.g. ["sector:fintech"]). */
+  dismissKeys: string[];
+  countIfRelaxed: number;
+};
+
+export type SearchEmptyReason = { relaxations: RelaxSuggestion[] } | null;
+
+export function normalizeDashboardFilters(
+  input: Partial<DashboardFilters> | undefined,
+): DashboardFilters {
+  if (!input) return EMPTY_DASHBOARD_FILTERS;
+  return {
+    college: typeof input.college === "string" ? input.college : null,
+    sectors: Array.isArray(input.sectors)
+      ? input.sectors.filter((s): s is string => typeof s === "string")
+      : [],
+    gradYear: typeof input.gradYear === "number" ? input.gradYear : null,
+    intent:
+      input.intent === "join_me" || input.intent === "seeking_to_join"
+        ? input.intent
+        : null,
+  };
+}
+
 const STORAGE_KEY = "school-dashboard-filters";
 
 export function loadDashboardFilters(): DashboardFilters {

--- a/src/lib/searchQueryParser.ts
+++ b/src/lib/searchQueryParser.ts
@@ -60,7 +60,7 @@ function buildSystemPrompt(currentYear: number): string {
 
 Output JSON keys:
 - "filters": object with optional keys "college", "sectors", "gradYear", "intent".
-  - "college": exactly one of these keys: ${collegeLabels}. Only set if the query explicitly names a school/department.
+  - "college": exactly one of these keys: ${collegeLabels}. Only set if the query explicitly names a school/department. A skill, job title, or field of expertise (e.g. "statistics expert", "designer", "ML engineer") is NOT a school name — never infer college from a skill.
   - "sectors": array of one or more of these keys: ${sectorLabels}. Only include sectors the query explicitly mentions or strongly implies by industry name.
   - "gradYear": integer between ${currentYear - 6} and ${currentYear + 6}. Only set if the query explicitly mentions a graduation year (e.g. "class of 2026", "graduating 2025"). For "current senior" or "incoming freshman", do NOT guess a year.
   - "intent": "join_me" (looking for someone to join their startup) or "seeking_to_join" (wants to join someone else's startup). Only set if the query is explicitly about this distinction.
@@ -84,7 +84,10 @@ Input: "non-technical founder with sales chops"
 Output: {"filters":{},"semanticQuery":"non-technical founder with sales experience","ftsTerms":["non-technical","sales","business development","founder"]}
 
 Input: "interesting people"
-Output: {"filters":{},"semanticQuery":"interesting people","ftsTerms":[]}`;
+Output: {"filters":{},"semanticQuery":"interesting people","ftsTerms":[]}
+
+Input: "statistics expert graduating in 2027"
+Output: {"filters":{"gradYear":2027},"semanticQuery":"statistics expert","ftsTerms":["statistics","data","analytics","quantitative"]}`;
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -136,28 +139,36 @@ function validateParsed(raw: unknown, q: string, currentYear: number): ParsedQue
       .slice(0, 10);
   }
 
+  // A year consumed as the gradYear filter must NOT also leak into the
+  // semantic/FTS path. graduation_year lives in no search_tsv, so a bare-year
+  // query ("2027") would otherwise run a text search for "2027" that matches no
+  // profile body and wipes out the correct gradYear-filtered set. Strip the year
+  // token from both so a pure-year query takes the pure-filter return path.
+  if (typeof result.filters.gradYear === "number") {
+    const yearStr = String(result.filters.gradYear);
+    result.ftsTerms = result.ftsTerms.filter(
+      (t) => t.replace(/\D/g, "") !== yearStr,
+    );
+    result.semanticQuery = result.semanticQuery
+      .replace(new RegExp(`\\b${yearStr}\\b`, "g"), "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
   return result;
 }
 
 export async function parseSearchQuery(q: string): Promise<ParsedQuery> {
   const apiKey = process.env.GROQ_API_KEY;
-  if (!apiKey) {
-    console.log("[groq] no GROQ_API_KEY — skipping parse for %s", q);
-    return safeFallback(q);
-  }
+  if (!apiKey) return safeFallback(q);
 
   const cacheKey = q.trim().toLowerCase();
   const cached = cacheGet(cacheKey);
-  if (cached) {
-    console.log("[groq] cache hit for %s", q);
-    return cached;
-  }
+  if (cached) return cached;
 
   const currentYear = new Date().getFullYear();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), GROQ_TIMEOUT_MS);
-
-  console.log("[groq] calling API for %s", q);
 
   try {
     const res = await fetch(GROQ_URL, {
@@ -179,38 +190,25 @@ export async function parseSearchQuery(q: string): Promise<ParsedQuery> {
       }),
     });
 
-    if (!res.ok) {
-      const errBody = await res.text();
-      console.log("[groq] API error status=%d body=%s", res.status, errBody);
-      return safeFallback(q);
-    }
+    if (!res.ok) return safeFallback(q);
 
     const json = (await res.json()) as {
       choices?: { message?: { content?: string } }[];
     };
     const content = json.choices?.[0]?.message?.content;
-    if (!content) {
-      console.log("[groq] empty content in response: %j", json);
-      return safeFallback(q);
-    }
-
-    console.log("[groq] raw response: %s", content);
+    if (!content) return safeFallback(q);
 
     let parsedJson: unknown;
     try {
       parsedJson = JSON.parse(content);
     } catch {
-      console.log("[groq] JSON parse failed for content: %s", content);
       return safeFallback(q);
     }
 
     const validated = validateParsed(parsedJson, q, currentYear);
-    console.log("[groq] validated result: %j", validated);
     cacheSet(cacheKey, validated);
     return validated;
-  } catch (err) {
-    const isAbort = err instanceof Error && err.name === "AbortError";
-    console.log("[groq] %s for query: %s", isAbort ? "timeout" : `error: ${err}`, q);
+  } catch {
     return safeFallback(q);
   } finally {
     clearTimeout(timer);

--- a/src/lib/searchQueryParser.ts
+++ b/src/lib/searchQueryParser.ts
@@ -1,0 +1,218 @@
+import {
+  SECTOR_INTEREST_LABELS,
+  UT_SCHOOLS_AND_PROGRAMS,
+} from "@/lib/utSchoolsAndMajors";
+import type { DashboardFilters } from "@/lib/dashboardFilters";
+
+export type ParsedQuery = {
+  filters: Partial<DashboardFilters>;
+  semanticQuery: string;
+  ftsTerms: string[];
+};
+
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const GROQ_MODEL = "llama-3.3-70b-versatile";
+const GROQ_TIMEOUT_MS = 1500;
+const CACHE_MAX = 1000;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+type CacheEntry = { value: ParsedQuery; expiresAt: number };
+const cache = new Map<string, CacheEntry>();
+
+function cacheGet(key: string): ParsedQuery | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.value;
+}
+
+function cacheSet(key: string, value: ParsedQuery) {
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+function safeFallback(q: string): ParsedQuery {
+  return { filters: {}, semanticQuery: q, ftsTerms: [] };
+}
+
+function buildSystemPrompt(currentYear: number): string {
+  const collegeKeys = Object.keys(UT_SCHOOLS_AND_PROGRAMS);
+  const sectorKeys = Object.keys(SECTOR_INTEREST_LABELS);
+  const collegeLabels = collegeKeys
+    .map(
+      (k) =>
+        `${k} (${UT_SCHOOLS_AND_PROGRAMS[k as keyof typeof UT_SCHOOLS_AND_PROGRAMS].label})`,
+    )
+    .join(", ");
+  const sectorLabels = sectorKeys
+    .map((k) => `${k} (${SECTOR_INTEREST_LABELS[k as keyof typeof SECTOR_INTEREST_LABELS]})`)
+    .join(", ");
+
+  return `You parse a user's natural-language search query for a UT Austin co-founder matching app and emit a strict JSON object.
+
+Output JSON keys:
+- "filters": object with optional keys "college", "sectors", "gradYear", "intent".
+  - "college": exactly one of these keys: ${collegeLabels}. Only set if the query explicitly names a school/department.
+  - "sectors": array of one or more of these keys: ${sectorLabels}. Only include sectors the query explicitly mentions or strongly implies by industry name.
+  - "gradYear": integer between ${currentYear - 6} and ${currentYear + 6}. Only set if the query explicitly mentions a graduation year (e.g. "class of 2026", "graduating 2025"). For "current senior" or "incoming freshman", do NOT guess a year.
+  - "intent": "join_me" (looking for someone to join their startup) or "seeking_to_join" (wants to join someone else's startup). Only set if the query is explicitly about this distinction.
+- "semanticQuery": a cleaned version of the query suitable for semantic embedding — drop the parts that became filters, keep the meaning-bearing words. If the query is purely structural ("class of 2026"), return an empty string.
+- "ftsTerms": array of expanded keyword synonyms for full-text search. Include the original meaningful words plus 2-6 related terms / synonyms / spelled-out abbreviations. Max 10 terms. Empty array if no useful keywords.
+
+HARD RULES:
+1. If the query does NOT explicitly reference a filter dimension, OMIT that key entirely. False positives are worse than false negatives.
+2. Use ONLY enum keys from the lists above. Never invent new values.
+3. Preserve negations and qualifiers ("non-technical", "not in fintech") in semanticQuery — do not flip them into positive filters.
+4. Return ONLY the JSON object. No markdown, no commentary.
+
+Examples:
+Input: "ML engineer in fintech graduating 2026"
+Output: {"filters":{"sectors":["fintech","ai_ml"],"gradYear":2026},"semanticQuery":"machine learning engineer","ftsTerms":["ML","machine learning","AI","engineer","fintech"]}
+
+Input: "McCombs MBA looking for technical co-founder"
+Output: {"filters":{"college":"mccombs_business","intent":"seeking_to_join"},"semanticQuery":"MBA student seeking technical co-founder","ftsTerms":["MBA","business","technical","co-founder"]}
+
+Input: "non-technical founder with sales chops"
+Output: {"filters":{},"semanticQuery":"non-technical founder with sales experience","ftsTerms":["non-technical","sales","business development","founder"]}
+
+Input: "interesting people"
+Output: {"filters":{},"semanticQuery":"interesting people","ftsTerms":[]}`;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validateParsed(raw: unknown, q: string, currentYear: number): ParsedQuery {
+  const result: ParsedQuery = { filters: {}, semanticQuery: q, ftsTerms: [] };
+  if (!isRecord(raw)) return result;
+
+  if (isRecord(raw.filters)) {
+    const f = raw.filters;
+
+    if (
+      typeof f.college === "string" &&
+      Object.prototype.hasOwnProperty.call(UT_SCHOOLS_AND_PROGRAMS, f.college)
+    ) {
+      result.filters.college = f.college;
+    }
+
+    if (Array.isArray(f.sectors)) {
+      const valid = f.sectors.filter(
+        (s): s is string =>
+          typeof s === "string" &&
+          Object.prototype.hasOwnProperty.call(SECTOR_INTEREST_LABELS, s),
+      );
+      if (valid.length > 0) result.filters.sectors = Array.from(new Set(valid));
+    }
+
+    if (typeof f.gradYear === "number" && Number.isInteger(f.gradYear)) {
+      if (f.gradYear >= currentYear - 6 && f.gradYear <= currentYear + 6) {
+        result.filters.gradYear = f.gradYear;
+      }
+    }
+
+    if (f.intent === "join_me" || f.intent === "seeking_to_join") {
+      result.filters.intent = f.intent;
+    }
+  }
+
+  if (typeof raw.semanticQuery === "string" && raw.semanticQuery.trim().length > 0) {
+    result.semanticQuery = raw.semanticQuery.trim();
+  }
+
+  if (Array.isArray(raw.ftsTerms)) {
+    result.ftsTerms = raw.ftsTerms
+      .filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+      .map((t) => t.trim())
+      .slice(0, 10);
+  }
+
+  return result;
+}
+
+export async function parseSearchQuery(q: string): Promise<ParsedQuery> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    console.log("[groq] no GROQ_API_KEY — skipping parse for %s", q);
+    return safeFallback(q);
+  }
+
+  const cacheKey = q.trim().toLowerCase();
+  const cached = cacheGet(cacheKey);
+  if (cached) {
+    console.log("[groq] cache hit for %s", q);
+    return cached;
+  }
+
+  const currentYear = new Date().getFullYear();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GROQ_TIMEOUT_MS);
+
+  console.log("[groq] calling API for %s", q);
+
+  try {
+    const res = await fetch(GROQ_URL, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        temperature: 0.1,
+        max_tokens: 512,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: buildSystemPrompt(currentYear) },
+          { role: "user", content: q },
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      const errBody = await res.text();
+      console.log("[groq] API error status=%d body=%s", res.status, errBody);
+      return safeFallback(q);
+    }
+
+    const json = (await res.json()) as {
+      choices?: { message?: { content?: string } }[];
+    };
+    const content = json.choices?.[0]?.message?.content;
+    if (!content) {
+      console.log("[groq] empty content in response: %j", json);
+      return safeFallback(q);
+    }
+
+    console.log("[groq] raw response: %s", content);
+
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(content);
+    } catch {
+      console.log("[groq] JSON parse failed for content: %s", content);
+      return safeFallback(q);
+    }
+
+    const validated = validateParsed(parsedJson, q, currentYear);
+    console.log("[groq] validated result: %j", validated);
+    cacheSet(cacheKey, validated);
+    return validated;
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    console.log("[groq] %s for query: %s", isAbort ? "timeout" : `error: ${err}`, q);
+    return safeFallback(q);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/supabase/functions/embed/index.ts
+++ b/supabase/functions/embed/index.ts
@@ -1,0 +1,185 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+const MAX_CHARS = 2000;
+
+// Build profile text by concatenating relevant fields in high-signal-first order
+async function buildProfileText(userId: string): Promise<string> {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select(
+      "title, personal_intro, startup_name, startup_description, accomplishments, interests, hobbies, city"
+    )
+    .eq("user_id", userId)
+    .single();
+
+  const { data: schoolProfile } = await supabase
+    .from("school_profiles")
+    .select("major, college, degree_type, sector_interests")
+    .eq("user_id", userId)
+    .single();
+
+  const parts: string[] = [];
+
+  if (profile) {
+    if (profile.title) parts.push(profile.title);
+    if (profile.personal_intro) parts.push(profile.personal_intro);
+    if (profile.startup_name) parts.push(profile.startup_name);
+    if (profile.startup_description) parts.push(profile.startup_description);
+  }
+
+  if (schoolProfile) {
+    if (schoolProfile.major) parts.push(schoolProfile.major);
+    if (schoolProfile.college) parts.push(schoolProfile.college);
+    if (schoolProfile.degree_type) parts.push(schoolProfile.degree_type);
+    if (
+      schoolProfile.sector_interests &&
+      Array.isArray(schoolProfile.sector_interests)
+    ) {
+      parts.push(schoolProfile.sector_interests.join(" "));
+    }
+  }
+
+  if (profile) {
+    if (profile.interests) parts.push(profile.interests);
+    if (profile.hobbies) parts.push(profile.hobbies);
+    if (profile.accomplishments) parts.push(profile.accomplishments);
+    if (profile.city) parts.push(profile.city);
+  }
+
+  return parts.filter(Boolean).join(" ");
+}
+
+// Embed text using gte-small model and return as vector
+async function embedText(text: string): Promise<number[]> {
+  const truncated = text.slice(0, MAX_CHARS);
+
+  // Use Supabase's built-in embedding via AI session
+  const session = new Supabase.ai.Session("gte-small");
+  const embedding = await session.run(truncated, {
+    mean_pool: true,
+    normalize: true,
+  });
+
+  return embedding;
+}
+
+// Drain mode: process queue messages and re-embed profiles
+async function drainQueue() {
+  try {
+    // Read up to 20 messages from the queue
+    const { data: messages, error: readError } = await supabase
+      .rpc("pgmq_read", {
+        queue_name: "embedding_refresh",
+        limit: 20,
+        vt: 30,
+      })
+      .returns<Array<{ msg_id: string; message: { user_id: string } }>>();
+
+    if (readError) {
+      console.error("Error reading from queue:", readError);
+      return { drained: 0, error: readError.message };
+    }
+
+    if (!messages || messages.length === 0) {
+      return { drained: 0 };
+    }
+
+    let successCount = 0;
+
+    for (const msg of messages) {
+      try {
+        const userId = msg.message.user_id;
+        const profileText = await buildProfileText(userId);
+        const embedding = await embedText(profileText);
+
+        // Update the profiles table with the new embedding
+        const { error: updateError } = await supabase
+          .from("profiles")
+          .update({ embedding })
+          .eq("user_id", userId);
+
+        if (updateError) {
+          console.error(
+            `Error updating embedding for user ${userId}:`,
+            updateError
+          );
+        } else {
+          successCount++;
+
+          // Delete the message from the queue
+          const { error: deleteError } = await supabase.rpc("pgmq_delete", {
+            queue_name: "embedding_refresh",
+            msg_id: msg.msg_id,
+          });
+
+          if (deleteError) {
+            console.error(
+              `Error deleting message ${msg.msg_id}:`,
+              deleteError
+            );
+          }
+        }
+      } catch (error) {
+        console.error("Error processing queue message:", error);
+      }
+    }
+
+    return { drained: successCount, total: messages.length };
+  } catch (error) {
+    console.error("Error draining queue:", error);
+    return { drained: 0, error: (error as Error).message };
+  }
+}
+
+// Query mode: embed a search string and return the vector
+async function queryEmbed(text: string) {
+  try {
+    const embedding = await embedText(text);
+    return { embedding, success: true };
+  } catch (error) {
+    console.error("Error embedding query:", error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+// Main handler
+Deno.serve(async (req) => {
+  try {
+    const { mode, text } = await req.json();
+
+    if (mode === "query") {
+      const result = await queryEmbed(text || "");
+      return new Response(JSON.stringify(result), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (mode === "drain") {
+      const result = await drainQueue();
+      return new Response(JSON.stringify(result), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ error: "Unknown mode. Use 'query' or 'drain'." }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    console.error("Error in embed function:", error);
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+});

--- a/supabase/migrations/20260528000002_add_embeddings.sql
+++ b/supabase/migrations/20260528000002_add_embeddings.sql
@@ -1,0 +1,11 @@
+-- Enable pgvector extension for embeddings
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Enable pgmq extension for durable queue
+CREATE EXTENSION IF NOT EXISTS pgmq;
+
+-- Add embedding column to profiles (384-dim vector from gte-small model)
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS embedding vector(384);
+
+-- Create the embedding_refresh queue for async re-embedding
+SELECT pgmq.create('embedding_refresh');

--- a/supabase/migrations/20260528000003_embedding_refresh_triggers.sql
+++ b/supabase/migrations/20260528000003_embedding_refresh_triggers.sql
@@ -1,0 +1,39 @@
+-- Trigger function to enqueue embedding refresh and nudge Edge Function
+CREATE OR REPLACE FUNCTION enqueue_embedding_refresh()
+RETURNS trigger AS $$
+DECLARE
+  v_edge_url text := current_setting('app.embed_fn_url', true);
+  v_edge_token text := current_setting('app.edge_fn_token', true);
+BEGIN
+  -- Enqueue the user_id for re-embedding (durable queue)
+  PERFORM pgmq.send('embedding_refresh',
+    jsonb_build_object('user_id', NEW.user_id));
+
+  -- Nudge the Edge Function immediately if configured (sub-minute freshness)
+  IF v_edge_url IS NOT NULL AND v_edge_token IS NOT NULL THEN
+    PERFORM net.http_post(
+      url := v_edge_url,
+      body := jsonb_build_object('mode', 'drain'),
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || v_edge_token
+      ));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on profiles: fire when search_tsv changes (indicates text content changed)
+DROP TRIGGER IF EXISTS profiles_embedding_refresh ON profiles;
+CREATE TRIGGER profiles_embedding_refresh
+  AFTER INSERT OR UPDATE OF search_tsv ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION enqueue_embedding_refresh();
+
+-- Trigger on school_profiles: fire when search_tsv changes, re-embed the parent user
+DROP TRIGGER IF EXISTS school_profiles_embedding_refresh ON school_profiles;
+CREATE TRIGGER school_profiles_embedding_refresh
+  AFTER INSERT OR UPDATE OF search_tsv ON school_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION enqueue_embedding_refresh();

--- a/supabase/migrations/20260528000004_schedule_embedding_drain.sql
+++ b/supabase/migrations/20260528000004_schedule_embedding_drain.sql
@@ -1,0 +1,20 @@
+-- Enable pg_cron extension
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Schedule the embedding drain to run every minute
+-- This serves as a safety net for missed trigger nudges and keeps the Edge Function worker warm
+-- Prerequisites: app.embed_fn_url and app.edge_fn_token must be set as Postgres parameters in Supabase dashboard
+SELECT cron.schedule(
+  'embed-drain',
+  '* * * * *',
+  $$
+    SELECT net.http_post(
+      url := current_setting('app.embed_fn_url'),
+      body := jsonb_build_object('mode', 'drain'),
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || current_setting('app.edge_fn_token')
+      )
+    );
+  $$
+);

--- a/supabase/migrations/20260528000005_backfill_embeddings.sql
+++ b/supabase/migrations/20260528000005_backfill_embeddings.sql
@@ -1,0 +1,10 @@
+-- Backfill: enqueue all existing non-deleted profiles for embedding
+-- Run this after the Edge Function is deployed and ready to process the queue
+SELECT pgmq.send_batch(
+  'embedding_refresh',
+  ARRAY(
+    SELECT jsonb_build_object('user_id', user_id)
+    FROM profiles
+    WHERE deleted_at IS NULL
+  )
+);

--- a/supabase/migrations/20260528000006_search_profiles_hybrid_rpc.sql
+++ b/supabase/migrations/20260528000006_search_profiles_hybrid_rpc.sql
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION search_profiles_hybrid(
+  eligible_ids text[],
+  query_text   text,
+  query_vec    vector(384)
+) RETURNS TABLE (user_id text, rrf_score real)
+LANGUAGE sql STABLE AS $$
+  WITH
+  q_tsv AS (SELECT to_tsquery('english', query_text) AS q),
+
+  -- Branch 1: keyword FTS on profiles (title, bio, startup, interests, city)
+  fts_top AS (
+    SELECT p.user_id,
+           row_number() OVER (ORDER BY ts_rank(p.search_tsv, q.q) DESC) AS rk
+    FROM profiles p, q_tsv q
+    WHERE p.user_id = ANY(eligible_ids)
+      AND p.deleted_at IS NULL
+      AND p.search_tsv @@ q.q
+    ORDER BY ts_rank(p.search_tsv, q.q) DESC
+    LIMIT 100
+  ),
+
+  -- Branch 2: keyword FTS on school_profiles (major, college, sector_interests)
+  school_fts_top AS (
+    SELECT sp.user_id,
+           row_number() OVER (ORDER BY ts_rank(sp.search_tsv, q.q) DESC) AS rk
+    FROM school_profiles sp, q_tsv q
+    WHERE sp.user_id = ANY(eligible_ids)
+      AND sp.search_tsv @@ q.q
+    ORDER BY ts_rank(sp.search_tsv, q.q) DESC
+    LIMIT 100
+  ),
+
+  -- Branch 3: semantic vector similarity (cosine distance)
+  -- Only includes profiles that have been embedded; others fall through to other branches
+  vec_top AS (
+    SELECT p.user_id,
+           row_number() OVER (ORDER BY p.embedding <=> query_vec) AS rk
+    FROM profiles p
+    WHERE p.user_id = ANY(eligible_ids)
+      AND p.deleted_at IS NULL
+      AND p.embedding IS NOT NULL
+    ORDER BY p.embedding <=> query_vec
+    LIMIT 100
+  ),
+
+  -- Branch 4: partial name match (handles "Jo" → "John" that FTS/vector miss)
+  name_top AS (
+    SELECT p.user_id,
+           row_number() OVER (ORDER BY p.user_id) AS rk
+    FROM profiles p
+    WHERE p.user_id = ANY(eligible_ids)
+      AND p.deleted_at IS NULL
+      AND (p.first_name ILIKE '%' || query_text || '%'
+        OR p.last_name  ILIKE '%' || query_text || '%')
+    LIMIT 50
+  ),
+
+  -- Combine all branches — each row is (user_id, rank_within_branch)
+  combined AS (
+    SELECT user_id, rk FROM fts_top
+    UNION ALL SELECT user_id, rk FROM school_fts_top
+    UNION ALL SELECT user_id, rk FROM vec_top
+    UNION ALL SELECT user_id, rk FROM name_top
+  )
+
+  -- RRF: sum 1/(60+rank) across all branches a profile appears in
+  SELECT user_id, SUM(1.0 / (60 + rk))::real AS rrf_score
+  FROM combined
+  GROUP BY user_id
+  ORDER BY rrf_score DESC
+  LIMIT 30;
+$$;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
# MCFM-118: Hybrid Semantic Search (Phase A + B)
 
## Problem
 
The existing search was limited to exact name `ILIKE` matching. Users couldn't search by natural language (e.g., "ML engineer in fintech graduating 2026") and had no way to discover profiles by skill, industry intent, or semantic meaning.
 
## Solution
 
A two-phase search overhaul: vector embeddings for semantic similarity (Phase A) + LLM-powered query parsing to extract structured filters and clean semantic queries (Phase B).
 
---
 
## Changes
 
### Infrastructure — Phase A
 
- Adds `pgvector` + `pgmq` extensions; new `profiles.embedding vector(384)` column
- Supabase Edge Function (`supabase/functions/embed/`) generates embeddings via `gte-small` model
- Postgres triggers on `profiles.search_tsv` and `school_profiles.search_tsv` enqueue re-embedding on content changes
- `pg_cron` job drains the queue every minute as a safety net
- Backfill migration enqueues all existing profiles on deploy
### Search Pipeline — Phase B
 
- `src/lib/searchQueryParser.ts`: calls Groq (`llama-3.3-70b`, 1500ms timeout) to parse a raw query into `{ filters, semanticQuery, ftsTerms }` with an in-memory LRU cache (1h TTL, max 1000 entries). Hard rules prevent false-positive filter inference (e.g., skills ≠ college names)
- `src/app/api/profiles/search/route.ts` rebuilt around a hybrid pipeline:
  - LLM parses query → inferred filters merged with user sidebar filters (user wins conflicts)
  - Dismissed filter keys are tracked per-request so "×" chips re-run without that filter
  - Query embedding fetched in parallel; Postgres RPC runs vector similarity + FTS + name `ILIKE` combined
- `src/lib/dashboardFilters.ts`: adds `RelaxSuggestion`, `RelaxDimension`, `normalizeDashboardFilters`, `getFilterChipLabels`
### UX
 
- "Understood as" chip row surfaces AI-inferred filters during search; each chip is individually dismissable
- Empty-state shows per-dimension relaxation buttons with count hints (e.g., "Drop 'McCombs' +12")
- Fixes: grad-year number parsed correctly from LLM output; wrong semantic meaning associations from over-eager filter inference; dashboard filter error; graduating-year filter in search bar
---
 
## Migrations
 
Run in sequence (order-dependent):
 
| File | Purpose |
|------|---------|
| `20260528000002_add_embeddings.sql` | Enable extensions, add embedding column |
| `20260528000003_embedding_refresh_triggers.sql` | Triggers → embedding_refresh queue |
| `20260528000004_schedule_embedding_drain.sql` | pg_cron drain job |
| `20260528000005_backfill_embeddings.sql` | Enqueue existing profiles |
| `20260528000006_search_profiles_hybrid_rpc.sql` | Hybrid search RPC |
 
---
 
## Deploy Notes
 
- `app.embed_fn_url` and `app.edge_fn_token` must be set as Postgres parameters in the Supabase dashboard **before** migrations run (required by trigger + cron)
- `GROQ_API_KEY` required in Edge Function env
- Backfill migration should run **after** the Edge Function is live
---
 
## Testing
 
- Natural language queries route through LLM parser with graceful fallback on timeout/error
- User-set sidebar filters always take precedence over AI-inferred filters
- Dismissed filter keys persist for the session (passed as `dismissedFilterKeys` in request body)