### PR TITLE
MCFM-116 | Add admin dashboard with csv export

### DIFF
--- a/src/app/api/delete-profile/route.ts
+++ b/src/app/api/delete-profile/route.ts
@@ -1,7 +1,95 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
+
+/**
+ * Admin-initiated account deletion.
+ * Requires the caller to be an org admin for the target user's org.
+ * ?targetUserId=<clerk-user-id>
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const adminAuth = await requireOrgAdmin();
+    if (adminAuth instanceof NextResponse) return adminAuth;
+    const { orgId } = adminAuth;
+
+    const targetUserId = request.nextUrl.searchParams.get("targetUserId");
+    if (!targetUserId) {
+      return NextResponse.json(
+        { error: "targetUserId query param required" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    // Verify the target belongs to the admin's org
+    const { data: targetProfile, error: profileError } = await supabase
+      .from("profiles")
+      .select("id, organization_id")
+      .eq("user_id", targetUserId)
+      .single();
+
+    if (profileError || !targetProfile) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    if (targetProfile.organization_id !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const internalProfileId = targetProfile.id;
+
+    // Delete storage
+    try {
+      const { data: oldFiles } = await supabase.storage
+        .from("profile-pic")
+        .list("", { search: targetUserId });
+      if (oldFiles && oldFiles.length > 0) {
+        await supabase.storage
+          .from("profile-pic")
+          .remove(oldFiles.map((f) => f.name));
+      }
+    } catch {}
+
+    await supabase.from("messages").delete().eq("sender_id", targetUserId);
+    await supabase
+      .from("conversation_participants")
+      .delete()
+      .eq("user_id", targetUserId);
+    await supabase
+      .from("likes")
+      .delete()
+      .or(`liker_id.eq.${targetUserId},liked_id.eq.${targetUserId}`);
+    await supabase
+      .from("user_profile_actions")
+      .delete()
+      .or(
+        `user_id.eq.${internalProfileId},other_profile_id.eq.${internalProfileId}`,
+      );
+    await supabase.from("profiles").delete().eq("user_id", targetUserId);
+
+    try {
+      const client = await clerkClient();
+      await client.users.deleteUser(targetUserId);
+    } catch (clerkError) {
+      console.error("Error deleting target user from Clerk:", clerkError);
+    }
+
+    return NextResponse.json({ message: "Account deleted successfully" });
+  } catch (error) {
+    console.error("Error in admin delete-profile endpoint:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
 
 export async function POST() {
   try {

--- a/src/app/api/school/analytics/route.ts
+++ b/src/app/api/school/analytics/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
+
+export async function GET() {
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  const { orgId } = auth;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // 1. Total signups + technical split
+  const { data: profiles, error: profilesError } = await supabase
+    .from("profiles")
+    .select("user_id, is_technical")
+    .eq("organization_id", orgId)
+    .is("deleted_at", null);
+
+  if (profilesError) {
+    return NextResponse.json(
+      { error: "Failed to fetch analytics" },
+      { status: 500 },
+    );
+  }
+
+  const orgProfiles = profiles ?? [];
+  const totalSignups = orgProfiles.length;
+  const technicalCount = orgProfiles.filter((p) => p.is_technical).length;
+  const nonTechnicalCount = totalSignups - technicalCount;
+  const orgUserIds = orgProfiles.map((p) => p.user_id);
+
+  // 2. Active last 7 days (via user_activity_summary)
+  let activeCount = 0;
+  if (orgUserIds.length > 0) {
+    const sevenDaysAgo = new Date(
+      Date.now() - 7 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const { count } = await supabase
+      .from("user_activity_summary")
+      .select("user_id", { count: "exact", head: true })
+      .in("user_id", orgUserIds)
+      .gte("last_active_at", sevenDaysAgo);
+    activeCount = count ?? 0;
+  }
+
+  // 3. Total connections (org-scoped conversations with at least 1 message)
+  let totalConnections = 0;
+  let totalMessages = 0;
+  if (orgUserIds.length > 0) {
+    const { data: orgParticipants } = await supabase
+      .from("conversation_participants")
+      .select("conversation_id")
+      .in("user_id", orgUserIds);
+
+    const candidateConvIds = [
+      ...new Set((orgParticipants ?? []).map((r) => r.conversation_id)),
+    ];
+
+    if (candidateConvIds.length > 0) {
+      const orgUserSet = new Set(orgUserIds);
+      const { data: allParticipants } = await supabase
+        .from("conversation_participants")
+        .select("conversation_id, user_id")
+        .in("conversation_id", candidateConvIds);
+
+      const convMap = new Map<string, string[]>();
+      for (const row of allParticipants ?? []) {
+        const arr = convMap.get(row.conversation_id) ?? [];
+        arr.push(row.user_id);
+        convMap.set(row.conversation_id, arr);
+      }
+
+      const orgConvIds = [...convMap.entries()]
+        .filter(([, participants]) =>
+          participants.every((uid) => orgUserSet.has(uid)),
+        )
+        .map(([id]) => id);
+
+      if (orgConvIds.length > 0) {
+        const { count: msgCount } = await supabase
+          .from("messages")
+          .select("id", { count: "exact", head: true })
+          .in("conversation_id", orgConvIds);
+
+        // Count conversations that have at least 1 message
+        const { data: msgsPerConv } = await supabase
+          .from("messages")
+          .select("conversation_id")
+          .in("conversation_id", orgConvIds);
+
+        const convsWithMessages = new Set(
+          (msgsPerConv ?? []).map((r) => r.conversation_id),
+        );
+        totalConnections = convsWithMessages.size;
+        totalMessages = msgCount ?? 0;
+      }
+    }
+  }
+
+  return NextResponse.json({
+    total_signups: totalSignups,
+    active_last_7_days: activeCount,
+    technical_count: technicalCount,
+    non_technical_count: nonTechnicalCount,
+    total_connections: totalConnections,
+    total_messages: totalMessages,
+  });
+}

--- a/src/app/api/school/connections/route.ts
+++ b/src/app/api/school/connections/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
+
+export type OrgConnection = {
+  conversation_id: string;
+  user1: {
+    user_id: string;
+    first_name: string | null;
+    last_name: string | null;
+    title: string | null;
+  };
+  user2: {
+    user_id: string;
+    first_name: string | null;
+    last_name: string | null;
+    title: string | null;
+  };
+  message_count: number;
+  created_at: string;
+  last_message_at: string | null;
+};
+
+export async function GET() {
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  const { orgId } = auth;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // 1. Get all user IDs in the org
+  const { data: orgProfiles, error: profilesError } = await supabase
+    .from("profiles")
+    .select("user_id")
+    .eq("organization_id", orgId)
+    .is("deleted_at", null);
+
+  if (profilesError) {
+    return NextResponse.json(
+      { error: "Failed to fetch org profiles" },
+      { status: 500 },
+    );
+  }
+
+  const orgUserIds = new Set((orgProfiles ?? []).map((p) => p.user_id));
+  if (orgUserIds.size === 0) {
+    return NextResponse.json({ connections: [], total_connections: 0 });
+  }
+
+  // 2. Get conversation IDs where an org user is a participant
+  const { data: orgParticipants } = await supabase
+    .from("conversation_participants")
+    .select("conversation_id")
+    .in("user_id", [...orgUserIds]);
+
+  const candidateConvIds = [
+    ...new Set((orgParticipants ?? []).map((r) => r.conversation_id)),
+  ];
+  if (candidateConvIds.length === 0) {
+    return NextResponse.json({ connections: [], total_connections: 0 });
+  }
+
+  // 3. Get all participants for those conversations
+  const { data: allParticipants } = await supabase
+    .from("conversation_participants")
+    .select("conversation_id, user_id")
+    .in("conversation_id", candidateConvIds);
+
+  // 4. Keep only conversations where every participant belongs to the org
+  const convMap = new Map<string, string[]>();
+  for (const row of allParticipants ?? []) {
+    const arr = convMap.get(row.conversation_id) ?? [];
+    arr.push(row.user_id);
+    convMap.set(row.conversation_id, arr);
+  }
+
+  const orgConvIds = [...convMap.entries()]
+    .filter(([, participants]) =>
+      participants.every((uid) => orgUserIds.has(uid)),
+    )
+    .map(([id]) => id);
+
+  if (orgConvIds.length === 0) {
+    return NextResponse.json({ connections: [], total_connections: 0 });
+  }
+
+  // 5. Get conversation details
+  const { data: conversations } = await supabase
+    .from("conversations")
+    .select("id, created_at, last_message_at")
+    .in("id", orgConvIds)
+    .order("created_at", { ascending: false });
+
+  // 6. Get message counts in one query
+  const { data: messageCounts } = await supabase
+    .from("messages")
+    .select("conversation_id")
+    .in("conversation_id", orgConvIds);
+
+  const msgCountMap = new Map<string, number>();
+  for (const row of messageCounts ?? []) {
+    msgCountMap.set(
+      row.conversation_id,
+      (msgCountMap.get(row.conversation_id) ?? 0) + 1,
+    );
+  }
+
+  // 7. Gather all participant user IDs and fetch profiles in one query
+  const allParticipantIds = [...new Set([...orgUserIds])];
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("user_id, first_name, last_name, title")
+    .in("user_id", allParticipantIds);
+
+  const profilesMap = new Map(
+    (profiles ?? []).map((p) => [p.user_id, p]),
+  );
+
+  const connections: OrgConnection[] = [];
+  for (const conv of conversations ?? []) {
+    const count = msgCountMap.get(conv.id) ?? 0;
+    if (count === 0) continue;
+
+    const participants = convMap.get(conv.id) ?? [];
+    if (participants.length !== 2) continue;
+
+    const p1 = profilesMap.get(participants[0]);
+    const p2 = profilesMap.get(participants[1]);
+    if (!p1 || !p2) continue;
+
+    connections.push({
+      conversation_id: conv.id,
+      user1: {
+        user_id: p1.user_id,
+        first_name: p1.first_name,
+        last_name: p1.last_name,
+        title: p1.title,
+      },
+      user2: {
+        user_id: p2.user_id,
+        first_name: p2.first_name,
+        last_name: p2.last_name,
+        title: p2.title,
+      },
+      message_count: count,
+      created_at: conv.created_at,
+      last_message_at: conv.last_message_at,
+    });
+  }
+
+  return NextResponse.json({
+    connections,
+    total_connections: connections.length,
+  });
+}

--- a/src/app/api/school/reports/cohort/route.ts
+++ b/src/app/api/school/reports/cohort/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
+import { toCsv } from "@/lib/csv";
+import {
+  UT_SCHOOLS_AND_PROGRAMS,
+  SECTOR_INTEREST_LABELS,
+} from "@/lib/utSchoolsAndMajors";
+
+const ARCHETYPE_LABELS: Record<string, string> = {
+  the_scaler: "The Scaler",
+  the_steward: "The Steward",
+  the_architect: "The Architect",
+};
+
+type ProfileRow = {
+  user_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  archetype: string | null;
+};
+
+type SchoolProfileRow = {
+  user_id: string;
+  school_status: string | null;
+  graduation_year: number | null;
+  college: string | null;
+  major: string | null;
+  sector_interests: string[] | null;
+};
+
+function schoolLabel(college: string | null): string {
+  if (!college) return "—";
+  const entry = (
+    UT_SCHOOLS_AND_PROGRAMS as Record<string, { label: string } | undefined>
+  )[college];
+  return entry?.label ?? college;
+}
+
+function sectorLabels(sectors: string[] | null): string {
+  if (!sectors || sectors.length === 0) return "—";
+  const labels = SECTOR_INTEREST_LABELS as Record<string, string | undefined>;
+  return sectors.map((s) => labels[s] ?? s).join("; ");
+}
+
+function titleCase(value: string | null): string {
+  if (!value) return "—";
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Active cohort report (CSV) — full snapshot of the current org cohort.
+ * Org-admin only. Scoped to the caller's organization. Excludes soft-deleted users.
+ */
+export async function GET() {
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  const { orgId } = auth;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: profiles, error: profilesError } = await supabase
+    .from("profiles")
+    .select("user_id, first_name, last_name, archetype")
+    .eq("organization_id", orgId)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  if (profilesError) {
+    return NextResponse.json(
+      { error: "Failed to fetch cohort" },
+      { status: 500 },
+    );
+  }
+
+  const orgProfiles = (profiles ?? []) as ProfileRow[];
+  const orgUserIds = orgProfiles.map((p) => p.user_id);
+
+  // School-specific structured fields
+  const schoolByUser = new Map<string, SchoolProfileRow>();
+  if (orgUserIds.length > 0) {
+    const { data: schoolProfiles } = await supabase
+      .from("school_profiles")
+      .select(
+        "user_id, school_status, graduation_year, college, major, sector_interests",
+      )
+      .in("user_id", orgUserIds);
+    for (const row of (schoolProfiles ?? []) as SchoolProfileRow[]) {
+      schoolByUser.set(row.user_id, row);
+    }
+  }
+
+  // Email lives only in Clerk — batch fetch
+  const emailByUser = new Map<string, string>();
+  if (orgUserIds.length > 0) {
+    try {
+      const client = await clerkClient();
+      const { data: users } = await client.users.getUserList({
+        userId: orgUserIds,
+        limit: orgUserIds.length,
+      });
+      for (const u of users) {
+        const primary = u.emailAddresses.find(
+          (e) => e.id === u.primaryEmailAddressId,
+        );
+        if (primary) emailByUser.set(u.id, primary.emailAddress);
+      }
+    } catch (err) {
+      console.error("[cohort report] Clerk email lookup failed:", err);
+    }
+  }
+
+  const header = [
+    "First name",
+    "Last name",
+    "Email",
+    "School",
+    "Founder archetype",
+    "Graduation year",
+    "Industry / Interest",
+    "Major",
+    "Student or Alumni",
+  ];
+
+  const rows: (string | number | null)[][] = orgProfiles.map((p) => {
+    const sp = schoolByUser.get(p.user_id);
+    return [
+      p.first_name ?? "",
+      p.last_name ?? "",
+      emailByUser.get(p.user_id) ?? "—",
+      schoolLabel(sp?.college ?? null),
+      p.archetype ? (ARCHETYPE_LABELS[p.archetype] ?? p.archetype) : "—",
+      sp?.graduation_year ?? "—",
+      sectorLabels(sp?.sector_interests ?? null),
+      sp?.major ?? "—",
+      titleCase(sp?.school_status ?? null),
+    ];
+  });
+
+  const csv = toCsv([header, ...rows]);
+  const date = new Date().toISOString().split("T")[0];
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="ut-cohort-${date}.csv"`,
+    },
+  });
+}

--- a/src/app/api/school/reports/match-outcomes/route.ts
+++ b/src/app/api/school/reports/match-outcomes/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
+import { toCsv } from "@/lib/csv";
+
+type IntentRow = {
+  from_user_id: string;
+  to_user_id: string;
+  we_match_notified_at: string | null;
+  created_at: string;
+};
+
+function pct(numerator: number, denominator: number): string {
+  if (denominator === 0) return "0.0%";
+  return `${((numerator / denominator) * 100).toFixed(1)}%`;
+}
+
+/**
+ * We Match outcomes report (CSV) — the "core UT proof point".
+ * Org-admin only, scoped to the caller's organization.
+ *
+ * Each row in match_intents is one directed "We Match" click (from → to). A
+ * reciprocal pair (A→B and B→A) is a mutual match. We report one-sided interest
+ * rate and mutual match rate, plus a per-pair breakdown.
+ */
+export async function GET() {
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  const { orgId } = auth;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: intentsData, error } = await supabase
+    .from("match_intents")
+    .select("from_user_id, to_user_id, we_match_notified_at, created_at")
+    .eq("organization_id", orgId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch match outcomes" },
+      { status: 500 },
+    );
+  }
+
+  const intents = (intentsData ?? []) as IntentRow[];
+
+  // Directed-edge lookup for reciprocity checks
+  const edgeKey = (from: string, to: string) => `${from}|${to}`;
+  const edges = new Set(intents.map((i) => edgeKey(i.from_user_id, i.to_user_id)));
+
+  const totalClicks = intents.length;
+  const senders = new Set(intents.map((i) => i.from_user_id));
+  let reciprocatedEdges = 0;
+  for (const i of intents) {
+    if (edges.has(edgeKey(i.to_user_id, i.from_user_id))) reciprocatedEdges += 1;
+  }
+  const mutualPairs = Math.floor(reciprocatedEdges / 2);
+  const oneSidedClicks = totalClicks - reciprocatedEdges;
+
+  // Resolve names for the per-pair detail
+  const userIds = [
+    ...new Set(intents.flatMap((i) => [i.from_user_id, i.to_user_id])),
+  ];
+  const nameByUser = new Map<string, string>();
+  if (userIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("user_id, first_name, last_name")
+      .in("user_id", userIds);
+    for (const p of profiles ?? []) {
+      const name = `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim();
+      nameByUser.set(p.user_id, name || p.user_id);
+    }
+  }
+  const nameOf = (userId: string) => nameByUser.get(userId) ?? userId;
+
+  // ── Summary block ──
+  const summary: (string | number)[][] = [
+    ["We Match Outcomes"],
+    ["Generated", new Date().toISOString()],
+    [],
+    ["Metric", "Value"],
+    ["Total We-Match clicks", totalClicks],
+    ["Unique senders", senders.size],
+    ["Mutual pairs", mutualPairs],
+    ["One-sided clicks", oneSidedClicks],
+    ["Mutual match rate", pct(reciprocatedEdges, totalClicks)],
+    ["One-sided interest rate", pct(oneSidedClicks, totalClicks)],
+    [],
+  ];
+
+  // ── Per-pair detail ──
+  // Mutual pairs emitted once (A ↔ B); one-sided edges as A → B.
+  const detail: (string | number)[][] = [
+    ["From", "Direction", "To", "Status", "Notified at", "Created at"],
+  ];
+  const seenMutual = new Set<string>();
+  for (const i of intents) {
+    const isMutual = edges.has(edgeKey(i.to_user_id, i.from_user_id));
+    if (isMutual) {
+      // Dedupe: only emit the first-seen direction of the pair
+      const pairId = [i.from_user_id, i.to_user_id].sort().join("|");
+      if (seenMutual.has(pairId)) continue;
+      seenMutual.add(pairId);
+      detail.push([
+        nameOf(i.from_user_id),
+        "↔",
+        nameOf(i.to_user_id),
+        "mutual",
+        i.we_match_notified_at ?? "—",
+        i.created_at,
+      ]);
+    } else {
+      detail.push([
+        nameOf(i.from_user_id),
+        "→",
+        nameOf(i.to_user_id),
+        "one-sided",
+        "—",
+        i.created_at,
+      ]);
+    }
+  }
+
+  const csv = toCsv([...summary, ...detail]);
+  const date = new Date().toISOString().split("T")[0];
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="ut-we-match-outcomes-${date}.csv"`,
+    },
+  });
+}

--- a/src/app/api/school/students/route.ts
+++ b/src/app/api/school/students/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireOrgAdmin } from "@/lib/auth/org-admin";
 
 export async function GET() {
-  const { sessionClaims } = await auth();
-
-  const orgId = sessionClaims?.metadata?.organization_id;
-  const isSchoolAdmin = sessionClaims?.metadata?.is_school_admin;
-
-  if (!orgId || !isSchoolAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  const { orgId } = auth;
 
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/src/app/school/[slug]/admin/layout.tsx
+++ b/src/app/school/[slug]/admin/layout.tsx
@@ -1,0 +1,40 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import { getVerifiedPrimaryEmail, isOrgAdmin } from "@/lib/auth/org-admin";
+
+async function getOrgBySlug(slug: string) {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+  const { data } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("slug", slug)
+    .single();
+  return data as { id: string } | null;
+}
+
+export default async function SchoolAdminLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const org = await getOrgBySlug(slug);
+  if (!org) notFound();
+
+  const { userId } = await auth();
+  if (!userId) notFound();
+
+  const email = await getVerifiedPrimaryEmail(userId);
+  if (!email) notFound();
+
+  const allowed = await isOrgAdmin({ orgId: org.id, email });
+  if (!allowed) notFound();
+
+  return <>{children}</>;
+}

--- a/src/app/school/[slug]/admin/page.tsx
+++ b/src/app/school/[slug]/admin/page.tsx
@@ -2,9 +2,22 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "@clerk/nextjs";
-import { FaUserGraduate, FaDownload, FaTrash, FaSync } from "react-icons/fa";
+import {
+  FaUserGraduate,
+  FaDownload,
+  FaTrash,
+  FaSync,
+  FaUsers,
+  FaChartBar,
+  FaFileCsv,
+  FaHeart,
+} from "react-icons/fa";
 import { FaShieldAlt } from "react-icons/fa";
 import toast from "react-hot-toast";
+import type { OrgConnection } from "@/app/api/school/connections/route";
+import { toCsv } from "@/lib/csv";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 type Student = {
   user_id: string;
@@ -19,16 +32,56 @@ type Student = {
   deleted_at: string | null;
 };
 
+type Analytics = {
+  total_signups: number;
+  active_last_7_days: number;
+  technical_count: number;
+  non_technical_count: number;
+  total_connections: number;
+  total_messages: number;
+};
+
+type Tab = "roster" | "connections" | "analytics" | "reports";
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4">
+      <p className="text-xs font-medium text-[var(--ui-text-muted)]">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-[var(--ui-text)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
 export default function SchoolAdminPage() {
   const { session } = useSession();
+  const [activeTab, setActiveTab] = useState<Tab>("roster");
+
   const [students, setStudents] = useState<Student[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [rosterLoading, setRosterLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const [connections, setConnections] = useState<OrgConnection[]>([]);
+  const [connectionsLoading, setConnectionsLoading] = useState(false);
+  const [connectionsFetched, setConnectionsFetched] = useState(false);
+
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
+  const [analyticsLoading, setAnalyticsLoading] = useState(false);
+  const [analyticsFetched, setAnalyticsFetched] = useState(false);
+
+  const [downloadingReport, setDownloadingReport] = useState<string | null>(
+    null,
+  );
 
   const fetchStudents = useCallback(async () => {
     if (!session) return;
+    setRosterLoading(true);
     try {
-      setIsLoading(true);
       const token = await session.getToken();
       const res = await fetch("/api/school/students", {
         headers: { Authorization: `Bearer ${token}` },
@@ -37,15 +90,64 @@ export default function SchoolAdminPage() {
       const data = await res.json();
       setStudents(data.students ?? []);
     } catch {
-      toast.error("Failed to load students. Admin access required.");
+      toast.error("Failed to load students.");
     } finally {
-      setIsLoading(false);
+      setRosterLoading(false);
+    }
+  }, [session]);
+
+  const fetchConnections = useCallback(async () => {
+    if (!session) return;
+    setConnectionsLoading(true);
+    try {
+      const token = await session.getToken();
+      const res = await fetch("/api/school/connections", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Forbidden");
+      const data = await res.json();
+      setConnections(data.connections ?? []);
+    } catch {
+      toast.error("Failed to load connections.");
+    } finally {
+      setConnectionsLoading(false);
+      setConnectionsFetched(true);
+    }
+  }, [session]);
+
+  const fetchAnalytics = useCallback(async () => {
+    if (!session) return;
+    setAnalyticsLoading(true);
+    try {
+      const token = await session.getToken();
+      const res = await fetch("/api/school/analytics", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Forbidden");
+      const data = await res.json();
+      setAnalytics(data);
+    } catch {
+      toast.error("Failed to load analytics.");
+    } finally {
+      setAnalyticsLoading(false);
+      setAnalyticsFetched(true);
     }
   }, [session]);
 
   useEffect(() => {
     fetchStudents();
   }, [fetchStudents]);
+
+  useEffect(() => {
+    if (activeTab === "connections" && !connectionsFetched) fetchConnections();
+    if (activeTab === "analytics" && !analyticsFetched) fetchAnalytics();
+  }, [
+    activeTab,
+    connectionsFetched,
+    analyticsFetched,
+    fetchConnections,
+    fetchAnalytics,
+  ]);
 
   const handleDelete = async (userId: string, name: string) => {
     if (
@@ -58,17 +160,11 @@ export default function SchoolAdminPage() {
     setDeletingId(userId);
     try {
       const token = await session?.getToken();
-      const res = await fetch("/api/delete-profile", {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ targetUserId: userId }),
-      });
-
+      const res = await fetch(
+        `/api/delete-profile?targetUserId=${encodeURIComponent(userId)}`,
+        { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+      );
       if (!res.ok) throw new Error("Delete failed");
-
       setStudents((prev) => prev.filter((s) => s.user_id !== userId));
       toast.success(`${name}'s account has been deleted.`);
     } catch {
@@ -90,23 +186,20 @@ export default function SchoolAdminPage() {
       "is_technical",
       "joined",
     ];
-
-    const rows = students.map((s) => [
-      s.user_id,
-      s.first_name,
-      s.last_name,
-      s.title ?? "",
-      s.education ?? "",
-      s.city,
-      s.country,
-      s.is_technical ? "yes" : "no",
-      new Date(s.created_at).toLocaleDateString(),
-    ]);
-
-    const csv = [headers, ...rows]
-      .map((r) => r.map((v) => `"${v}"`).join(","))
-      .join("\n");
-
+    const rows = students
+      .filter((s) => !s.deleted_at)
+      .map((s) => [
+        s.user_id,
+        s.first_name,
+        s.last_name,
+        s.title ?? "",
+        s.education ?? "",
+        s.city,
+        s.country,
+        s.is_technical ? "yes" : "no",
+        new Date(s.created_at).toLocaleDateString(),
+      ]);
+    const csv = toCsv([headers, ...rows]);
     const blob = new Blob([csv], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -116,136 +209,671 @@ export default function SchoolAdminPage() {
     URL.revokeObjectURL(url);
   };
 
+  // Authenticated blob download for the on-demand report endpoints (they
+  // require the Bearer token, so a plain <a href> won't work).
+  const downloadReport = async (path: string) => {
+    setDownloadingReport(path);
+    try {
+      const token = await session?.getToken();
+      const res = await fetch(path, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Export failed");
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        res
+          .headers
+          .get("Content-Disposition")
+          ?.match(/filename="(.+)"/)?.[1] ?? "report.csv";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error("Export failed.");
+    } finally {
+      setDownloadingReport(null);
+    }
+  };
+
   const activeStudents = students.filter((s) => !s.deleted_at);
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+    {
+      id: "roster",
+      label: "Roster",
+      icon: <FaUserGraduate className="h-3.5 w-3.5" />,
+    },
+    {
+      id: "connections",
+      label: "Connections",
+      icon: <FaUsers className="h-3.5 w-3.5" />,
+    },
+    {
+      id: "analytics",
+      label: "Analytics",
+      icon: <FaChartBar className="h-3.5 w-3.5" />,
+    },
+    {
+      id: "reports",
+      label: "Reports",
+      icon: <FaFileCsv className="h-3.5 w-3.5" />,
+    },
+  ];
 
   return (
     <div className="mx-auto max-w-5xl p-4 pt-6">
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <FaShieldAlt className="h-5 w-5 text-white/40" />
-          <h1 className="text-xl font-semibold text-(--mist-white)">
-            Student Admin
+          <FaShieldAlt
+            className="h-5 w-5"
+            style={{ color: "var(--ui-text-muted)" }}
+          />
+          <h1
+            className="text-xl font-semibold"
+            style={{ color: "var(--ui-text)" }}
+          >
+            Admin Dashboard
           </h1>
-          <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs text-white/50">
-            {activeStudents.length} active
-          </span>
         </div>
 
         <div className="flex items-center gap-2">
-          <button
-            onClick={fetchStudents}
-            className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/50 transition hover:border-white/20 hover:text-white/80"
-          >
-            <FaSync className="h-3 w-3" />
-            Refresh
-          </button>
-          <button
-            onClick={handleExportCSV}
-            disabled={students.length === 0}
-            className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/50 transition hover:border-white/20 hover:text-white/80 disabled:opacity-30"
-          >
-            <FaDownload className="h-3 w-3" />
-            Export CSV
-          </button>
+          {activeTab === "roster" && (
+            <>
+              <button
+                onClick={fetchStudents}
+                className="flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition"
+                style={{
+                  borderColor: "var(--ui-border-strong)",
+                  color: "var(--ui-text-muted)",
+                }}
+              >
+                <FaSync className="h-3 w-3" />
+                Refresh
+              </button>
+              <button
+                onClick={handleExportCSV}
+                disabled={activeStudents.length === 0}
+                className="flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition disabled:opacity-40"
+                style={{
+                  borderColor: "var(--ui-border-strong)",
+                  color: "var(--ui-text-muted)",
+                }}
+              >
+                <FaDownload className="h-3 w-3" />
+                Export CSV
+              </button>
+            </>
+          )}
+          {(activeTab === "connections" || activeTab === "analytics") && (
+            <button
+              onClick={
+                activeTab === "connections" ? fetchConnections : fetchAnalytics
+              }
+              className="flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition"
+              style={{
+                borderColor: "var(--ui-border-strong)",
+                color: "var(--ui-text-muted)",
+              }}
+            >
+              <FaSync className="h-3 w-3" />
+              Refresh
+            </button>
+          )}
         </div>
       </div>
 
       {/* FERPA notice */}
-      <div className="mb-5 rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-3 text-xs text-yellow-400/80">
+      <div className="mb-5 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
         <strong>FERPA Notice:</strong> Student data is protected under FERPA.
         Access is restricted to authorized school administrators. Do not share
         or redistribute student records.
       </div>
 
-      {/* Student table */}
-      {isLoading ? (
-        <div className="flex justify-center py-16">
-          <FaSync className="h-6 w-6 animate-spin text-white/20" />
-        </div>
-      ) : activeStudents.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 py-16 text-center">
-          <FaUserGraduate className="h-10 w-10 text-white/10" />
-          <p className="text-white/40">No students have joined yet.</p>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-xl border border-white/10">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-white/10 bg-white/5">
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-white/40">
-                  Student
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-white/40">
-                  Education
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-white/40">
-                  Location
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-white/40">
-                  Type
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-white/40">
-                  Joined
-                </th>
-                <th className="px-4 py-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {activeStudents.map((student, i) => (
-                <tr
-                  key={student.user_id}
-                  className={`border-b border-white/5 transition hover:bg-white/3 ${
-                    i % 2 === 0 ? "" : "bg-white/2"
-                  }`}
+      {/* Tabs */}
+      <div
+        className="mb-5 flex gap-1 rounded-xl border p-1"
+        style={{
+          borderColor: "var(--ui-border)",
+          backgroundColor: "var(--ui-surface)",
+        }}
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className="flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition"
+            style={
+              activeTab === tab.id
+                ? {
+                    backgroundColor: "var(--ui-surface-active)",
+                    color: "var(--ui-text)",
+                  }
+                : { color: "var(--ui-text-muted)" }
+            }
+          >
+            {tab.icon}
+            {tab.label}
+            {tab.id === "roster" && activeStudents.length > 0 && (
+              <span
+                className="rounded-full px-1.5 py-0.5 text-xs"
+                style={{
+                  backgroundColor: "var(--ui-surface-active)",
+                  color: "var(--ui-text-muted)",
+                }}
+              >
+                {activeStudents.length}
+              </span>
+            )}
+            {tab.id === "connections" && connections.length > 0 && (
+              <span
+                className="rounded-full px-1.5 py-0.5 text-xs"
+                style={{
+                  backgroundColor: "var(--ui-surface-active)",
+                  color: "var(--ui-text-muted)",
+                }}
+              >
+                {connections.length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Roster Tab ── */}
+      {activeTab === "roster" && (
+        <>
+          {rosterLoading ? (
+            <div className="flex justify-center py-16">
+              <FaSync
+                className="h-6 w-6 animate-spin"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+            </div>
+          ) : activeStudents.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <FaUserGraduate
+                className="h-10 w-10"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+              <p style={{ color: "var(--ui-text-muted)" }}>
+                No students have joined yet.
+              </p>
+            </div>
+          ) : (
+            <div
+              className="overflow-hidden rounded-xl border"
+              style={{ borderColor: "var(--ui-border)" }}
+            >
+              <table className="w-full text-sm">
+                <thead>
+                  <tr
+                    className="border-b"
+                    style={{
+                      borderColor: "var(--ui-border)",
+                      backgroundColor: "var(--ui-surface)",
+                    }}
+                  >
+                    {[
+                      "Student",
+                      "Education",
+                      "Location",
+                      "Type",
+                      "Joined",
+                      "",
+                    ].map((h) => (
+                      <th
+                        key={h}
+                        className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
+                        style={{ color: "var(--ui-text-muted)" }}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeStudents.map((student, i) => (
+                    <tr
+                      key={student.user_id}
+                      className="border-b transition"
+                      style={{
+                        borderColor: "var(--ui-border)",
+                        backgroundColor:
+                          i % 2 !== 0 ? "var(--ui-surface)" : undefined,
+                      }}
+                    >
+                      <td className="px-4 py-3">
+                        <div
+                          className="font-medium"
+                          style={{ color: "var(--ui-text)" }}
+                        >
+                          {student.first_name} {student.last_name}
+                        </div>
+                        {student.title && (
+                          <div
+                            className="text-xs"
+                            style={{ color: "var(--ui-text-muted)" }}
+                          >
+                            {student.title}
+                          </div>
+                        )}
+                      </td>
+                      <td
+                        className="px-4 py-3"
+                        style={{ color: "var(--ui-text-muted)" }}
+                      >
+                        {student.education ?? "—"}
+                      </td>
+                      <td
+                        className="px-4 py-3"
+                        style={{ color: "var(--ui-text-muted)" }}
+                      >
+                        {student.city}, {student.country}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${
+                            student.is_technical
+                              ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
+                              : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
+                          }`}
+                        >
+                          {student.is_technical ? "Technical" : "Non-technical"}
+                        </span>
+                      </td>
+                      <td
+                        className="px-4 py-3 text-xs"
+                        style={{ color: "var(--ui-text-subtle)" }}
+                      >
+                        {new Date(student.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() =>
+                            handleDelete(
+                              student.user_id,
+                              `${student.first_name} ${student.last_name}`,
+                            )
+                          }
+                          disabled={deletingId === student.user_id}
+                          className="cursor-pointer rounded p-1.5 transition hover:bg-red-500/15 hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed"
+                          style={{ color: "var(--ui-text-subtle)" }}
+                          title="Delete account"
+                        >
+                          <FaTrash className="h-3.5 w-3.5" />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ── Connections Tab ── */}
+      {activeTab === "connections" && (
+        <>
+          {connectionsLoading ? (
+            <div className="flex justify-center py-16">
+              <FaSync
+                className="h-6 w-6 animate-spin"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+            </div>
+          ) : connections.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <FaUsers
+                className="h-10 w-10"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+              <p style={{ color: "var(--ui-text-muted)" }}>
+                No connections yet.
+              </p>
+            </div>
+          ) : (
+            <div
+              className="overflow-hidden rounded-xl border"
+              style={{ borderColor: "var(--ui-border)" }}
+            >
+              <table className="w-full text-sm">
+                <thead>
+                  <tr
+                    className="border-b"
+                    style={{
+                      borderColor: "var(--ui-border)",
+                      backgroundColor: "var(--ui-surface)",
+                    }}
+                  >
+                    {[
+                      "User 1",
+                      "User 2",
+                      "Messages",
+                      "Connected",
+                      "Last Active",
+                    ].map((h) => (
+                      <th
+                        key={h}
+                        className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
+                        style={{ color: "var(--ui-text-muted)" }}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {connections.map((conn, i) => (
+                    <tr
+                      key={conn.conversation_id}
+                      className="border-b transition"
+                      style={{
+                        borderColor: "var(--ui-border)",
+                        backgroundColor:
+                          i % 2 !== 0 ? "var(--ui-surface)" : undefined,
+                      }}
+                    >
+                      <td className="px-4 py-3">
+                        <div
+                          className="font-medium"
+                          style={{ color: "var(--ui-text)" }}
+                        >
+                          {conn.user1.first_name} {conn.user1.last_name}
+                        </div>
+                        {conn.user1.title && (
+                          <div
+                            className="text-xs"
+                            style={{ color: "var(--ui-text-muted)" }}
+                          >
+                            {conn.user1.title}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div
+                          className="font-medium"
+                          style={{ color: "var(--ui-text)" }}
+                        >
+                          {conn.user2.first_name} {conn.user2.last_name}
+                        </div>
+                        {conn.user2.title && (
+                          <div
+                            className="text-xs"
+                            style={{ color: "var(--ui-text-muted)" }}
+                          >
+                            {conn.user2.title}
+                          </div>
+                        )}
+                      </td>
+                      <td
+                        className="px-4 py-3"
+                        style={{ color: "var(--ui-text-muted)" }}
+                      >
+                        {conn.message_count}
+                      </td>
+                      <td
+                        className="px-4 py-3 text-xs"
+                        style={{ color: "var(--ui-text-subtle)" }}
+                      >
+                        {new Date(conn.created_at).toLocaleDateString()}
+                      </td>
+                      <td
+                        className="px-4 py-3 text-xs"
+                        style={{ color: "var(--ui-text-subtle)" }}
+                      >
+                        {conn.last_message_at
+                          ? new Date(conn.last_message_at).toLocaleDateString()
+                          : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ── Analytics Tab ── */}
+      {activeTab === "analytics" && (
+        <>
+          {analyticsLoading ? (
+            <div className="flex justify-center py-16">
+              <FaSync
+                className="h-6 w-6 animate-spin"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+            </div>
+          ) : !analytics ? (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <FaChartBar
+                className="h-10 w-10"
+                style={{ color: "var(--ui-text-subtle)" }}
+              />
+              <p style={{ color: "var(--ui-text-muted)" }}>
+                No analytics data available.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <StatCard
+                  label="Total Signups"
+                  value={analytics.total_signups}
+                />
+                <StatCard
+                  label="Active (last 7 days)"
+                  value={analytics.active_last_7_days}
+                />
+                <StatCard
+                  label="Total Connections"
+                  value={analytics.total_connections}
+                />
+                <StatCard
+                  label="Total Messages"
+                  value={analytics.total_messages}
+                />
+                <StatCard
+                  label="Technical Founders"
+                  value={analytics.technical_count}
+                />
+                <StatCard
+                  label="Non-Technical Founders"
+                  value={analytics.non_technical_count}
+                />
+              </div>
+
+              {analytics.total_signups > 0 && (
+                <div
+                  className="rounded-xl border p-4"
+                  style={{
+                    borderColor: "var(--ui-border)",
+                    backgroundColor: "var(--ui-surface)",
+                  }}
                 >
-                  <td className="px-4 py-3">
-                    <div className="font-medium text-(--mist-white)">
-                      {student.first_name} {student.last_name}
-                    </div>
-                    {student.title && (
-                      <div className="text-xs text-white/40">{student.title}</div>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-white/60">
-                    {student.education ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-white/60">
-                    {student.city}, {student.country}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                        student.is_technical
-                          ? "bg-blue-500/10 text-blue-400"
-                          : "bg-purple-500/10 text-purple-400"
-                      }`}
-                    >
-                      {student.is_technical ? "Technical" : "Non-technical"}
+                  <p
+                    className="mb-3 text-xs font-medium"
+                    style={{ color: "var(--ui-text-muted)" }}
+                  >
+                    Technical split
+                  </p>
+                  <div
+                    className="flex h-2.5 overflow-hidden rounded-full"
+                    style={{ backgroundColor: "var(--ui-border)" }}
+                  >
+                    <div
+                      className="bg-blue-500 transition-all"
+                      style={{
+                        width: `${(analytics.technical_count / analytics.total_signups) * 100}%`,
+                      }}
+                    />
+                    <div
+                      className="bg-purple-500 transition-all"
+                      style={{
+                        width: `${(analytics.non_technical_count / analytics.total_signups) * 100}%`,
+                      }}
+                    />
+                  </div>
+                  <div
+                    className="mt-2.5 flex gap-4 text-xs"
+                    style={{ color: "var(--ui-text-muted)" }}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-blue-500" />
+                      Technical (
+                      {Math.round(
+                        (analytics.technical_count / analytics.total_signups) *
+                          100,
+                      )}
+                      %)
                     </span>
-                  </td>
-                  <td className="px-4 py-3 text-xs text-white/40">
-                    {new Date(student.created_at).toLocaleDateString()}
-                  </td>
-                  <td className="px-4 py-3">
-                    <button
-                      onClick={() =>
-                        handleDelete(
-                          student.user_id,
-                          `${student.first_name} ${student.last_name}`,
-                        )
-                      }
-                      disabled={deletingId === student.user_id}
-                      className="rounded p-1.5 text-white/20 transition hover:bg-red-500/10 hover:text-red-400 disabled:opacity-30"
-                      title="Delete account"
-                    >
-                      <FaTrash className="h-3.5 w-3.5" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block h-2 w-2 rounded-full bg-purple-500" />
+                      Non-technical (
+                      {Math.round(
+                        (analytics.non_technical_count /
+                          analytics.total_signups) *
+                          100,
+                      )}
+                      %)
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ── Reports Tab ── */}
+      {activeTab === "reports" && (
+        <div className="space-y-5">
+          <p className="text-sm" style={{ color: "var(--ui-text-muted)" }}>
+            Generate CSV snapshots of the current cohort and matching outcomes on
+            demand. Each export reflects live data at the moment you download it.
+          </p>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {/* Active cohort report */}
+            <div
+              className="flex flex-col rounded-xl border p-5"
+              style={{
+                borderColor: "var(--ui-border)",
+                backgroundColor: "var(--ui-surface)",
+              }}
+            >
+              <div
+                className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg"
+                style={{ backgroundColor: "var(--ui-surface-active)" }}
+              >
+                <FaUsers
+                  className="h-4 w-4"
+                  style={{ color: "var(--ui-text-muted)" }}
+                />
+              </div>
+              <h3
+                className="text-base font-semibold"
+                style={{ color: "var(--ui-text)" }}
+              >
+                Active cohort report
+              </h3>
+              <p
+                className="mt-1 text-sm"
+                style={{ color: "var(--ui-text-muted)" }}
+              >
+                Full snapshot of the current cohort. Includes:
+              </p>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {[
+                  "School",
+                  "Founder archetype",
+                  "Graduation year",
+                  "Industry / Interest",
+                  "Student or Alumni",
+                ].map((chip) => (
+                  <span
+                    key={chip}
+                    className="rounded-md px-2 py-1 text-xs font-medium"
+                    style={{
+                      backgroundColor: "var(--ui-surface-active)",
+                      color: "var(--ui-text-muted)",
+                    }}
+                  >
+                    {chip}
+                  </span>
+                ))}
+              </div>
+              <button
+                onClick={() => downloadReport("/api/school/reports/cohort")}
+                disabled={downloadingReport !== null}
+                className="mt-4 flex w-fit cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+                style={{
+                  backgroundColor: "var(--ui-btn-bg)",
+                  color: "var(--ui-btn-text)",
+                }}
+              >
+                {downloadingReport === "/api/school/reports/cohort" ? (
+                  <FaSync className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <FaDownload className="h-3.5 w-3.5" />
+                )}
+                Export CSV
+              </button>
+            </div>
+
+            {/* We Match outcomes */}
+            <div
+              className="flex flex-col rounded-xl border p-5"
+              style={{
+                borderColor: "var(--ui-border)",
+                backgroundColor: "var(--ui-surface)",
+              }}
+            >
+              <div
+                className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg"
+                style={{ backgroundColor: "var(--ui-surface-active)" }}
+              >
+                <FaHeart
+                  className="h-4 w-4"
+                  style={{ color: "var(--ui-text-muted)" }}
+                />
+              </div>
+              <h3
+                className="text-base font-semibold"
+                style={{ color: "var(--ui-text)" }}
+              >
+                We Match outcomes
+              </h3>
+              <p
+                className="mt-1 text-sm"
+                style={{ color: "var(--ui-text-muted)" }}
+              >
+                One-sided interest rate and mutual match rate. Core proof point.
+              </p>
+              <button
+                onClick={() =>
+                  downloadReport("/api/school/reports/match-outcomes")
+                }
+                disabled={downloadingReport !== null}
+                className="mt-auto flex w-fit cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+                style={{
+                  backgroundColor: "var(--ui-btn-bg)",
+                  color: "var(--ui-btn-text)",
+                }}
+              >
+                {downloadingReport === "/api/school/reports/match-outcomes" ? (
+                  <FaSync className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <FaDownload className="h-3.5 w-3.5" />
+                )}
+                Export CSV
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/school/[slug]/layout.tsx
+++ b/src/app/school/[slug]/layout.tsx
@@ -5,6 +5,7 @@ import OrgHeaderSwitch from "@/components/school/OrgHeaderSwitch";
 import { SchoolProvider } from "@/components/school/SchoolContext";
 import { getOrganizationBySlug } from "@/lib/organizations";
 import { getOrgConfig, DEFAULT_ORG_CONFIG } from "@/orgs/registry";
+import { getVerifiedPrimaryEmail, getOrgAdminEmails } from "@/lib/auth/org-admin";
 
 export async function generateMetadata({
   params,
@@ -31,7 +32,7 @@ export default async function SchoolSlugLayout({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const [{ userId }, org] = await Promise.all([
+  const [{ userId, sessionClaims }, org] = await Promise.all([
     auth(),
     getOrganizationBySlug(slug),
   ]);
@@ -41,6 +42,20 @@ export default async function SchoolSlugLayout({
   }
 
   const cfg = getOrgConfig(slug) ?? DEFAULT_ORG_CONFIG;
+
+  let isAdmin = false;
+  if (userId) {
+    const orgId = sessionClaims?.metadata?.organization_id as string | undefined;
+    if (orgId) {
+      const [email, adminEmails] = await Promise.all([
+        getVerifiedPrimaryEmail(userId),
+        getOrgAdminEmails(orgId),
+      ]);
+      if (email) {
+        isAdmin = adminEmails.includes(email.toLowerCase());
+      }
+    }
+  }
 
   return (
     <SchoolProvider slug={slug} schoolName={org.name} config={cfg}>
@@ -71,7 +86,7 @@ export default async function SchoolSlugLayout({
         }
         className="min-h-screen bg-[var(--org-bg)] text-[var(--org-text)]"
       >
-        <OrgHeaderSwitch slug={slug} schoolName={org.name} config={cfg} isSignedIn={!!userId} />
+        <OrgHeaderSwitch slug={slug} schoolName={org.name} config={cfg} isSignedIn={!!userId} isAdmin={isAdmin} />
         <main>{children}</main>
       </div>
     </SchoolProvider>

--- a/src/components/school/OrgHeaderSwitch.tsx
+++ b/src/components/school/OrgHeaderSwitch.tsx
@@ -7,11 +7,12 @@ type Props = {
   schoolName: string;
   config: OrgConfig;
   isSignedIn: boolean;
+  isAdmin: boolean;
 };
 
-export default function OrgHeaderSwitch({ slug, schoolName, config, isSignedIn }: Props) {
+export default function OrgHeaderSwitch({ slug, schoolName, config, isSignedIn, isAdmin }: Props) {
   if (isSignedIn) {
-    return <SchoolHeader slug={slug} schoolName={schoolName} config={config} />;
+    return <SchoolHeader slug={slug} schoolName={schoolName} config={config} isAdmin={isAdmin} />;
   }
   return <PublicSchoolHeader />;
 }

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -14,9 +14,10 @@ type SchoolHeaderProps = {
   slug: string;
   schoolName: string;
   config: OrgConfig;
+  isAdmin: boolean;
 };
 
-export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderProps) {
+export default function SchoolHeader({ slug, schoolName, config, isAdmin }: SchoolHeaderProps) {
   const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -52,6 +53,9 @@ export default function SchoolHeader({ slug, schoolName, config }: SchoolHeaderP
       href: "/privacy-policy",
       label: "Privacy Policy",
     },
+    ...(isAdmin
+      ? [{ href: `/school/${slug}/admin`, label: "Admin" }]
+      : []),
   ];
 
   const headerText = config.branding.wordmark ? `${config.branding.wordmark} Co-Foundr` : schoolName;

--- a/src/lib/auth/org-admin.ts
+++ b/src/lib/auth/org-admin.ts
@@ -1,0 +1,73 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+function supabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function getVerifiedPrimaryEmail(
+  userId: string,
+): Promise<string | null> {
+  try {
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const primary = user.emailAddresses.find(
+      (e) => e.id === user.primaryEmailAddressId,
+    );
+    if (!primary || primary.verification?.status !== "verified") return null;
+    return primary.emailAddress.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export async function getOrgAdminEmails(orgId: string): Promise<string[]> {
+  const supabase = supabaseAdmin();
+  const { data } = await supabase
+    .from("organizations")
+    .select("settings")
+    .eq("id", orgId)
+    .single();
+  const emails: string[] = data?.settings?.admin_emails ?? [];
+  return emails.map((e) => e.trim().toLowerCase());
+}
+
+export async function isOrgAdmin({
+  orgId,
+  email,
+}: {
+  orgId: string;
+  email: string;
+}): Promise<boolean> {
+  const adminEmails = await getOrgAdminEmails(orgId);
+  return adminEmails.includes(email.toLowerCase());
+}
+
+/**
+ * Server-side guard for org-admin API routes.
+ * Returns { userId, orgId, email } on success, or a NextResponse (401/403) to return early.
+ */
+export async function requireOrgAdmin(): Promise<
+  { userId: string; orgId: string; email: string } | NextResponse
+> {
+  const { userId, sessionClaims } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const orgId = sessionClaims?.metadata?.organization_id as string | undefined;
+  if (!orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const email = await getVerifiedPrimaryEmail(userId);
+  if (!email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!(await isOrgAdmin({ orgId, email }))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return { userId, orgId, email };
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,22 @@
+/**
+ * Serialize a 2D array of cells into a CSV string.
+ *
+ * Every cell is wrapped in double quotes and any embedded double quotes are
+ * escaped (`"` → `""`), so values containing commas, quotes, or newlines stay
+ * intact. Rows are joined with CRLF for maximum spreadsheet compatibility.
+ *
+ * Shared by the admin roster export and the on-demand report endpoints so all
+ * CSVs quote identically.
+ */
+export function toCsv(rows: (string | number | null | undefined)[][]): string {
+  return rows
+    .map((row) =>
+      row
+        .map((cell) => {
+          const value = cell == null ? "" : String(cell);
+          return `"${value.replace(/"/g, '""')}"`;
+        })
+        .join(","),
+    )
+    .join("\r\n");
+}

--- a/supabase/migrations/20260602000001_seed_ut_admin_emails.sql
+++ b/supabase/migrations/20260602000001_seed_ut_admin_emails.sql
@@ -1,0 +1,12 @@
+-- Seed admin email addresses for the UT Austin organization.
+-- These users will have access to /school/ut/admin (and ut.mamuncofoundr.com/admin).
+-- Emails must match verified Clerk primary email addresses.
+-- Add or remove emails by editing the JSON array and re-running this migration.
+
+UPDATE organizations
+SET settings = jsonb_set(
+  COALESCE(settings, '{}'::jsonb),
+  '{admin_emails}',
+  '["admin@mamuncofoundr.com"]'::jsonb
+)
+WHERE slug = 'ut';


### PR DESCRIPTION
# MCFM-116 | Admin Dashboard + Email-Based Org Admin Authorization 

<img width="1271" height="768" alt="Screenshot 2026-06-02 at 1 59 01 PM" src="https://github.com/user-attachments/assets/3cdaaf4c-60cd-4f72-9af0-5f520daf5c59" />

## Summary
Adds a per-organization admin dashboard for school tenants (e.g. UT at
`ut.mamuncofoundr.com/admin`), with email-based authorization enforced on both the
page and every backing endpoint. Includes a "Manual report pulls" section for
on-demand CSV snapshots.

## Authorization
- New `src/lib/auth/org-admin.ts` — single server-side choke point:
  - `getVerifiedPrimaryEmail` (only verified Clerk primary emails)
  - admin list sourced from `organizations.settings.admin_emails` (jsonb, no redeploy
    to edit; swappable to a dedicated table later)
  - `requireOrgAdmin()` API guard → 401/403, returns `{ userId, orgId, email }`
- Defense in depth: server `layout.tsx` gate (`notFound()` for non-admins) **and**
  API-level guards on every endpoint.
- Migration `20260602000001_seed_ut_admin_emails.sql` seeds UT admin emails.

## Dashboard (`/school/[slug]/admin`)
Four tabs, themed via semantic CSS tokens (works in UT light theme + dark orgs):
- **Roster** — student table with CSV export + admin delete
- **Connections** — org-scoped conversations w/ message counts
- **Analytics** — signups, active users, technical split, connections/messages
- **Reports** — two on-demand CSV exports:
  - *Active cohort report* — name, email (Clerk), school, founder archetype,
    graduation year, industry/interest, student/alumni
  - *We Match outcomes* — one-sided interest rate + mutual match rate (from
    `match_intents`), with per-pair detail

## API endpoints (all org-scoped + `requireOrgAdmin`)
- `GET /api/school/students` — migrated off Clerk-metadata flag to `requireOrgAdmin`
- `GET /api/school/connections`, `GET /api/school/analytics`
- `GET /api/school/reports/cohort`, `GET /api/school/reports/match-outcomes` (CSV)
- `DELETE /api/delete-profile?targetUserId=` — admin can delete only same-org users

## Other
- Conditional **Admin** link in `SchoolHeader` (desktop nav + mobile hamburger),
  gated server-side.
- Shared `src/lib/csv.ts` `toCsv()` helper (roster + report exports quote identically).
- UI polish: `cursor-pointer` on all dashboard buttons; fixed wrapped technical/
  non-technical pill rendering.

## Verification
`npx tsc --noEmit` and `npm run build` pass. Endpoints return 401 (unauth) / 403
(non-admin) / 200 (admin); responses are org-isolated.

## Follow-up
Populate `20260602000001_seed_ut_admin_emails.sql` with the real UT admin emails
before applying.
