### PR TITLE
MCFM-129 | Add site metadata + robots.ts for SEO across subdomains + main domain

### DIFF
--- a/src/app/(school)/school/[slug]/layout.tsx
+++ b/src/app/(school)/school/[slug]/layout.tsx
@@ -16,8 +16,42 @@ export async function generateMetadata({
   const org = await getOrganizationBySlug(slug);
   const cfg = getOrgConfig(slug) ?? DEFAULT_ORG_CONFIG;
 
+  const orgName = org?.name ?? "School Portal";
+  const description = cfg.landing.subheadline;
+  const baseUrl =
+    org?.subdomain
+      ? `https://${org.subdomain}.mamuncofoundr.com`
+      : process.env.NEXT_PUBLIC_APP_URL ?? "https://mamuncofoundr.com";
+  const ogImage = cfg.landing.heroImageUrl ?? cfg.branding.logoUrl;
+
   return {
-    title: org?.name ?? "School Portal",
+    metadataBase: new URL(baseUrl),
+    title: {
+      default: orgName,
+      template: `%s | ${orgName}`,
+    },
+    description,
+    alternates: {
+      canonical: "/",
+    },
+    openGraph: {
+      type: "website",
+      url: baseUrl,
+      siteName: orgName,
+      title: orgName,
+      description,
+      images: [ogImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: orgName,
+      description,
+      images: [ogImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
     icons: cfg.branding.faviconUrl
       ? { icon: cfg.branding.faviconUrl }
       : undefined,

--- a/src/app/(school)/school/[slug]/page.tsx
+++ b/src/app/(school)/school/[slug]/page.tsx
@@ -22,9 +22,27 @@ export default async function SchoolLanding({
   const cfg = getOrgConfig(slug);
   if (!cfg) notFound();
 
+  const baseUrl = `https://${org.subdomain ?? slug}.mamuncofoundr.com`;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "EducationalOrganization",
+    name: cfg.branding.wordmark ?? org.name,
+    url: baseUrl,
+    logo: `${baseUrl}${cfg.branding.logoUrl}`,
+    description: cfg.landing.subheadline,
+  };
+
+  const jsonLdScript = (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+
   if (slug === "ut") {
     return (
       <>
+        {jsonLdScript}
         <Hero />
         <HowItWorks />
         <ValuesPillars />
@@ -38,7 +56,9 @@ export default async function SchoolLanding({
   const { branding, landing } = cfg;
 
   return (
-    <div className="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center px-6 py-20 text-center">
+    <>
+      {jsonLdScript}
+      <div className="flex min-h-[calc(100vh-64px)] flex-col items-center justify-center px-6 py-20 text-center">
       {landing.heroImageUrl && (
         <div className="absolute inset-0 -z-10 opacity-10">
           <Image
@@ -86,5 +106,6 @@ export default async function SchoolLanding({
         </Link>
       </div>
     </div>
+    </>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+import { headers } from "next/headers";
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const host = (await headers()).get("host") ?? "mamuncofoundr.com";
+  const baseUrl = `https://${host}`;
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/dashboard",
+        "/admin",
+        "/onboarding",
+        "/matches",
+        "/messages",
+        "/profile",
+        "/edit-profile",
+        "/sso-callback",
+        "/sso-complete",
+        "/pending-activation",
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from "next";
+import { headers } from "next/headers";
+
+const APEX = new Set([
+  "mamuncofoundr.com",
+  "www.mamuncofoundr.com",
+  "localhost",
+]);
+
+const APEX_PUBLIC_PATHS = [
+  "",
+  "/pricing",
+  "/careers",
+  "/contact-us",
+  "/founder-archetypes",
+  "/privacy-policy",
+  "/refund-policy",
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const host = (await headers()).get("host") ?? "mamuncofoundr.com";
+  const bare = host.split(":")[0].toLowerCase();
+  const base = `https://${host}`;
+  const isApex =
+    APEX.has(bare) ||
+    bare.endsWith(".vercel.app") ||
+    bare.split(".").length < 3;
+
+  if (!isApex) {
+    return [
+      {
+        url: `${base}/`,
+        lastModified: new Date(),
+        changeFrequency: "weekly",
+        priority: 1,
+      },
+    ];
+  }
+
+  return APEX_PUBLIC_PATHS.map((p) => ({
+    url: `${base}${p || "/"}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: p === "" ? 1 : 0.6,
+  }));
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -105,8 +105,14 @@ async function updateUserActivity(userId: string) {
 }
 
 export default clerkMiddleware(async (auth, req: NextRequest) => {
-  const { userId, sessionClaims, redirectToSignIn } = await auth();
   const pathname = req.nextUrl.pathname;
+
+  // Crawler metadata routes must bypass subdomain rewrite and auth gates
+  if (pathname === "/robots.txt" || pathname === "/sitemap.xml") {
+    return NextResponse.next();
+  }
+
+  const { userId, sessionClaims, redirectToSignIn } = await auth();
   const host = req.headers.get("host") ?? "";
   const isApiRoute = pathname.startsWith("/api/");
   const isStaticAsset = /\.(ico|png|jpg|jpeg|svg|css|js|woff|woff2?|ttf)$/.test(pathname);


### PR DESCRIPTION
## MCFM-129 | Add site metadata + robots.ts for SEO across subdomains + main domain

`ut.mamuncofoundr.com` was not surfacing in Google because the app lacked crawler metadata (`robots.txt`, `sitemap.xml`) and school pages had minimal `<head>` tags. One Next.js deployment serves both the apex domain and school subdomains via middleware rewrite (`ut.mamuncofoundr.com/*` → `/school/ut/*`), so SEO files must be host-aware and bypass that rewrite. This PR adds Tier 2 on-page SEO: dynamic `robots.ts` / `sitemap.ts`, richer school `generateMetadata`, and `EducationalOrganization` JSON-LD on school landing pages.

## Changes

### Middleware
- Short-circuit `/robots.txt` and `/sitemap.xml` before subdomain rewrite and Clerk auth gates so crawlers hit root metadata handlers on subdomains without being rewritten to `/school/{slug}/sitemap.xml` or redirected to sign-in (`src/middleware.ts`).

### Crawler metadata (host-aware)
- Add `src/app/robots.ts` — reads `Host` via `headers()`, emits per-host allow/disallow rules (blocks `/api/`, `/dashboard`, `/admin`, etc.), and points `Sitemap` at `https://{host}/sitemap.xml`.
- Add `src/app/sitemap.ts` — reads `Host` to distinguish apex vs subdomain:
  - **Subdomain** (e.g. `ut.mamuncofoundr.com`): emits `https://{host}/` only (auth pages intentionally excluded).
  - **Apex** (`mamuncofoundr.com`, `www`, `localhost`, `*.vercel.app`): emits public marketing routes (`/`, `/pricing`, `/careers`, `/contact-us`, `/founder-archetypes`, `/privacy-policy`, `/refund-policy`).
- Both routes use `headers()` so responses are dynamic per-host, not statically cached at build time.

### School page metadata
- Expand `generateMetadata` in `src/app/(school)/school/[slug]/layout.tsx`:
  - `metadataBase` → `https://{subdomain}.mamuncofoundr.com`
  - `description` from `cfg.landing.subheadline`
  - Canonical URL (`alternates.canonical: "/"`)
  - Open Graph + Twitter cards (`summary_large_image`, hero image or logo fallback)
  - `robots: { index: true, follow: true }`

### Structured data
- Add `EducationalOrganization` JSON-LD to school landing page (`src/app/(school)/school/[slug]/page.tsx`) on both UT and generic landing branches, built from org registry config (name, logo, description, subdomain URL).

## Migration / Config

None. No new env vars, migrations, or third-party setup.

## Testing

- `curl -H "Host: ut.mamuncofoundr.com" https://<deploy>/sitemap.xml` — confirm URL is `https://ut.mamuncofoundr.com/`, not rewritten.
- `curl -H "Host: ut.mamuncofoundr.com" https://<deploy>/robots.txt` — confirm `Sitemap: https://ut.mamuncofoundr.com/sitemap.xml`.
- View `ut.mamuncofoundr.com` page source — verify canonical, OG/Twitter meta tags, and JSON-LD script.
- Post-deploy: add `ut.mamuncofoundr.com` as a separate Search Console property and submit `https://ut.mamuncofoundr.com/sitemap.xml`.

## Notes

- `robots.txt` disallow rules are advisory; middleware auth still enforces access on protected routes.
- Subdomain sitemap does not validate the host against the `organizations` table — any 3-label host gets a landing-page entry. Low risk; optional hardening for a follow-up.
- Search Console verification and indexing lag are off-page concerns outside this PR.