### PR TITLE
MCFM-122 | UT Edit Profile + Onboarding Consistency

### DIFF
--- a/src/app/api/ut-profile/route.ts
+++ b/src/app/api/ut-profile/route.ts
@@ -4,7 +4,50 @@ import { createClient } from "@supabase/supabase-js";
 import {
   mapOnboardingDatatoProfileDB,
   mapUTDataToSchoolProfileRow,
+  mapProfileToOnboardingData,
+  mapSchoolProfileToUTData,
 } from "@/lib/mapProfileToFromDBFormat";
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const { data: profileRow, error: profileError } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("user_id", userId)
+      .is("deleted_at", null)
+      .single();
+
+    if (profileError || !profileRow) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+
+    const { data: schoolRow } = await supabase
+      .from("school_profiles")
+      .select("*")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    const profile: OnboardingData = {
+      ...mapProfileToOnboardingData(profileRow),
+      ...(schoolRow ? mapSchoolProfileToUTData(schoolRow) : {}),
+    };
+
+    return NextResponse.json({ profile });
+  } catch (error) {
+    console.error("Error in UT profile GET:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/onboarding/form-components/UTAboutYouForm.tsx
+++ b/src/app/onboarding/form-components/UTAboutYouForm.tsx
@@ -5,13 +5,7 @@ import { useForm } from "react-hook-form";
 import FormInput from "@/components/ui/FormInput";
 import LocationSelector from "@/components/ui/LocationSelector";
 import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
-import {
-  UT_SCHOOLS_AND_PROGRAMS,
-  getDegreeTypesForSchool,
-  getProgramsForSchoolAndDegreeType,
-  DEGREE_TYPE_LABELS,
-  SECTOR_INTEREST_LABELS,
-} from "@/lib/utSchoolsAndMajors";
+import UTSchoolFields from "@/app/onboarding/form-components/UTSchoolFields";
 
 type UTAboutYouData = {
   firstName: string;
@@ -82,18 +76,6 @@ function UTAboutYouForm({
   const personalIntroValue = watch("personalIntro") || "";
   const archetypeValue = watch("archetype");
   const isTechnicalValue = watch("isTechnical");
-  const utStatusValue = watch("utStatus");
-  const utCollegeValue = watch("utCollege");
-  const utDegreeTypeValue = watch("utDegreeType");
-  const utSectorInterestsValue = watch("utSectorInterests") || [];
-
-  const availableDegreeTypes = utCollegeValue
-    ? getDegreeTypesForSchool(utCollegeValue)
-    : [];
-
-  const availablePrograms = utCollegeValue && utDegreeTypeValue
-    ? getProgramsForSchoolAndDegreeType(utCollegeValue, utDegreeTypeValue)
-    : [];
 
   useEffect(() => {
     if (defaultValues) reset(defaultValues);
@@ -181,168 +163,13 @@ function UTAboutYouForm({
           />
         </div>
 
-        {/* ── Student or Alumni ── */}
-        <div className="flex flex-col gap-y-3">
-          <label className={LABEL_CLS}>Are you a student or alumni? *</label>
-          <div className="flex gap-x-3">
-            {(["student", "alumni"] as const).map((val) => (
-              <label
-                key={val}
-                className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
-                  utStatusValue === val
-                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
-                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
-                }`}
-              >
-                <input
-                  type="radio"
-                  value={val}
-                  {...register("utStatus", { required: true })}
-                  className="sr-only"
-                />
-                {val === "student" ? "Student" : "Alumni"}
-              </label>
-            ))}
-          </div>
-          {errors.utStatus && (
-            <p className="text-xs text-red-400">Please select an option</p>
-          )}
-        </div>
-
-        {/* ── Education (UT-specific) ── */}
-        <div className="flex flex-col gap-y-5">
-          {/* School Selection */}
-          <div className="flex flex-col gap-y-1.5">
-            <label className={LABEL_CLS}>UT College / School *</label>
-            <select
-              {...register("utCollege")}
-              className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
-            >
-              <option value="">Select a school...</option>
-              {Object.entries(UT_SCHOOLS_AND_PROGRAMS).map(([key, school]) => (
-                <option key={key} value={key}>
-                  {school.label}
-                </option>
-              ))}
-            </select>
-            {errors.utCollege && (
-              <p className="text-xs text-red-400">School is required</p>
-            )}
-          </div>
-
-          {/* Degree Type Selection (conditional) */}
-          {utCollegeValue && (
-            <div className="flex flex-col gap-y-1.5">
-              <label className={LABEL_CLS}>Degree Type *</label>
-              <select
-                {...register("utDegreeType")}
-                className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
-              >
-                <option value="">Select a degree type...</option>
-                {availableDegreeTypes.map((degreeType) => (
-                  <option key={degreeType} value={degreeType}>
-                    {DEGREE_TYPE_LABELS[degreeType]}
-                  </option>
-                ))}
-              </select>
-              {errors.utDegreeType && (
-                <p className="text-xs text-red-400">Degree type is required</p>
-              )}
-            </div>
-          )}
-
-          {/* Major Selection (conditional) */}
-          {utCollegeValue && utDegreeTypeValue && (
-            <div className="flex flex-col gap-y-1.5">
-              <label className={LABEL_CLS}>Program / Major *</label>
-              <select
-                {...register("utMajor")}
-                className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]"
-              >
-                <option value="">Select a program...</option>
-                {availablePrograms.map((program) => (
-                  <option key={program.name} value={program.name}>
-                    {program.name}
-                  </option>
-                ))}
-              </select>
-              {errors.utMajor && (
-                <p className="text-xs text-red-400">Program is required</p>
-              )}
-            </div>
-          )}
-
-          {/* Sector Interests (conditional) */}
-          {utCollegeValue && (
-            <div className="flex flex-col gap-y-3">
-              <label className={LABEL_CLS}>Areas of Interest</label>
-              <p className="text-xs text-[var(--ui-text-muted)]">
-                Select relevant sectors aligned with your program
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {UT_SCHOOLS_AND_PROGRAMS[utCollegeValue].sectorInterests.map(
-                  (sector) => (
-                    <label
-                      key={sector}
-                      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-all duration-150 ${
-                        utSectorInterestsValue.includes(sector)
-                          ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
-                          : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)]"
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        value={sector}
-                        checked={utSectorInterestsValue.includes(sector)}
-                        onChange={(e) => {
-                          const newValue = e.target.checked
-                            ? [...utSectorInterestsValue, sector as UTSectorInterest]
-                            : utSectorInterestsValue.filter((s) => s !== sector);
-                          setValue("utSectorInterests", newValue);
-                        }}
-                        className="sr-only"
-                      />
-                      <span>{SECTOR_INTEREST_LABELS[sector]}</span>
-                    </label>
-                  ),
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Graduation Year */}
-          <div className="flex flex-col gap-y-1.5">
-            <label className={LABEL_CLS}>Graduation Year</label>
-            <FormInput
-              type="number"
-              placeholder="e.g. 2026"
-              {...register("gradYear", {
-                valueAsNumber: true,
-                min: { value: 1900, message: "Invalid year" },
-                max: { value: 2035, message: "Invalid year" },
-              })}
-            />
-            {errors.gradYear && (
-              <p className="text-xs text-red-400">{errors.gradYear.message}</p>
-            )}
-          </div>
-
-          {/* Additional Education */}
-          <div className="flex flex-col gap-y-1.5">
-            <label className={LABEL_CLS}>
-              Additional Education
-              <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
-                (optional)
-              </span>
-            </label>
-            <textarea
-              {...register("additionalEducation")}
-              className={TEXTAREA_CLS}
-              rows={2}
-              placeholder="Other degrees or institutions (e.g. Austin Community College, BS Computer Science)"
-            />
-          </div>
-        </div>
+        {/* ── School Details (UT-specific) ── */}
+        <UTSchoolFields
+          register={register}
+          watch={watch}
+          setValue={setValue}
+          errors={errors}
+        />
 
         {/* ── Work Experience ── */}
         <div className="flex flex-col gap-y-1.5">

--- a/src/app/onboarding/form-components/UTBackgroundAndSocialsForm.tsx
+++ b/src/app/onboarding/form-components/UTBackgroundAndSocialsForm.tsx
@@ -6,7 +6,6 @@ import FormInput from "@/components/ui/FormInput";
 import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
 
 type UTBackgroundAndSocialsData = {
-  schedulingUrl?: string;
   linkedin?: string;
   git?: string;
 };
@@ -46,36 +45,12 @@ function UTBackgroundAndSocialsForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 4 of 6
+            Step 4 of 5
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">Additional details</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
             All fields are optional — add what feels relevant.
           </p>
-        </div>
-
-        {/* ── Scheduling ── */}
-        <div className="flex flex-col gap-y-1.5">
-          <label className={LABEL_CLS}>
-            Scheduling Link
-            <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
-              (Calendly, Cal.com…)
-            </span>
-          </label>
-          <FormInput
-            {...register("schedulingUrl")}
-            type="url"
-            placeholder="https://calendly.com/your-link"
-          />
-        </div>
-
-        {/* ── Section break ── */}
-        <div className="flex items-center gap-3">
-          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
-          <span className="text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
-            Socials
-          </span>
-          <div className="h-px flex-1 bg-[var(--ui-surface)]" />
         </div>
 
         {/* ── Social links ── */}

--- a/src/app/onboarding/form-components/UTReviewForm.tsx
+++ b/src/app/onboarding/form-components/UTReviewForm.tsx
@@ -30,7 +30,7 @@ export default function UTReviewForm({
       {/* Header */}
       <div className="pb-4">
         <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-          Step 6 of 6
+          Step 5 of 5
         </p>
         <h2 className="text-2xl font-bold text-[var(--ui-text)]">Review your info</h2>
         <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/app/onboarding/form-components/UTSchoolFields.tsx
+++ b/src/app/onboarding/form-components/UTSchoolFields.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import {
+  UseFormRegister,
+  UseFormWatch,
+  UseFormSetValue,
+  FieldErrors,
+  FieldValues,
+} from "react-hook-form";
+import FormInput from "@/components/ui/FormInput";
+import {
+  UT_SCHOOLS_AND_PROGRAMS,
+  getDegreeTypesForSchool,
+  getProgramsForSchoolAndDegreeType,
+  DEGREE_TYPE_LABELS,
+  SECTOR_INTEREST_LABELS,
+} from "@/lib/utSchoolsAndMajors";
+
+const LABEL_CLS =
+  "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
+
+const SELECT_CLS =
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]";
+
+type UTSchoolFieldsData = {
+  utStatus: "student" | "alumni";
+  gradYear?: number;
+  utCollege?: UTCollege;
+  utDegreeType?: UTDegreeType;
+  utMajor?: string;
+  utSectorInterests?: UTSectorInterest[];
+  additionalEducation?: string;
+};
+
+type Props<T extends FieldValues> = {
+  register: UseFormRegister<T>;
+  watch: UseFormWatch<T>;
+  setValue: UseFormSetValue<T>;
+  errors: FieldErrors<T>;
+};
+
+export default function UTSchoolFields<T extends FieldValues>({ register, watch, setValue, errors }: Props<T>) {
+  const reg = register as unknown as UseFormRegister<UTSchoolFieldsData>;
+  const w = watch as unknown as UseFormWatch<UTSchoolFieldsData>;
+  const sv = setValue as unknown as UseFormSetValue<UTSchoolFieldsData>;
+  const errs = errors as unknown as FieldErrors<UTSchoolFieldsData>;
+
+  const utStatusValue = w("utStatus");
+  const utCollegeValue = w("utCollege");
+  const utDegreeTypeValue = w("utDegreeType");
+  const utSectorInterestsValue = w("utSectorInterests") || [];
+
+  const availableDegreeTypes = utCollegeValue ? getDegreeTypesForSchool(utCollegeValue) : [];
+  const availablePrograms =
+    utCollegeValue && utDegreeTypeValue
+      ? getProgramsForSchoolAndDegreeType(utCollegeValue, utDegreeTypeValue)
+      : [];
+
+  return (
+    <>
+      {/* ── Student or Alumni ── */}
+      <div className="flex flex-col gap-y-3">
+        <label className={LABEL_CLS}>Are you a student or alumni? *</label>
+        <div className="flex gap-x-3">
+          {(["student", "alumni"] as const).map((val) => (
+            <label
+              key={val}
+              className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                utStatusValue === val
+                  ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                  : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+              }`}
+            >
+              <input
+                type="radio"
+                value={val}
+                {...reg("utStatus", { required: true })}
+                className="sr-only"
+              />
+              {val === "student" ? "Student" : "Alumni"}
+            </label>
+          ))}
+        </div>
+        {errs.utStatus && (
+          <p className="text-xs text-red-400">Please select an option</p>
+        )}
+      </div>
+
+      {/* ── UT College Selection ── */}
+      <div className="flex flex-col gap-y-1.5">
+        <label className={LABEL_CLS}>UT College / School *</label>
+        <select
+          {...reg("utCollege")}
+          className={SELECT_CLS}
+          onChange={(e) => {
+            sv("utCollege", e.target.value as UTCollege);
+            sv("utDegreeType", undefined);
+            sv("utMajor", undefined);
+            sv("utSectorInterests", []);
+          }}
+        >
+          <option value="">Select a school...</option>
+          {Object.entries(UT_SCHOOLS_AND_PROGRAMS).map(([key, school]) => (
+            <option key={key} value={key}>
+              {school.label}
+            </option>
+          ))}
+        </select>
+        {errs.utCollege && (
+          <p className="text-xs text-red-400">School is required</p>
+        )}
+      </div>
+
+      {/* ── Degree Type (conditional) ── */}
+      {utCollegeValue && (
+        <div className="flex flex-col gap-y-1.5">
+          <label className={LABEL_CLS}>Degree Type</label>
+          <select
+            {...reg("utDegreeType")}
+            className={SELECT_CLS}
+            onChange={(e) => {
+              sv("utDegreeType", e.target.value as UTDegreeType);
+              sv("utMajor", undefined);
+            }}
+          >
+            <option value="">Select a degree type...</option>
+            {availableDegreeTypes.map((degreeType) => (
+              <option key={degreeType} value={degreeType}>
+                {DEGREE_TYPE_LABELS[degreeType]}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* ── Major (conditional) ── */}
+      {utCollegeValue && utDegreeTypeValue && (
+        <div className="flex flex-col gap-y-1.5">
+          <label className={LABEL_CLS}>Program / Major</label>
+          <select {...reg("utMajor")} className={SELECT_CLS}>
+            <option value="">Select a program...</option>
+            {availablePrograms.map((program) => (
+              <option key={program.name} value={program.name}>
+                {program.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* ── Sector Interests (conditional) ── */}
+      {utCollegeValue && (
+        <div className="flex flex-col gap-y-3">
+          <label className={LABEL_CLS}>Areas of Interest</label>
+          <p className="text-xs text-[var(--ui-text-muted)]">
+            Select relevant sectors aligned with your program
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {UT_SCHOOLS_AND_PROGRAMS[utCollegeValue].sectorInterests.map((sector) => (
+              <label
+                key={sector}
+                className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-all duration-150 ${
+                  utSectorInterestsValue.includes(sector)
+                    ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                    : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)]"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  value={sector}
+                  checked={utSectorInterestsValue.includes(sector)}
+                  onChange={(e) => {
+                    const newValue = e.target.checked
+                      ? [...utSectorInterestsValue, sector as UTSectorInterest]
+                      : utSectorInterestsValue.filter((s) => s !== sector);
+                    sv("utSectorInterests", newValue);
+                  }}
+                  className="sr-only"
+                />
+                <span>{SECTOR_INTEREST_LABELS[sector]}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Graduation Year ── */}
+      <div className="flex flex-col gap-y-1.5">
+        <label className={LABEL_CLS}>Graduation Year</label>
+        <FormInput
+          type="number"
+          placeholder="e.g. 2026"
+          {...reg("gradYear", {
+            valueAsNumber: true,
+            min: { value: 1900, message: "Invalid year" },
+            max: { value: 2035, message: "Invalid year" },
+          })}
+        />
+        {errs.gradYear && (
+          <p className="text-xs text-red-400">{errs.gradYear.message}</p>
+        )}
+      </div>
+
+      {/* ── Additional Education ── */}
+      <div className="flex flex-col gap-y-1.5">
+        <label className={LABEL_CLS}>
+          Additional Education
+          <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
+            (optional)
+          </span>
+        </label>
+        <textarea
+          {...reg("additionalEducation")}
+          className="w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none"
+          rows={2}
+          placeholder="Other degrees or institutions (e.g. Austin Community College, BS Computer Science)"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/app/onboarding/form-components/UTStartupForm.tsx
+++ b/src/app/onboarding/form-components/UTStartupForm.tsx
@@ -8,12 +8,12 @@ import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
 
 type UTStartupFormData = {
   hasStartup: "yes" | "no";
+  intent: "join_me" | "seeking_to_join" | "no_preference";
   startupName?: string;
   startupDescription?: string;
   startupTimeSpent?: string;
   startupFunding?: string;
   coFounderStatus?: string;
-  intent?: "join_me" | "seeking_to_join" | "no_preference";
   equityExpectation?: number;
 };
 
@@ -101,6 +101,49 @@ function UTStartupForm({
           </div>
           {errors.hasStartup && (
             <p className="text-xs text-red-400">This field is required</p>
+          )}
+        </div>
+
+        {/* ── Co-Founder Matching Intent (always shown) ── */}
+        <div className="flex flex-col gap-y-3">
+          <label className={LABEL_CLS}>Co-Founder Matching Intent *</label>
+          <div className="flex flex-col gap-y-2">
+            {[
+              {
+                value: "join_me" as const,
+                label: "Join me — I have a startup/idea",
+              },
+              {
+                value: "seeking_to_join" as const,
+                label: "Seeking to join — I want to join someone else's project",
+              },
+              {
+                value: "no_preference" as const,
+                label: "No preference — open to either",
+              },
+            ].map(({ value, label }) => (
+              <label key={value} className={PILL_RADIO_CLS}>
+                <input
+                  type="radio"
+                  value={value}
+                  {...register("intent", {
+                    required: "Please select your matching intent",
+                  })}
+                  className="sr-only"
+                />
+                <span
+                  className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                    watch("intent") === value
+                      ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                      : "border-[var(--ui-border-strong)] bg-transparent"
+                  }`}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+          {errors.intent && (
+            <p className="text-xs text-red-400">{errors.intent.message}</p>
           )}
         </div>
 
@@ -200,49 +243,6 @@ function UTStartupForm({
               </div>
               {errors.coFounderStatus && (
                 <p className="text-xs text-red-400">{errors.coFounderStatus.message}</p>
-              )}
-            </div>
-
-            {/* ── Co-founder intent ── */}
-            <div className="flex flex-col gap-y-3">
-              <label className={LABEL_CLS}>Co-Founder Matching Intent *</label>
-              <div className="flex flex-col gap-y-2">
-                {[
-                  {
-                    value: "join_me" as const,
-                    label: "Join me — I have a startup/idea",
-                  },
-                  {
-                    value: "seeking_to_join" as const,
-                    label: "Seeking to join — I want to join someone else's project",
-                  },
-                  {
-                    value: "no_preference" as const,
-                    label: "No preference — open to either",
-                  },
-                ].map(({ value, label }) => (
-                  <label key={value} className={PILL_RADIO_CLS}>
-                    <input
-                      type="radio"
-                      value={value}
-                      {...register("intent", {
-                        required: "Please select your matching intent",
-                      })}
-                      className="sr-only"
-                    />
-                    <span
-                      className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
-                        watch("intent") === value
-                          ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
-                          : "border-[var(--ui-border-strong)] bg-transparent"
-                      }`}
-                    />
-                    {label}
-                  </label>
-                ))}
-              </div>
-              {errors.intent && (
-                <p className="text-xs text-red-400">{errors.intent.message}</p>
               )}
             </div>
 

--- a/src/app/school/[slug]/onboarding/page.tsx
+++ b/src/app/school/[slug]/onboarding/page.tsx
@@ -15,14 +15,13 @@ import ReviewForm from "@/app/onboarding/form-components/ReviewForm";
 import UTAboutYouForm from "@/app/onboarding/form-components/UTAboutYouForm";
 import UTStartupForm from "@/app/onboarding/form-components/UTStartupForm";
 import UTBackgroundAndSocialsForm from "@/app/onboarding/form-components/UTBackgroundAndSocialsForm";
-import UTInterestsForm from "@/app/onboarding/form-components/UTInterestsForm";
 import UTReviewForm from "@/app/onboarding/form-components/UTReviewForm";
 import OnboardingProgressBar from "@/components/ui/OnboardingProgressBar";
 import { useStepTransition } from "@/hooks/useOnboardingAnimation";
 import { useOnboardingDraft } from "@/hooks/useOnboardingDraft";
 import { useSchool } from "@/components/school/SchoolContext";
 
-const TOTAL_STEPS = 6;
+const TOTAL_STEPS = 5;
 
 function getCompletedSteps(
   data: OnboardingData,
@@ -44,13 +43,14 @@ function getCompletedSteps(
 
   if (isUT) {
     if (step2BaseFields && data.utStatus) completed.add(2);
-    // Step 3: Startup details (has startup field required)
+    // Step 3: intent is always required; startup details only when hasStartup=yes
     if (
-      data.hasStartup === "no" ||
-      (data.hasStartup === "yes" &&
-        data.coFounderStatus !== undefined &&
-        data.intent !== undefined &&
-        data.equityExpectation !== undefined)
+      data.hasStartup !== undefined &&
+      data.intent !== undefined &&
+      (data.hasStartup === "no" ||
+        (data.hasStartup === "yes" &&
+          data.coFounderStatus !== undefined &&
+          data.equityExpectation !== undefined))
     ) {
       completed.add(3);
     }
@@ -271,22 +271,14 @@ export default function SchoolOnboardingPage({
             />
           )
         )}
-        {stepNumber === 5 && (
-          isUT ? (
-            <UTInterestsForm
-              onBack={handleBack}
-              onNext={(newData) => advanceStep(newData, 6)}
-              defaultValues={formData}
-            />
-          ) : (
-            <InterestsAndValuesForm
-              onBack={handleBack}
-              onNext={(newData) => advanceStep(newData, 5)}
-              defaultValues={formData}
-            />
-          )
+        {stepNumber === 5 && !isUT && (
+          <InterestsAndValuesForm
+            onBack={handleBack}
+            onNext={(newData) => advanceStep(newData, 5)}
+            defaultValues={formData}
+          />
         )}
-        {stepNumber === 6 && isUT && (
+        {stepNumber === 5 && isUT && (
           <UTReviewForm
             data={formData}
             onBack={handleBack}

--- a/src/app/school/[slug]/profile/page.tsx
+++ b/src/app/school/[slug]/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { use, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import dynamic from "next/dynamic";
 import Image from "next/image";
@@ -10,11 +10,16 @@ import { useRouter } from "next/navigation";
 import { FaArrowLeft } from "react-icons/fa6";
 import toast from "react-hot-toast";
 
-import { useProfileUpsert, useUserProfile } from "@/features/profile/useProfile";
+import {
+  useSchoolProfile,
+  useSchoolProfileUpsert,
+  useUserProfile,
+  useProfileUpsert,
+} from "@/features/profile/useProfile";
 import { useSchool } from "@/components/school/SchoolContext";
 import FormInput from "@/components/ui/FormInput";
-import AIWriter from "@/components/ui/AIWriter";
 import LocationSelector from "@/components/ui/LocationSelector";
+import UTSchoolFields from "@/app/onboarding/form-components/UTSchoolFields";
 import { trackEvent } from "@/lib/posthog-events";
 
 const FaceDetectionUploader = dynamic(
@@ -29,19 +34,8 @@ const FaceDetectionUploader = dynamic(
           fill="none"
           viewBox="0 0 24 24"
         >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
         </svg>
         Loading AI model…
       </div>
@@ -49,12 +43,35 @@ const FaceDetectionUploader = dynamic(
   },
 );
 
-export default function SchoolProfilePage() {
-  const { slug, schoolName } = useSchool();
+const CHAR_LIMIT = 500;
+
+const PILL_RADIO_CLS =
+  "flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all duration-150 hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)] has-[:checked]:text-[var(--ui-text)]";
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  return (
+    <p className={`text-right text-xs ${(value?.length ?? 0) > max - 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"}`}>
+      {value?.length ?? 0} / {max}
+    </p>
+  );
+}
+
+export default function SchoolProfilePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params);
+  const isUT = slug === "ut";
+
+  const { schoolName } = useSchool();
   const router = useRouter();
   const { session } = useSession();
-  const { data: profileData, isLoading, isError, error } = useUserProfile();
-  const { mutateAsync: upsertProfile } = useProfileUpsert();
+
+  // Use UT hooks when on the UT school; fall back to general hooks for other schools
+  const utProfile = useSchoolProfile();
+  const generalProfile = useUserProfile();
+  const { data: profileData, isLoading, isError, error } = isUT ? utProfile : generalProfile;
+
+  const utUpsert = useSchoolProfileUpsert();
+  const generalUpsert = useProfileUpsert();
+  const { mutateAsync: upsertProfile } = isUT ? utUpsert : generalUpsert;
 
   const [validatedPhotoFile, setValidatedPhotoFile] = useState<File | null>(null);
   const [photoError, setPhotoError] = useState<string | null>(null);
@@ -74,13 +91,13 @@ export default function SchoolProfilePage() {
     if (profileData) reset(profileData);
   }, [profileData, reset]);
 
-  const titleValue = watch("title") || "";
-  const educationValue = watch("education") || "";
   const experienceValue = watch("experience") || "";
   const personalIntroValue = watch("personalIntro") || "";
-  const accomplishmentsValue = watch("accomplishments") || "";
-  const interestsValue = watch("interests") || "";
-  const hobbiesValue = watch("hobbies") || "";
+  const archetypeValue = watch("archetype");
+  const isTechnicalValue = watch("isTechnical");
+  const hasStartupValue = watch("hasStartup");
+  const intentValue = watch("intent");
+  const coFounderStatusValue = watch("coFounderStatus");
 
   const onSubmit = async (formData: Partial<OnboardingData>) => {
     if (!profileData?.pfp_url) {
@@ -89,7 +106,7 @@ export default function SchoolProfilePage() {
       return;
     }
     try {
-      await upsertProfile(formData);
+      await upsertProfile(formData as OnboardingData);
       trackEvent.profileUpdated({
         city: formData.city,
         country: formData.country,
@@ -98,7 +115,6 @@ export default function SchoolProfilePage() {
         battery_level: formData.batteryLevel,
         satisfaction: formData.satisfaction,
       });
-      toast.success("Profile saved!");
       router.push(`/school/${slug}/dashboard`);
     } catch {
       toast.error("Failed to save profile. Please try again.");
@@ -139,9 +155,7 @@ export default function SchoolProfilePage() {
       setValidatedPhotoFile(null);
       setTimeout(() => window.location.reload(), 1500);
     } catch (err) {
-      setPhotoError(
-        err instanceof Error ? err.message : "Failed to upload photo.",
-      );
+      setPhotoError(err instanceof Error ? err.message : "Failed to upload photo.");
     } finally {
       setIsUploadingPhoto(false);
     }
@@ -165,20 +179,19 @@ export default function SchoolProfilePage() {
   const labelClass = "block text-sm font-medium text-[var(--ui-text-muted)]";
   const textareaClass =
     "w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]";
+  const selectClass =
+    "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]";
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-6">
-      {/* Branding header */}
+      {/* Header */}
       <div className="mb-6 text-center">
         <p className="text-xs font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
           Mamun &times; {schoolName}
         </p>
-        <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">
-          Edit Your Profile
-        </h1>
+        <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">Edit Your Profile</h1>
       </div>
 
-      {/* Back link */}
       <Link
         href={`/school/${slug}/dashboard`}
         className="mb-6 inline-flex items-center gap-1.5 text-xs text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
@@ -187,7 +200,6 @@ export default function SchoolProfilePage() {
         Back to dashboard
       </Link>
 
-      {/* No photo warning */}
       {!profileData?.pfp_url && (
         <div className="mb-6 rounded-xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-400">
           You must upload a profile picture before you can save changes.
@@ -195,7 +207,7 @@ export default function SchoolProfilePage() {
       )}
 
       <div className="space-y-5">
-        {/* Profile picture */}
+        {/* ── Profile Picture ── */}
         <div className={sectionClass}>
           <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
             Profile Picture
@@ -232,13 +244,11 @@ export default function SchoolProfilePage() {
             </button>
           )}
           {photoError && <p className="text-sm text-red-400">{photoError}</p>}
-          {photoSuccess && (
-            <p className="text-sm text-green-400">{photoSuccess}</p>
-          )}
+          {photoSuccess && <p className="text-sm text-green-400">{photoSuccess}</p>}
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-          {/* Basic information */}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5 pb-24">
+          {/* ── Basic Information ── */}
           <div className={sectionClass}>
             <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Basic Information
@@ -251,66 +261,38 @@ export default function SchoolProfilePage() {
                   placeholder="First Name"
                   {...register("firstName", { required: "Required" })}
                 />
-                {errors.firstName && (
-                  <p className="text-xs text-red-400">
-                    {errors.firstName.message}
-                  </p>
-                )}
+                {errors.firstName && <p className="text-xs text-red-400">{errors.firstName.message}</p>}
               </div>
-
               <div className="space-y-1.5">
                 <label className={labelClass}>Last Name *</label>
                 <FormInput
                   placeholder="Last Name"
                   {...register("lastName", { required: "Required" })}
                 />
-                {errors.lastName && (
-                  <p className="text-xs text-red-400">
-                    {errors.lastName.message}
-                  </p>
-                )}
+                {errors.lastName && <p className="text-xs text-red-400">{errors.lastName.message}</p>}
               </div>
             </div>
 
             <div className="space-y-1.5">
               <label className={labelClass}>Title *</label>
-              <AIWriter
-                text={titleValue}
-                onAccept={(s) => setValue("title", s)}
-                fieldType="title"
-              />
               <FormInput
                 placeholder="e.g. Software Engineer"
                 {...register("title", { required: "Required" })}
               />
-              {errors.title && (
-                <p className="text-xs text-red-400">{errors.title.message}</p>
-              )}
+              {errors.title && <p className="text-xs text-red-400">{errors.title.message}</p>}
             </div>
 
             <div className="space-y-1.5">
-              <input
-                type="hidden"
-                {...register("country", { required: true })}
-              />
-              <input
-                type="hidden"
-                {...register("city", { required: true })}
-              />
+              <input type="hidden" {...register("country", { required: true })} />
+              <input type="hidden" {...register("city", { required: true })} />
               <input type="hidden" {...register("state")} />
               <LocationSelector
                 countryValue={watch("country") || ""}
                 stateValue={watch("state") || ""}
                 cityValue={watch("city") || ""}
-                onCountryChange={(v) =>
-                  setValue("country", v, { shouldValidate: true })
-                }
-                onStateChange={(v) =>
-                  setValue("state", v, { shouldValidate: true })
-                }
-                onCityChange={(v) =>
-                  setValue("city", v, { shouldValidate: true })
-                }
+                onCountryChange={(v) => setValue("country", v, { shouldValidate: true })}
+                onStateChange={(v) => setValue("state", v, { shouldValidate: true })}
+                onCityChange={(v) => setValue("city", v, { shouldValidate: true })}
                 errors={{
                   country: errors.country ? "Country is required" : undefined,
                   state: errors.state ? "State is required" : undefined,
@@ -320,98 +302,99 @@ export default function SchoolProfilePage() {
             </div>
           </div>
 
-          {/* Professional information */}
+          {/* ── School Details (UT only) ── */}
+          {isUT && (
+            <div className={sectionClass}>
+              <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
+                School Details
+              </h2>
+              <UTSchoolFields
+                register={register}
+                watch={watch}
+                setValue={setValue}
+                errors={errors}
+              />
+            </div>
+          )}
+
+          {/* ── Professional ── */}
           <div className={sectionClass}>
             <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
-              Professional Information
+              Professional
             </h2>
 
             <div className="space-y-1.5">
-              <label className={labelClass}>Education *</label>
-              <AIWriter
-                text={educationValue}
-                onAccept={(s) => setValue("education", s)}
-                fieldType="education"
-              />
+              <label className={labelClass}>Work Experience *</label>
               <textarea
                 rows={3}
-                placeholder="Your degree, school, etc."
-                {...register("education", { required: "Required" })}
+                maxLength={CHAR_LIMIT}
+                placeholder="Current/previous roles or internships"
+                {...register("experience", { required: "Required", maxLength: { value: CHAR_LIMIT, message: `Max ${CHAR_LIMIT} characters` } })}
                 className={textareaClass}
               />
-              {errors.education && (
-                <p className="text-xs text-red-400">
-                  {errors.education.message}
-                </p>
-              )}
+              <CharCount value={experienceValue} max={CHAR_LIMIT} />
+              {errors.experience && <p className="text-xs text-red-400">{errors.experience.message}</p>}
             </div>
 
-            <div className="space-y-1.5">
-              <label className={labelClass}>Experience *</label>
-              <AIWriter
-                text={experienceValue}
-                onAccept={(s) => setValue("experience", s)}
-                fieldType="experience"
-              />
-              <textarea
-                rows={3}
-                placeholder="Current/previous roles"
-                {...register("experience", { required: "Required" })}
-                className={textareaClass}
-              />
-              {errors.experience && (
-                <p className="text-xs text-red-400">
-                  {errors.experience.message}
-                </p>
-              )}
-            </div>
-
+            {/* Technical background */}
             <div className="space-y-2">
-              <label className={labelClass}>Current Satisfaction *</label>
-              <div className="flex flex-wrap gap-4">
-                {["Happy", "Content", "Browsing"].map((opt) => (
-                  <label key={opt} className="flex items-center gap-2">
+              <label className={labelClass}>Technical Background? *</label>
+              <div className="flex gap-x-3">
+                {(["yes", "no"] as const).map((val) => (
+                  <label
+                    key={val}
+                    className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                      isTechnicalValue === val
+                        ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                        : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                    }`}
+                  >
                     <input
                       type="radio"
-                      value={opt}
-                      {...register("satisfaction", { required: "Required" })}
-                      className="h-4 w-4 accent-white"
+                      value={val}
+                      {...register("isTechnical", { required: "Required" })}
+                      className="sr-only"
                     />
-                    <span className="text-sm text-[var(--ui-text)]">{opt}</span>
+                    {val === "yes" ? "Yes" : "No"}
                   </label>
                 ))}
               </div>
-              {errors.satisfaction && (
-                <p className="text-xs text-red-400">
-                  {errors.satisfaction.message}
-                </p>
-              )}
+              {errors.isTechnical && <p className="text-xs text-red-400">{errors.isTechnical.message}</p>}
             </div>
 
-            <div className="space-y-2">
-              <label className={labelClass}>Founder Battery Level *</label>
-              <div className="flex flex-wrap gap-4">
-                {["Energized", "Content", "Burnt out"].map((opt) => (
-                  <label key={opt} className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      value={opt}
-                      {...register("batteryLevel", { required: "Required" })}
-                      className="h-4 w-4 accent-white"
-                    />
-                    <span className="text-sm text-[var(--ui-text)]">{opt}</span>
-                  </label>
-                ))}
-              </div>
-              {errors.batteryLevel && (
-                <p className="text-xs text-red-400">
-                  {errors.batteryLevel.message}
-                </p>
-              )}
-            </div>
+            {/* Satisfaction + battery only for non-UT schools */}
+            {!isUT && (
+              <>
+                <div className="space-y-2">
+                  <label className={labelClass}>Current Satisfaction *</label>
+                  <div className="flex flex-wrap gap-4">
+                    {["Happy", "Content", "Browsing"].map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input type="radio" value={opt} {...register("satisfaction", { required: "Required" })} className="h-4 w-4 accent-white" />
+                        <span className="text-sm text-[var(--ui-text)]">{opt}</span>
+                      </label>
+                    ))}
+                  </div>
+                  {errors.satisfaction && <p className="text-xs text-red-400">{errors.satisfaction.message}</p>}
+                </div>
+
+                <div className="space-y-2">
+                  <label className={labelClass}>Founder Battery Level *</label>
+                  <div className="flex flex-wrap gap-4">
+                    {["Energized", "Content", "Burnt out"].map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input type="radio" value={opt} {...register("batteryLevel", { required: "Required" })} className="h-4 w-4 accent-white" />
+                        <span className="text-sm text-[var(--ui-text)]">{opt}</span>
+                      </label>
+                    ))}
+                  </div>
+                  {errors.batteryLevel && <p className="text-xs text-red-400">{errors.batteryLevel.message}</p>}
+                </div>
+              </>
+            )}
           </div>
 
-          {/* Personal story */}
+          {/* ── Personal Story ── */}
           <div className={sectionClass}>
             <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Personal Story
@@ -419,45 +402,25 @@ export default function SchoolProfilePage() {
 
             <div className="space-y-1.5">
               <label className={labelClass}>Personal Introduction *</label>
-              <AIWriter
-                text={personalIntroValue}
-                onAccept={(s) => setValue("personalIntro", s)}
-                fieldType="personalIntro"
-              />
               <textarea
                 rows={4}
+                maxLength={CHAR_LIMIT}
                 placeholder="A short paragraph introducing yourself…"
                 {...register("personalIntro", {
                   required: "Required",
                   minLength: { value: 10, message: "At least 10 characters" },
+                  maxLength: { value: CHAR_LIMIT, message: `Max ${CHAR_LIMIT} characters` },
                 })}
                 className={textareaClass}
               />
-              {errors.personalIntro && (
-                <p className="text-xs text-red-400">
-                  {errors.personalIntro.message}
-                </p>
-              )}
+              <CharCount value={personalIntroValue} max={CHAR_LIMIT} />
+              {errors.personalIntro && <p className="text-xs text-red-400">{errors.personalIntro.message}</p>}
             </div>
 
-            <div className="space-y-1.5">
-              <label className={labelClass}>Accomplishments</label>
-              <AIWriter
-                text={accomplishmentsValue}
-                onAccept={(s) => setValue("accomplishments", s)}
-                fieldType="accomplishments"
-              />
-              <textarea
-                rows={3}
-                placeholder="Built an app used by 10k+ users, Top 5% LeetCode…"
-                {...register("accomplishments")}
-                className={textareaClass}
-              />
-            </div>
-
+            {/* Founder Archetype */}
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <label className={labelClass}>Founder Archetype</label>
+                <label className={labelClass}>Founder Archetype *</label>
                 <a
                   href="/founder-archetypes"
                   target="_blank"
@@ -470,48 +433,30 @@ export default function SchoolProfilePage() {
               <div className="flex flex-col gap-y-2">
                 {(
                   [
-                    {
-                      value: "the_scalar",
-                      label: "The Scalar",
-                      tooltip:
-                        "Speed and scale above all else. Uses AI and proprietary data to grow without headcount.",
-                    },
-                    {
-                      value: "the_steward",
-                      label: "The Steward",
-                      tooltip:
-                        "Values-driven and mission-first. Prioritizes ethical integrity and community trust.",
-                    },
-                    {
-                      value: "the_architect",
-                      label: "The Architect",
-                      tooltip:
-                        "Builds the infrastructure others run on. Creates platforms powered by network effects.",
-                    },
+                    { value: "the_scaler", label: "The Scaler", tooltip: "Speed and scale above all else. Uses AI and proprietary data to grow without headcount." },
+                    { value: "the_steward", label: "The Steward", tooltip: "Values-driven and mission-first. Prioritizes ethical integrity and community trust." },
+                    { value: "the_architect", label: "The Architect", tooltip: "Builds the infrastructure others run on. Creates platforms powered by network effects." },
                   ] as const
                 ).map(({ value, label, tooltip }) => (
                   <label
                     key={value}
-                    className="relative flex cursor-pointer items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] transition-all hover:border-[var(--ui-border-strong)] hover:bg-[var(--ui-surface)] has-[:checked]:border-[var(--ui-text-muted)] has-[:checked]:bg-[var(--ui-surface-active)]"
+                    className={`${PILL_RADIO_CLS} relative`}
                   >
                     <input
                       type="radio"
                       value={value}
-                      {...register("archetype")}
+                      {...register("archetype", { required: "Required" })}
                       className="sr-only"
                     />
                     <span
                       className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
-                        watch("archetype") === value
+                        archetypeValue === value
                           ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
                           : "border-[var(--ui-border-strong)] bg-transparent"
                       }`}
                     />
                     <span className="flex-1">{label}</span>
-                    <span
-                      className="group/tip relative ml-auto flex items-center"
-                      onClick={(e) => e.preventDefault()}
-                    >
+                    <span className="group/tip relative ml-auto flex items-center" onClick={(e) => e.preventDefault()}>
                       <span className="flex h-5 w-5 cursor-default items-center justify-center rounded-full border border-[var(--ui-border-strong)] text-[10px] font-medium text-[var(--ui-text-subtle)] transition-colors group-hover/tip:border-white/35 group-hover/tip:text-[var(--ui-text-muted)]">
                         i
                       </span>
@@ -522,10 +467,187 @@ export default function SchoolProfilePage() {
                   </label>
                 ))}
               </div>
+              {errors.archetype && <p className="text-xs text-red-400">{errors.archetype.message}</p>}
             </div>
           </div>
 
-          {/* Social links */}
+          {/* ── Startup & Co-Founder Intent ── */}
+          <div className={sectionClass}>
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
+              Startup &amp; Co-Founder Intent
+            </h2>
+
+            <div className="space-y-2">
+              <label className={labelClass}>Do you have a startup or idea? *</label>
+              <div className="flex gap-x-3">
+                {(["yes", "no"] as const).map((val) => (
+                  <label
+                    key={val}
+                    className={`flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm font-medium transition-all duration-150 ${
+                      hasStartupValue === val
+                        ? "border-[var(--ui-text-muted)] bg-[var(--ui-surface-active)] text-[var(--ui-text)]"
+                        : "border-[var(--ui-border)] bg-[var(--ui-surface)] text-[var(--ui-text-muted)] hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)]"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      value={val}
+                      {...register("hasStartup", { required: "Required" })}
+                      className="sr-only"
+                    />
+                    {val === "yes" ? "Yes" : "No"}
+                  </label>
+                ))}
+              </div>
+              {errors.hasStartup && <p className="text-xs text-red-400">{errors.hasStartup.message}</p>}
+            </div>
+
+            {hasStartupValue === "yes" && (
+              <>
+                <div className="space-y-1.5">
+                  <label className={labelClass}>Startup Name</label>
+                  <FormInput placeholder="Your startup name" {...register("startupName")} />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className={labelClass}>Startup Description</label>
+                  <textarea
+                    rows={3}
+                    placeholder="What does your startup do?"
+                    {...register("startupDescription")}
+                    className={textareaClass}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className={labelClass}>Time Spent on Startup</label>
+                  <select {...register("startupTimeSpent")} className={selectClass}>
+                    <option value="">Select…</option>
+                    {["Just started", "1-3 months", "3-6 months", "6-12 months", "1-2 years", "2+ years"].map((opt) => (
+                      <option key={opt} value={opt}>{opt}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className={labelClass}>Funding Stage</label>
+                  <select {...register("startupFunding")} className={selectClass}>
+                    <option value="">Select…</option>
+                    {["Idea stage", "Bootstrapped", "Friends & Family", "Pre-seed", "Seed", "Series A+"].map((opt) => (
+                      <option key={opt} value={opt}>{opt}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Co-founder status */}
+                <div className="space-y-2">
+                  <label className={labelClass}>Co-Founder Status *</label>
+                  <div className="flex flex-col gap-y-2">
+                    {["Solo founder", "Have co-founder(s)", "Seeking co-founder"].map((opt) => (
+                      <label key={opt} className={PILL_RADIO_CLS}>
+                        <input
+                          type="radio"
+                          value={opt}
+                          {...register("coFounderStatus", { required: hasStartupValue === "yes" ? "Required" : false })}
+                          className="sr-only"
+                        />
+                        <span
+                          className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                            coFounderStatusValue === opt
+                              ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                              : "border-[var(--ui-border-strong)] bg-transparent"
+                          }`}
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                  {errors.coFounderStatus && <p className="text-xs text-red-400">{errors.coFounderStatus.message}</p>}
+                </div>
+
+                {/* Co-founder intent (UT-specific but shown for all when hasStartup) */}
+                <div className="space-y-2">
+                  <label className={labelClass}>Co-Founder Matching Intent *</label>
+                  <div className="flex flex-col gap-y-2">
+                    {[
+                      { value: "join_me" as const, label: "Join me — I have a startup/idea" },
+                      { value: "seeking_to_join" as const, label: "Seeking to join — I want to join someone else's project" },
+                      { value: "no_preference" as const, label: "No preference — open to either" },
+                    ].map(({ value, label }) => (
+                      <label key={value} className={PILL_RADIO_CLS}>
+                        <input
+                          type="radio"
+                          value={value}
+                          {...register("intent", { required: "Required" })}
+                          className="sr-only"
+                        />
+                        <span
+                          className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                            intentValue === value
+                              ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                              : "border-[var(--ui-border-strong)] bg-transparent"
+                          }`}
+                        />
+                        {label}
+                      </label>
+                    ))}
+                  </div>
+                  {errors.intent && <p className="text-xs text-red-400">{errors.intent.message}</p>}
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className={labelClass}>Equity Expectation (%) *</label>
+                  <FormInput
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="0.1"
+                    placeholder="e.g. 20"
+                    {...register("equityExpectation", {
+                      required: hasStartupValue === "yes" ? "Required" : false,
+                      min: { value: 0, message: "At least 0%" },
+                      max: { value: 100, message: "Max 100%" },
+                    })}
+                  />
+                  {errors.equityExpectation && <p className="text-xs text-red-400">{errors.equityExpectation.message}</p>}
+                </div>
+              </>
+            )}
+
+            {/* Intent also visible when no startup */}
+            {hasStartupValue === "no" && (
+              <div className="space-y-2">
+                <label className={labelClass}>Co-Founder Matching Intent *</label>
+                <div className="flex flex-col gap-y-2">
+                  {[
+                    { value: "join_me" as const, label: "Join me — I have a startup/idea" },
+                    { value: "seeking_to_join" as const, label: "Seeking to join — I want to join someone else's project" },
+                    { value: "no_preference" as const, label: "No preference — open to either" },
+                  ].map(({ value, label }) => (
+                    <label key={value} className={PILL_RADIO_CLS}>
+                      <input
+                        type="radio"
+                        value={value}
+                        {...register("intent", { required: "Required" })}
+                        className="sr-only"
+                      />
+                      <span
+                        className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                          intentValue === value
+                            ? "border-[var(--ui-btn-bg)] bg-[var(--ui-btn-bg)]"
+                            : "border-[var(--ui-border-strong)] bg-transparent"
+                        }`}
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+                {errors.intent && <p className="text-xs text-red-400">{errors.intent.message}</p>}
+              </div>
+            )}
+          </div>
+
+          {/* ── Social Links ── */}
           <div className={sectionClass}>
             <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
               Social Links
@@ -533,125 +655,34 @@ export default function SchoolProfilePage() {
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {[
                 { label: "LinkedIn", placeholder: "https://linkedin.com/in/username", field: "linkedin" as const },
-                { label: "Twitter", placeholder: "https://twitter.com/username", field: "twitter" as const },
                 { label: "GitHub", placeholder: "https://github.com/username", field: "git" as const },
-                { label: "Personal Website", placeholder: "https://yourwebsite.com", field: "personalWebsite" as const },
-                { label: "Scheduling URL", placeholder: "https://calendly.com/username", field: "schedulingUrl" as const },
               ].map(({ label, placeholder, field }) => (
                 <div key={field} className="space-y-1.5">
                   <label className={labelClass}>{label}</label>
-                  <FormInput
-                    placeholder={placeholder}
-                    type="url"
-                    {...register(field)}
-                  />
+                  <FormInput placeholder={placeholder} type="url" {...register(field)} />
                 </div>
               ))}
             </div>
           </div>
 
-          {/* Interests & values */}
-          <div className={sectionClass}>
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--ui-text-muted)]">
-              Interests &amp; Values
-            </h2>
-
-            <div className="space-y-2">
-              <label className={labelClass}>Responsibility Areas</label>
-              <div className="flex flex-wrap gap-4">
-                {["Ops", "Sales", "Design", "Engineering", "Product"].map(
-                  (area) => (
-                    <label key={area} className="flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        value={area}
-                        {...register("responsibilities")}
-                        className="h-4 w-4 accent-white"
-                      />
-                      <span className="text-sm text-[var(--ui-text)]">{area}</span>
-                    </label>
-                  ),
-                )}
-              </div>
+          {/* ── Sticky action bar ── */}
+          <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-[var(--ui-border)] bg-[var(--ui-bg)]/90 backdrop-blur-sm">
+            <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
+              <Link
+                href={`/school/${slug}/dashboard`}
+                className="cursor-pointer rounded-xl border border-[var(--ui-border-strong)] bg-white px-5 py-2.5 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
+              >
+                Cancel
+              </Link>
+              <button
+                type="submit"
+                disabled={isSubmitting || !profileData?.pfp_url}
+                title={!profileData?.pfp_url ? "Upload a profile picture first" : undefined}
+                className="cursor-pointer rounded-xl bg-[var(--ui-btn-bg)] px-8 py-2.5 text-sm font-medium text-[var(--ui-btn-text)] transition hover:bg-[var(--ui-btn-bg)]/90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {isSubmitting ? "Saving…" : "Save Changes"}
+              </button>
             </div>
-
-            <div className="space-y-2">
-              <label className={labelClass}>Priority Areas</label>
-              <div className="flex flex-wrap gap-4">
-                {[
-                  "Emerging Tech",
-                  "AI",
-                  "Healthcare",
-                  "Fintech",
-                  "Circular Economy",
-                  "Climate",
-                  "Education",
-                  "Consumer",
-                ].map((area) => (
-                  <label key={area} className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      value={area}
-                      {...register("priorityAreas")}
-                      className="h-4 w-4 accent-white"
-                    />
-                    <span className="text-sm text-[var(--ui-text)]">{area}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className={labelClass}>Interests</label>
-              <AIWriter
-                text={interestsValue}
-                onAccept={(s) => setValue("interests", s)}
-                fieldType="interests"
-              />
-              <textarea
-                rows={3}
-                placeholder="Your interests and passions"
-                {...register("interests")}
-                className={textareaClass}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label className={labelClass}>Hobbies</label>
-              <AIWriter
-                text={hobbiesValue}
-                onAccept={(s) => setValue("hobbies", s)}
-                fieldType="hobbies"
-              />
-              <textarea
-                rows={3}
-                placeholder="Your hobbies and activities"
-                {...register("hobbies")}
-                className={textareaClass}
-              />
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="flex items-center justify-between pb-8">
-            <Link
-              href={`/school/${slug}/dashboard`}
-              className="text-sm text-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
-            >
-              Cancel
-            </Link>
-            <button
-              type="submit"
-              disabled={isSubmitting || !profileData?.pfp_url}
-              title={
-                !profileData?.pfp_url
-                  ? "Upload a profile picture first"
-                  : undefined
-              }
-              className="rounded-xl bg-[var(--ui-surface)] px-8 py-2.5 text-sm font-medium text-[var(--ui-text)] transition hover:bg-[var(--ui-surface)] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {isSubmitting ? "Saving…" : "Save Changes"}
-            </button>
           </div>
         </form>
       </div>

--- a/src/components/school/SchoolHeader.tsx
+++ b/src/components/school/SchoolHeader.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { UserButton } from "@clerk/nextjs";
-import { FaHeart, FaBars } from "react-icons/fa6";
+import { FaHeart, FaBars, FaUserPen } from "react-icons/fa6";
 import { FaTimes } from "react-icons/fa";
 import clsx from "clsx";
 import { useLikedProfilesData } from "@/features/likes/useLikes";
@@ -103,7 +103,17 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
           )}
         </Link>
 
-        {mounted && <UserButton afterSignOutUrl={`/school/${slug}`} />}
+        {mounted && (
+          <UserButton afterSignOutUrl={`/school/${slug}`}>
+            <UserButton.MenuItems>
+              <UserButton.Link
+                label="Edit profile"
+                labelIcon={<FaUserPen className="h-3.5 w-3.5" />}
+                href={`/school/${slug}/profile`}
+              />
+            </UserButton.MenuItems>
+          </UserButton>
+        )}
 
         {/* Mobile hamburger */}
         <button

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -247,6 +247,72 @@ export function useSearchProfiles(query: string, userFilters: DashboardFilters) 
   };
 }
 
+export function useSchoolProfile() {
+  const { userId } = useAuth();
+  const { session } = useSession();
+
+  return useQuery<OnboardingData, { message: string }>({
+    queryKey: ["school-profile", userId],
+    queryFn: async () => {
+      if (!userId) throw { message: "You must be logged in to view your profile" };
+      const token = await session?.getToken();
+      if (!token) throw { message: "Authentication failed. Please log in again." };
+
+      const response = await fetch("/api/ut-profile", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw { message: errorData.error || "Failed to load school profile" };
+      }
+
+      const data = await response.json();
+      return data.profile;
+    },
+    enabled: !!userId,
+    retry: 1,
+  });
+}
+
+export function useSchoolProfileUpsert() {
+  const { userId } = useAuth();
+  const { session } = useSession();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (formData: OnboardingData) => {
+      const token = await session?.getToken();
+      if (!userId || !token) throw new Error("No logged in user or authentication has failed");
+
+      const response = await fetch("/api/ut-profile", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to update school profile");
+      }
+
+      return await response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["school-profile", userId] });
+      queryClient.invalidateQueries({ queryKey: ["profiles", userId] });
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+      toast.success("Profile updated successfully!");
+    },
+    onError: (error) => {
+      toast.error(error?.message || "Failed to update profile.");
+    },
+  });
+}
+
 export function useProfileUpsert() {
   const { userId } = useAuth();
   const { session } = useSession();


### PR DESCRIPTION
# MCFM-122 | UT Edit Profile + Onboarding Consistency

## Summary

Introduces a full edit-profile experience for UT school users and aligns the onboarding flow with the edit surface. The two were previously out of sync in field sets, option values, step counts, and data fetching. This PR treats the onboarding as the canonical field definition and brings the edit page into conformance with it.

---

## Motivation

UT users completing onboarding had no way to update their profile afterward. The edit page at `/school/[slug]/profile` existed but used the general-purpose profile hooks and data model — it did not read or write UT-specific fields (`utStatus`, `utCollege`, `utMajor`, `intent`, etc.), and the field set diverged significantly from onboarding (different option values for `startupTimeSpent`/`startupFunding`, extra fields like `accomplishments`/`twitter`/`personalWebsite`, missing fields from the onboarding, and a broken step counter showing 6 steps when there are 5).

Additionally, `intent` (co-founder matching intent) was only collected in onboarding for users who answered "yes" to having a startup — users without a startup had no path to set it.

---

## Changes

### API — `GET /api/ut-profile`
Added a GET handler to the UT profile route. Merges `profiles` + `school_profiles` rows into a single `OnboardingData` payload, using the existing `mapProfileToOnboardingData` and `mapSchoolProfileToUTData` mappers. The POST handler was already present; this completes the CRUD contract.

### New component — `UTSchoolFields`
Extracted the UT-specific school fields (student/alumni toggle, college, degree type, major, sector interests, grad year, additional education) from `UTAboutYouForm` into a shared `UTSchoolFields` component. Used in both the onboarding step 2 and the edit profile page, eliminating the duplication that caused the two surfaces to drift.

### New hooks — `useSchoolProfile` / `useSchoolProfileUpsert`
Added two React Query hooks in `useProfile.ts` that call `GET /api/ut-profile` and `POST /api/ut-profile` respectively. The edit profile page conditionally uses these (vs the general hooks) based on `slug === "ut"`.

### Edit profile page — `/school/[slug]/profile`
Full rebuild to be UT-aware:
- Accepts `params: Promise<{ slug }>` and branches on `isUT` throughout
- Reads/writes via `useSchoolProfile` / `useSchoolProfileUpsert` for UT, general hooks for other schools
- Field set now mirrors the onboarding: basic info, school details (UT only), professional (experience, isTechnical), personal story (personalIntro, archetype), startup & co-founder intent, social links (LinkedIn + GitHub only)
- Removed fields not in onboarding: `accomplishments`, `twitter`, `personalWebsite`, `education`, `interests`, `hobbies`, `responsibilities`, `priorityAreas`, `satisfaction`, `batteryLevel` (last two gated to non-UT only)
- `startupTimeSpent` options changed to duration-based ("Just started" → "2+ years") matching onboarding
- `startupFunding` options aligned to onboarding ("Idea stage", "Bootstrapped", "Friends & Family", "Pre-seed", "Seed", "Series A+")
- Replaced inline action footer with a sticky bottom bar
- Removed all `AIWriter` usages (not present in onboarding)

### Co-founder intent — always required
`UTStartupForm` previously only showed the intent picker inside the `hasStartup === "yes"` branch. Intent is now rendered unconditionally after the hasStartup toggle, required for all users. The `getCompletedSteps` function in the onboarding page was updated to require `intent` (alongside `hasStartup`) to mark step 3 complete, regardless of startup status.

### Onboarding step count
- Removed `UTInterestsForm` from the UT flow (was step 5 of 6; the UT flow never needed an interests step)
- `TOTAL_STEPS` corrected from 6 → 5
- Step labels in `UTBackgroundAndSocialsForm` ("Step 4 of 6") and `UTReviewForm` ("Step 6 of 6") corrected to "Step 4 of 5" and "Step 5 of 5"

### Removed dead field — `schedulingUrl`
The onboarding collected a scheduling URL in step 4 but the mapper hardcoded it to `undefined` — it was never saved to the database. The field has been removed from `UTBackgroundAndSocialsForm` and its local type.

### School header
Added an "Edit profile" link to the Clerk `UserButton` menu so users can reach the edit page from anywhere in the school app.

---

## Data contract

No database migrations required. The `intent` column already exists in `school_profiles` (added in migration `20260528000001`). All other affected fields were already present in `profiles`.

---

## Testing

1. Complete UT onboarding as a new user — verify 5 steps, step labels are correct, intent picker appears regardless of startup answer
2. Complete onboarding with `hasStartup: no` — confirm `intent` is saved to `school_profiles`
3. Navigate to `/school/ut/profile` — verify school details section pre-fills from the saved profile, startup/intent section reflects saved values
4. Edit and save — confirm both `profiles` and `school_profiles` update correctly
5. Verify `startupTimeSpent` and `startupFunding` dropdowns show duration-based and stage-based options respectively in edit profile
6. Verify "Edit profile" appears in the Clerk UserButton menu
7. Run the same flow on a non-UT school slug — confirm general hooks are used and UT-specific sections are hidden
