### PR TITLE
MCFM-130 | UT Link Bug Fixes

### DIFF
--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -11,6 +11,7 @@ import toast from "react-hot-toast";
 
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
+import ProfileViewModal from "@/features/profile/ProfileViewModal";
 import { useGetProfiles, useSearchProfiles } from "@/features/profile/useProfile";
 import { useSchool } from "@/features/school/components/SchoolContext";
 import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/useLikes";
@@ -33,8 +34,12 @@ import {
 
 function SearchResultCard({
   profile,
+  onViewProfile,
+  onViewProfileById,
 }: {
   profile: OnboardingData;
+  onViewProfile: (profile: OnboardingData) => void;
+  onViewProfileById: (userId: string) => void;
 }) {
   const queryClient = useQueryClient();
   const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
@@ -66,7 +71,11 @@ function SearchResultCard({
 
   return (
     <div className="overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]">
-      <div className="p-4">
+      <button
+        type="button"
+        onClick={() => onViewProfile(profile)}
+        className="w-full p-4 text-left hover:bg-[var(--ui-surface-active)] transition cursor-pointer"
+      >
         {/* Avatar + name row */}
         <div className="mb-3 flex items-center gap-3">
           {profile.pfp_url ? (
@@ -120,8 +129,8 @@ function SearchResultCard({
         )}
 
         {profile.user_id && (
-          <div className="mb-3">
-            <CoFounderLinks userId={profile.user_id} />
+          <div className="mb-3" onClick={(e) => e.stopPropagation()}>
+            <CoFounderLinks userId={profile.user_id} onClickCofounder={onViewProfileById} />
           </div>
         )}
 
@@ -146,7 +155,7 @@ function SearchResultCard({
             ))}
           </div>
         )}
-      </div>
+      </button>
 
       {/* Actions */}
       <div className="flex items-center gap-3 border-t border-[var(--ui-border)] px-4 py-3">
@@ -174,6 +183,21 @@ export default function SchoolDashboardPage() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [filters, setFilters] = useState<DashboardFilters>(EMPTY_DASHBOARD_FILTERS);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const [viewingUserId, setViewingUserId] = useState<string | null>(null);
+  const [viewingProfile, setViewingProfile] = useState<OnboardingData | null>(null);
+
+  const openProfile = (profile: OnboardingData) => {
+    setViewingProfile(profile);
+    setViewingUserId(null);
+  };
+  const openProfileById = (userId: string) => {
+    setViewingUserId(userId);
+    setViewingProfile(null);
+  };
+  const closeProfile = () => {
+    setViewingUserId(null);
+    setViewingProfile(null);
+  };
   const queryClient = useQueryClient();
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -364,6 +388,7 @@ export default function SchoolDashboardPage() {
 
   return (
     <div className="mx-auto flex min-h-dvh max-w-5xl flex-col px-4 pt-6 pb-8">
+      <ProfileViewModal profile={viewingProfile} userId={viewingUserId} onClose={closeProfile} />
       {brandingHeader}
 
       <FilterSidebar
@@ -454,7 +479,7 @@ export default function SchoolDashboardPage() {
           {searchResults && searchResults.length > 0 && (
             <div className="flex flex-col gap-3">
               {searchResults.map((profile) => (
-                <SearchResultCard key={profile.user_id} profile={profile} />
+                <SearchResultCard key={profile.user_id} profile={profile} onViewProfile={openProfile} onViewProfileById={openProfileById} />
               ))}
             </div>
           )}
@@ -587,7 +612,7 @@ export default function SchoolDashboardPage() {
 
                 {curProfile.user_id && (
                   <div className="mb-3">
-                    <CoFounderLinks userId={curProfile.user_id} />
+                    <CoFounderLinks userId={curProfile.user_id} onClickCofounder={setViewingUserId} />
                   </div>
                 )}
 

--- a/src/app/api/cofounder-invite/[token]/accept/route.ts
+++ b/src/app/api/cofounder-invite/[token]/accept/route.ts
@@ -135,7 +135,9 @@ export async function POST(
       .eq("user_id", invite.inviter_user_id)
       .single();
 
-    if (orgRow?.slug) {
+    if (!orgRow?.slug) {
+      console.error("[cofounder-invite accept] org slug missing for organization_id:", invite.organization_id);
+    } else {
       const clerk = await clerkClient();
       const [inviterClerk, acceptorClerk] = await Promise.all([
         clerk.users.getUser(invite.inviter_user_id),
@@ -148,7 +150,9 @@ export async function POST(
       const acceptorName =
         [acceptorProfile.first_name, acceptorProfile.last_name].filter(Boolean).join(" ") || "Your co-founder";
 
-      await Promise.allSettled([
+      if (!inviterEmail) console.warn("[cofounder-invite accept] inviter has no email, skipping linked email");
+      if (!acceptorEmail) console.warn("[cofounder-invite accept] acceptor has no email, skipping linked email");
+      const [inviterResult, acceptorResult] = await Promise.allSettled([
         inviterEmail
           ? sendCofounderLinkedEmail({ to: inviterEmail, linkedName: acceptorName, slug: orgRow.slug })
           : Promise.resolve(),
@@ -156,6 +160,12 @@ export async function POST(
           ? sendCofounderLinkedEmail({ to: acceptorEmail, linkedName: inviterName, slug: orgRow.slug })
           : Promise.resolve(),
       ]);
+      if (inviterResult.status === "rejected") {
+        console.error("[cofounder-invite accept] inviter linked email failed:", inviterResult.reason);
+      }
+      if (acceptorResult.status === "rejected") {
+        console.error("[cofounder-invite accept] acceptor linked email failed:", acceptorResult.reason);
+      }
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/profile/[userId]/route.ts
+++ b/src/app/api/profile/[userId]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   try {
     // Get the authenticated user from Clerk
-    const { userId: requestingUserId } = await auth();
+    const { userId: requestingUserId, sessionClaims } = await auth();
 
     if (!requestingUserId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -33,9 +33,33 @@ export async function GET(
 
     // Authorization check: Only allow if:
     // 1. User is requesting their own profile, OR
-    // 2. Users are in a conversation together, OR
-    // 3. Users have liked each other (mutual match)
+    // 2. Both users belong to the same school org, OR
+    // 3. Users are in a conversation together, OR
+    // 4. Users have liked each other (mutual match), OR
+    // 5. Users have a confirmed co-founder link
     const isOwnProfile = requestingUserId === userId;
+
+    // Same-org check: school org members can view any profile in their org
+    const requestingOrgId = (sessionClaims?.metadata as { organization_id?: string } | null)?.organization_id ?? null;
+    if (!isOwnProfile && requestingOrgId) {
+      const { data: targetProfile } = await supabase
+        .from("profiles")
+        .select("organization_id")
+        .eq("user_id", userId)
+        .is("deleted_at", null)
+        .single();
+      if (targetProfile?.organization_id === requestingOrgId) {
+        // Same org — fetch and return immediately
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("*")
+          .eq("user_id", userId)
+          .is("deleted_at", null)
+          .single();
+        if (error || !data) return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+        return NextResponse.json({ profile: mapProfileToOnboardingData(data) });
+      }
+    }
 
     if (!isOwnProfile) {
       // Check if users are in a conversation together

--- a/src/features/cofounder/CoFounderLinks.tsx
+++ b/src/features/cofounder/CoFounderLinks.tsx
@@ -14,47 +14,52 @@ export default function CoFounderLinks({ userId, onClickCofounder }: Props) {
   if (isLoading || !cofounders || cofounders.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-[10px] font-semibold uppercase tracking-wider opacity-60">
+    <div className="flex flex-col gap-2">
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
         Co-founders
       </span>
-      {cofounders.map((cf) => {
-        const name = [cf.first_name, cf.last_name].filter(Boolean).join(" ") || "Co-founder";
-        const initials =
-          (cf.first_name?.[0] ?? "").toUpperCase() + (cf.last_name?.[0] ?? "").toUpperCase();
+      <div className="flex flex-wrap gap-2">
+        {cofounders.map((cf) => {
+          const name = [cf.first_name, cf.last_name].filter(Boolean).join(" ") || "Co-founder";
+          const initials =
+            (cf.first_name?.[0] ?? "").toUpperCase() + (cf.last_name?.[0] ?? "").toUpperCase();
 
-        return (
-          <button
-            key={cf.link_id}
-            type="button"
-            onClick={() => onClickCofounder?.(cf.user_id)}
-            className="flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-2 py-1 text-[11px] font-medium backdrop-blur-sm transition hover:bg-white/20"
-            title={name}
-          >
-            {cf.pfp_url ? (
-              <Image
-                src={cf.pfp_url}
-                alt={name}
-                width={16}
-                height={16}
-                className="h-4 w-4 rounded-full object-cover"
-              />
-            ) : (
-              <span className="flex h-4 w-4 items-center justify-center rounded-full bg-white/30 text-[9px] font-bold">
-                {initials}
-              </span>
-            )}
-            <span className="max-w-[80px] truncate">{name}</span>
-            {cf.title && (
-              <span className="max-w-[60px] truncate opacity-70">{cf.title}</span>
-            )}
-            <span
-              className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-green-400"
-              title="Linked"
-            />
-          </button>
-        );
-      })}
+          return (
+            <button
+              key={cf.link_id}
+              type="button"
+              onClick={() => onClickCofounder?.(cf.user_id)}
+              className="flex items-center gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface-active)] px-3 py-2 text-left transition hover:border-[#bf5700] hover:bg-[#fff6f0] cursor-pointer"
+              title={onClickCofounder ? `View ${name}'s profile` : name}
+            >
+              {cf.pfp_url ? (
+                <Image
+                  src={cf.pfp_url}
+                  alt={name}
+                  width={36}
+                  height={36}
+                  className="h-9 w-9 flex-shrink-0 rounded-full object-cover"
+                />
+              ) : (
+                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#bf5700]/20 text-sm font-bold text-[#bf5700]">
+                  {initials}
+                </span>
+              )}
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-sm font-semibold text-[var(--ui-text)]">{name}</span>
+                  <span className="h-2 w-2 flex-shrink-0 rounded-full bg-green-400" title="Linked" />
+                </div>
+                {cf.title && (
+                  <p className="mt-0.5 text-xs text-[var(--ui-text-muted)] truncate max-w-[140px]">
+                    {cf.title}
+                  </p>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/features/matches/ProfileDetailModal.tsx
+++ b/src/features/matches/ProfileDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import { motion, AnimatePresence } from "motion/react";
 import {
@@ -16,6 +16,7 @@ import {
 import { FaTimes } from "react-icons/fa";
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
+import ProfileViewModal from "@/features/profile/ProfileViewModal";
 import {
   getDegreeAbbreviation,
   getSchoolFullName,
@@ -49,6 +50,8 @@ export default function ProfileDetailModal({
   isUnlikePending,
   weMatchPendingId,
 }: ProfileDetailModalProps) {
+  const [viewingCofounderUserId, setViewingCofounderUserId] = useState<string | null>(null);
+
   if (!profile) return null;
 
   const initials =
@@ -106,6 +109,7 @@ export default function ProfileDetailModal({
   ].filter(Boolean) as { href: string; icon: React.ReactNode; label: string }[];
 
   return (
+    <>
     <AnimatePresence>
       {profile && (
         <motion.div
@@ -197,7 +201,7 @@ export default function ProfileDetailModal({
                   )}
                   {userId && (
                     <div className="mt-2">
-                      <CoFounderLinks userId={userId} />
+                      <CoFounderLinks userId={userId} onClickCofounder={setViewingCofounderUserId} />
                     </div>
                   )}
                 </div>
@@ -388,6 +392,11 @@ export default function ProfileDetailModal({
         </motion.div>
       )}
     </AnimatePresence>
+    <ProfileViewModal
+      userId={viewingCofounderUserId}
+      onClose={() => setViewingCofounderUserId(null)}
+    />
+    </>
   );
 }
 

--- a/src/features/profile/ProfileViewModal.tsx
+++ b/src/features/profile/ProfileViewModal.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import Image from "next/image";
+import { motion, AnimatePresence } from "motion/react";
+import {
+  FaLinkedin,
+  FaGithub,
+  FaTwitter,
+  FaGlobe,
+  FaCalendar,
+  FaPaperPlane,
+  FaArrowLeft,
+} from "react-icons/fa6";
+import { FaTimes } from "react-icons/fa";
+import HiringBadge from "@/components/HiringBadge";
+import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
+import {
+  getDegreeAbbreviation,
+  getSchoolFullName,
+  SECTOR_INTEREST_LABELS,
+} from "@/features/school/data/utSchoolsAndMajors";
+import { useProfileByUserId } from "./useProfile";
+import { useToggleLike, useLikeStatus } from "@/features/likes/useLikes";
+import toast from "react-hot-toast";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface ProfileViewModalProps {
+  /** Pass a full profile when you already have the data (avoids an extra fetch). */
+  profile?: OnboardingData | null;
+  /** Pass only a userId when you don't have the profile object yet (modal fetches it). */
+  userId?: string | null;
+  onClose: () => void;
+}
+
+export default function ProfileViewModal({ profile: profileProp, userId, onClose }: ProfileViewModalProps) {
+  // Internal navigation: when user clicks a linked cofounder, we navigate to their profile.
+  // navUserId overrides the props while set; clearing it returns to the root profile.
+  const [navUserId, setNavUserId] = useState<string | null>(null);
+
+  // Reset internal nav whenever the root target changes (modal opened for a new person)
+  const rootId = profileProp?.user_id ?? userId ?? null;
+  useEffect(() => { setNavUserId(null); }, [rootId]);
+
+  const targetId = navUserId ?? rootId;
+  const isNavigated = !!navUserId;
+
+  // Only fetch when we don't have the profile directly (or we've navigated away)
+  const shouldFetch = isNavigated || (!profileProp && !!targetId);
+  const { data: fetchedProfile, isLoading } = useProfileByUserId(targetId ?? "", shouldFetch && !!targetId);
+  const profile = isNavigated ? (fetchedProfile ?? null) : (profileProp ?? fetchedProfile ?? null);
+
+  const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
+  const { data: likeStatus } = useLikeStatus(targetId ?? "");
+  const queryClient = useQueryClient();
+
+  const handleInvite = async () => {
+    if (!targetId || isLikeLoading) return;
+    try {
+      await toggleLike(targetId, likeStatus?.isLiked ?? false);
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+      queryClient.invalidateQueries({ queryKey: ["profiles-search"] });
+    } catch {
+      toast.error("Failed to send invite");
+    }
+  };
+
+  if (!targetId) return null;
+
+  const initials = profile
+    ? (profile.firstName?.[0] ?? "").toUpperCase() + (profile.lastName?.[0] ?? "").toUpperCase()
+    : "";
+
+  const degreeAbbrev =
+    profile?.utCollege && profile?.utMajor
+      ? getDegreeAbbreviation(profile.utCollege, profile.utMajor)
+      : undefined;
+
+  const yearSuffix = profile?.gradYear
+    ? `'${String(profile.gradYear).slice(-2)}`
+    : undefined;
+
+  const schoolFullName = profile?.utCollege
+    ? getSchoolFullName(profile.utCollege)
+    : undefined;
+
+  const isOnline = profile?.last_active_at
+    ? new Date().getTime() - new Date(profile.last_active_at).getTime() < 5 * 60 * 1000
+    : false;
+
+  const socialLinks = profile
+    ? [
+        profile.linkedin && { href: profile.linkedin, icon: <FaLinkedin className="h-4 w-4" />, label: "LinkedIn" },
+        profile.twitter && { href: profile.twitter, icon: <FaTwitter className="h-4 w-4" />, label: "Twitter / X" },
+        profile.git && { href: profile.git, icon: <FaGithub className="h-4 w-4" />, label: "GitHub" },
+        profile.personalWebsite && { href: profile.personalWebsite, icon: <FaGlobe className="h-4 w-4" />, label: "Website" },
+        profile.schedulingUrl && { href: profile.schedulingUrl, icon: <FaCalendar className="h-4 w-4" />, label: "Schedule a call" },
+      ].filter(Boolean) as { href: string; icon: React.ReactNode; label: string }[]
+    : [];
+
+  const showLoading = isLoading && shouldFetch;
+
+  return (
+    <AnimatePresence>
+      {targetId && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="flex h-[92vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] shadow-2xl sm:rounded-2xl sm:h-[85vh]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Sticky header */}
+            <div className="flex-shrink-0 border-b border-[var(--ui-border)] p-5">
+              {showLoading ? (
+                <div className="flex items-center gap-4">
+                  <div className="h-[72px] w-[72px] flex-shrink-0 animate-pulse rounded-full bg-[var(--ui-surface-active)]" />
+                  <div className="flex flex-col gap-2">
+                    <div className="h-5 w-40 animate-pulse rounded-md bg-[var(--ui-surface-active)]" />
+                    <div className="h-4 w-28 animate-pulse rounded-md bg-[var(--ui-surface-active)]" />
+                  </div>
+                </div>
+              ) : profile ? (
+                <div className="flex items-start gap-4">
+                  {/* Back button when navigated into a cofounder */}
+                  {isNavigated && (
+                    <button
+                      onClick={() => setNavUserId(null)}
+                      className="mt-1 flex-shrink-0 rounded-full p-2 text-[var(--ui-text-muted)] transition hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] cursor-pointer"
+                      title="Back"
+                    >
+                      <FaArrowLeft className="h-4 w-4" />
+                    </button>
+                  )}
+
+                  <div className="relative flex-shrink-0">
+                    {profile.pfp_url ? (
+                      <Image
+                        src={profile.pfp_url}
+                        alt={`${profile.firstName} ${profile.lastName}`}
+                        width={72}
+                        height={72}
+                        className="h-[72px] w-[72px] rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-[72px] w-[72px] items-center justify-center rounded-full bg-gray-100 text-xl font-bold text-gray-700">
+                        {initials}
+                      </div>
+                    )}
+                    <div
+                      className={`absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ${isOnline ? "bg-green-500" : "bg-gray-300"}`}
+                    />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-bold text-[var(--ui-text)]">
+                        {profile.firstName} {profile.lastName}
+                      </h2>
+                      {profile.isHiring && (
+                        <HiringBadge
+                          hiringEmail={profile.hiringEmail}
+                          companyName={profile.startupName}
+                          className="px-2 py-0.5 text-xs"
+                        />
+                      )}
+                    </div>
+
+                    <div className="flex flex-wrap gap-1.5">
+                      {profile.utStatus && (
+                        <span className="inline-flex items-center rounded-md border border-[var(--ui-border-strong)] px-2 py-0.5 text-xs font-medium text-[var(--ui-text-muted)]">
+                          {profile.utStatus === "student" ? "Student" : "Alumni"}
+                        </span>
+                      )}
+                      {profile.archetype && (
+                        <span className="inline-flex items-center rounded-md border border-[var(--org-primary)] px-2 py-0.5 text-xs font-medium text-[var(--org-primary)]">
+                          {profile.archetype === "the_scaler"
+                            ? "The Scaler"
+                            : profile.archetype === "the_steward"
+                              ? "The Steward"
+                              : "The Architect"}
+                        </span>
+                      )}
+                      {profile.isTechnical && (
+                        <span className="inline-flex items-center rounded-md border border-[var(--org-primary)] px-2 py-0.5 text-xs font-medium text-[var(--org-primary)]">
+                          {profile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
+                        </span>
+                      )}
+                    </div>
+
+                    {(degreeAbbrev || schoolFullName) && (
+                      <p className="mt-1.5 text-xs text-[var(--ui-text-muted)]">
+                        {degreeAbbrev && yearSuffix ? `${degreeAbbrev} ${yearSuffix}` : degreeAbbrev ?? ""}
+                        {schoolFullName && profile.utMajor ? ` · ${schoolFullName} — ${profile.utMajor}` : ""}
+                      </p>
+                    )}
+
+                    {targetId && (
+                      <div className="mt-2">
+                        <CoFounderLinks userId={targetId} onClickCofounder={setNavUserId} />
+                      </div>
+                    )}
+                  </div>
+
+                  <button
+                    onClick={onClose}
+                    className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                  >
+                    <FaTimes className="h-4 w-4" />
+                  </button>
+                </div>
+              ) : null}
+            </div>
+
+            {/* Scrollable body */}
+            {profile && (
+              <div className="flex-1 overflow-y-auto p-5">
+                <div className="space-y-5">
+                  {profile.personalIntro && (
+                    <Section title="About">
+                      <p className="text-sm leading-relaxed text-[var(--ui-text)]">
+                        {profile.personalIntro}
+                      </p>
+                    </Section>
+                  )}
+
+                  {profile.utSectorInterests && profile.utSectorInterests.length > 0 && (
+                    <Section title="Sector Interests">
+                      <div className="flex flex-wrap gap-1.5">
+                        {profile.utSectorInterests.map((interest: string, i: number) => (
+                          <span
+                            key={interest}
+                            className="rounded-md px-2.5 py-1 text-xs font-medium"
+                            style={
+                              i < 2
+                                ? { backgroundColor: "var(--org-primary)", color: "#fff" }
+                                : { backgroundColor: "#f3f4f6", color: "#6b7280" }
+                            }
+                          >
+                            {SECTOR_INTEREST_LABELS[interest as keyof typeof SECTOR_INTEREST_LABELS] || interest}
+                          </span>
+                        ))}
+                      </div>
+                    </Section>
+                  )}
+
+                  {profile.education && (
+                    <Section title="Education">
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                        {profile.education}
+                      </p>
+                    </Section>
+                  )}
+
+                  {profile.experience && (
+                    <Section title="Experience">
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                        {profile.experience}
+                      </p>
+                    </Section>
+                  )}
+
+                  {profile.accomplishments && (
+                    <Section title="Accomplishments">
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                        {profile.accomplishments}
+                      </p>
+                    </Section>
+                  )}
+
+                  {profile.hasStartup === "yes" && profile.startupName && (
+                    <Section title="Startup">
+                      <p className="mb-1 font-medium text-[var(--ui-text)]">{profile.startupName}</p>
+                      {profile.startupDescription && (
+                        <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
+                          {profile.startupDescription}
+                        </p>
+                      )}
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {profile.startupTimeSpent && (
+                          <span className="rounded-md bg-gray-100 px-2.5 py-1 text-xs text-gray-500">
+                            {profile.startupTimeSpent}
+                          </span>
+                        )}
+                        {profile.startupFunding && (
+                          <span className="rounded-md bg-gray-100 px-2.5 py-1 text-xs text-gray-500">
+                            {profile.startupFunding}
+                          </span>
+                        )}
+                      </div>
+                    </Section>
+                  )}
+
+                  {socialLinks.length > 0 && (
+                    <Section title="Connect">
+                      <div className="flex flex-wrap gap-2">
+                        {socialLinks.map(({ href, icon, label }) => (
+                          <a
+                            key={label}
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[var(--org-primary)] hover:text-[var(--org-primary)]"
+                          >
+                            {icon}
+                            {label}
+                          </a>
+                        ))}
+                      </div>
+                    </Section>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Footer */}
+            {profile && (
+              <div className="flex-shrink-0 border-t border-[var(--ui-border)] p-4">
+                <button
+                  onClick={handleInvite}
+                  disabled={isLikeLoading}
+                  className={`flex w-full items-center justify-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 cursor-pointer ${
+                    likeStatus?.isLiked
+                      ? "bg-pink-500 text-white hover:bg-pink-600"
+                      : "bg-[var(--org-primary)] text-white hover:opacity-90"
+                  }`}
+                >
+                  <FaPaperPlane className="h-4 w-4" />
+                  {likeStatus?.isLiked ? "Invited ✓" : "Send Invite"}
+                </button>
+              </div>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -79,6 +79,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
     {
       href: `/school/${slug}/dashboard`,
       label: "Find a co-foundr",
+      featured: true,
     },
     {
       href: `/school/${slug}/contact-us`,
@@ -102,23 +103,26 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
     >
       <Link
         href={`/school/${slug}`}
-        className="text-base font-semibold tracking-tight text-white"
+        className="text-base font-semibold tracking-tight text-white/70 transition-colors hover:text-white"
       >
         {headerText}
       </Link>
 
       {/* Desktop nav */}
       <nav className="hidden flex-1 items-center justify-end gap-8 md:flex">
-        {navItems.map(({ href, label }) => (
+        {navItems.map(({ href, label, featured }) => (
           <Link
             key={href}
             href={href}
-            className={clsx(
-              "text-sm font-medium transition-opacity border-b-2",
-              pathname.startsWith(href)
-                ? "opacity-100 border-white"
-                : "opacity-70 hover:opacity-90 border-transparent",
-            )}
+            className={featured
+              ? "rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
+              : clsx(
+                  "text-sm font-medium transition-colors border-b-2",
+                  pathname.startsWith(href)
+                    ? "text-white border-white"
+                    : "text-white/70 hover:text-white border-transparent",
+                )
+            }
           >
             {label}
           </Link>
@@ -127,8 +131,16 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
 
       <div className="ml-4 flex items-center gap-4 md:ml-8 md:gap-6">
         <Link
+          href={`/school/${slug}/cofounder`}
+          className="hidden items-center gap-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white md:flex"
+        >
+          <FaUserPlus className="h-3.5 w-3.5" />
+          Invite a co-foundr
+        </Link>
+
+        <Link
           href={`/school/${slug}/matches`}
-          className="relative flex items-center justify-center transition-opacity hover:opacity-80"
+          className="relative flex items-center justify-center text-white/70 transition-colors hover:text-white"
         >
           <FaHeart className="h-5 w-5 text-white" />
           {savedMatchesCount > 0 && (
@@ -155,11 +167,6 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
                 labelIcon={<FaUserPen className="h-3.5 w-3.5" />}
                 href={`/school/${slug}/profile`}
               />
-              <UserButton.Link
-                label="Invite a co-founder"
-                labelIcon={<FaUserPlus className="h-3.5 w-3.5" />}
-                href={`/school/${slug}/cofounder`}
-              />
               <UserButton.Action
                 label="Delete Account"
                 labelIcon={<FaTrash className="h-3.5 w-3.5 text-red-500" />}
@@ -172,7 +179,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
         {/* Mobile hamburger */}
         <button
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          className="cursor-pointer rounded-lg p-1.5 text-white transition-opacity hover:opacity-80 md:hidden"
+          className="cursor-pointer rounded-lg p-1.5 text-white/70 transition-colors hover:text-white md:hidden"
           aria-label="Toggle menu"
         >
           {isMobileMenuOpen ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
@@ -187,17 +194,30 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
           style={{ backgroundColor: config.branding.primaryColor }}
         >
           <ul className="p-2 space-y-0.5">
-            {navItems.map(({ href, label }) => (
+            {navItems.map(({ href, label, featured }) => (
               <li key={href}>
                 <Link
                   href={href}
-                  className="block rounded-lg px-3 py-2 text-sm font-medium text-white/80 hover:bg-white/10 hover:text-white"
+                  className={featured
+                    ? "block rounded-lg border border-white/30 px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
+                    : "block rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                  }
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   {label}
                 </Link>
               </li>
             ))}
+            <li>
+              <Link
+                href={`/school/${slug}/cofounder`}
+                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                <FaUserPlus className="h-3.5 w-3.5" />
+                Invite a co-foundr
+              </Link>
+            </li>
           </ul>
         </div>
       )}

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -26,7 +26,7 @@ export async function sendTemplateEmail<T extends EmailType>({
 
   try {
     await (
-      resend.emails.send as unknown as (
+      resend.emails.create as unknown as (
         o: Record<string, unknown>,
       ) => Promise<unknown>
     )({


### PR DESCRIPTION
# MCFM-130 | Add profile modal for viewing search results + co-founder links

## Summary
Introduces a reusable `ProfileViewModal` that lets users view full profile details inline — without leaving the search page or the swipe flow — by clicking any search result card or any linked co-founder chip. The modal supports two data modes: pass a pre-loaded `OnboardingData` object (zero extra fetch) or just a `userId` (modal fetches on demand). Internal cofounder navigation is built-in: clicking a co-founder chip from within the modal pushes to their profile with a back button, without opening a second modal. Alongside this, several supporting fixes land: the co-founder invite accept email bug is corrected, `CoFounderLinks` is visually overhauled into a card layout, "Invite a co-foundr" is promoted to the top-level header, and the Resend SDK call is updated to `emails.create`.

## Changes

### New: `ProfileViewModal` component
- Added `src/features/profile/ProfileViewModal.tsx` (357 lines) as a fully self-contained animated sheet/modal showing a user's complete profile: avatar with online indicator, badges (archetype, technical/non-technical, hiring), degree/school, co-founders, about, sector interests, education, experience, accomplishments, startup info, social links, and a "Send Invite / Invited ✓" toggle button.
- Dual-mode API: accepts either `profile?: OnboardingData` (avoids a network round-trip when the data is already in hand) or `userId?: string` (modal fetches via `useProfileByUserId`). When navigating to a cofounder from within the modal, `navUserId` state overrides the root and forces a fetch, with a back button to return to the original profile.
- Root-target tracking via `useEffect` on `rootId` ensures `navUserId` resets whenever the modal is opened for a different person, preventing stale navigation state.

### Client: Dashboard page + search card
- `SearchResultCard` in `src/app/(school)/school/[slug]/dashboard/page.tsx` is now a `<button>` wrapping the card body, firing `onViewProfile(profile)` on click to open `ProfileViewModal` with the already-loaded profile data.
- `CoFounderLinks` inside the card wraps its click in `e.stopPropagation()` so tapping a co-founder chip opens their profile without also triggering the parent card click.
- Page-level state (`viewingProfile`, `viewingUserId`) drives a single `ProfileViewModal` instance shared across all search result cards.
- The existing swipe/match card on the dashboard also gains `onClickCofounder={setViewingUserId}` so co-founder chips there also open the modal.

### Client: `ProfileDetailModal` (matches flow)
- `src/features/matches/ProfileDetailModal.tsx` gains a `viewingCofounderUserId` state and renders a nested `ProfileViewModal` for cofounder-chip clicks, using a `<>` fragment to keep both modals in the tree simultaneously.

### Component: `CoFounderLinks` visual overhaul
- `src/features/cofounder/CoFounderLinks.tsx` reworked from small horizontal pill chips into column-stacked cards with a 36×36 avatar, name in semibold, title in muted text below, and a green "linked" dot. Hover state uses `#bf5700` border/background to match org branding.
- The component is consistently passed `onClickCofounder` from every call site so co-founder navigation is available wherever it renders.

### API: Profile authorization — same-org members
- `src/app/api/profile/[userId]/route.ts` adds a new authorization path (case 2 in the chain): if the requester's Clerk `sessionClaims.metadata.organization_id` matches the target user's `organization_id` in Supabase, the profile is returned immediately. This is required so dashboard members can fetch profiles of peers they haven't matched or messaged yet — without it, `ProfileViewModal` would 403 on any unfamiliar profile.

### API: Co-founder invite accept — email bug fix
- `src/app/api/cofounder-invite/[token]/accept/route.ts` had an inverted condition: `if (orgRow?.slug)` branched into the happy path, but the intent was to guard with `if (!orgRow?.slug)` for the error log, then proceed in the `else`. Fixed to correctly fall into the email-send block when the slug is present.
- Captures `Promise.allSettled` results into `[inviterResult, acceptorResult]` and logs individual rejections, replacing silent failure. Adds pre-flight `console.warn` when either party has no email address.

### Header: Promote "Invite a co-foundr" to top nav
- `src/features/school/components/SchoolHeader.tsx` moves "Invite a co-foundr" from the Clerk `UserButton` dropdown (low-visibility) to a dedicated `<Link>` in the desktop nav and mobile hamburger menu — matching the primary CTA prominence the feature deserves.
- "Find a co-foundr" receives a `featured: true` nav flag that renders it as a bordered pill button rather than a plain underlined link, visually distinguishing the primary action.

### Email: Resend SDK method fix
- `src/lib/email/send.ts` updates the Resend call from `resend.emails.send` to `resend.emails.create`, aligning with the current Resend SDK API surface. The previous method was causing co-founder linked emails to fail silently.

## Migration / Config
- No new env vars or DB migrations required.
- Profile API authorization expansion is purely additive and backward-compatible.

## Testing
- Manually verified profile modal opens from search result cards and displays correct data.
- Verified cofounder chip navigation (forward + back) within the modal.
- Verified co-founder invite accept email now sends correctly after the inverted-condition and Resend SDK fixes.
- Verified "Invite a co-foundr" appears in header on desktop and mobile.