### PR TITLE
MCFM 131 | Data Bleed Fix

### DIFF
--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -201,8 +201,8 @@ export default function SchoolDashboardPage() {
   const queryClient = useQueryClient();
   const cardRef = useRef<HTMLDivElement>(null);
 
-  const { schoolName } = useSchool();
-  const { data: profiles, isLoading: isLoadingProfiles } = useGetProfiles(filters);
+  const { schoolName, slug } = useSchool();
+  const { data: profiles, isLoading: isLoadingProfiles } = useGetProfiles(filters, slug);
 
   useEffect(() => {
     setFilters(loadDashboardFilters());
@@ -212,7 +212,7 @@ export default function SchoolDashboardPage() {
     setFilters(next);
     saveDashboardFilters(next);
   };
-  const { data: searchResults, isFetching: isSearching, inferred, emptyReason, dismissFilter } = useSearchProfiles(searchQuery, filters);
+  const { data: searchResults, isFetching: isSearching, inferred, emptyReason, dismissFilter } = useSearchProfiles(searchQuery, filters, slug);
 
   // Relax a single binding filter from the empty-results state. Inferred filters
   // are dismissed (Mode B re-search); user filters are cleared from the sidebar.

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,19 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
 import {
   filterProfilesByPreferences,
   scoreCandidate,
 } from "@/features/matching/matchingService";
-
-function isApexHost(host: string): boolean {
-  const bare = host.split(":")[0].toLowerCase();
-  return (
-    bare === "mamuncofoundr.com" ||
-    bare === "www.mamuncofoundr.com"
-  );
-}
+import { resolveTenantScope } from "@/features/school/auth/tenant-scope";
 
 export async function GET(req: NextRequest) {
   try {
@@ -28,24 +21,20 @@ export async function GET(req: NextRequest) {
       process.env.SUPABASE_SERVICE_ROLE_KEY!,
     );
 
-    // Organization context: null = general pool, UUID = school tenant
-    const orgId = sessionClaims?.metadata?.organization_id ?? null;
+    // Tenant context is anchored to the page's org slug (untrusted input,
+    // validated server-side), NOT the HTTP host. `denied` → the viewer is not
+    // a member of the requested school and isn't staff, so return nothing.
+    const sessionOrgId = sessionClaims?.metadata?.organization_id ?? null;
+    const slug = req.nextUrl.searchParams.get("org");
+    const scope = await resolveTenantScope({ userId, sessionOrgId, slug });
 
-    // Mamun staff (@mamuncofoundr.com) on the apex host should see the general
-    // pool, not their org-scoped pool. Other school orgs are never mixed in.
-    const host = req.headers.get("host") ?? "";
-    const onApex = isApexHost(host);
-    let useGeneralPool = !orgId;
-    if (orgId && onApex) {
-      const clerk = await clerkClient();
-      const user = await clerk.users.getUser(userId);
-      const email = user.emailAddresses
-        .find((e) => e.id === user.primaryEmailAddressId)
-        ?.emailAddress?.toLowerCase();
-      if (email?.endsWith("@mamuncofoundr.com")) {
-        useGeneralPool = true;
-      }
+    if (scope.kind === "denied") {
+      return NextResponse.json({ profiles: [] });
     }
+
+    // null = general pool (organization_id IS NULL), UUID = school tenant pool
+    const useGeneralPool = scope.kind === "general";
+    const scopeOrgId = scope.kind === "org" ? scope.orgId : null;
 
     // Get the current user's profile
     const { data: currentUserData, error: currentUserError } = await supabase
@@ -76,7 +65,7 @@ export async function GET(req: NextRequest) {
     // school-specific onboarding (i.e. have a row in school_profiles for this
     // org). Acts as the "verified school user" filter. Must be scoped by
     // organization_id to avoid leaking cross-tenant existence.
-    const inSchoolTenant = !useGeneralPool && !!orgId;
+    const inSchoolTenant = !useGeneralPool && !!scopeOrgId;
 
     const collegeFilter = req.nextUrl.searchParams.get("college");
     const sectorsParam = req.nextUrl.searchParams.get("sectors");
@@ -99,7 +88,7 @@ export async function GET(req: NextRequest) {
       let schoolQuery = supabase
         .from("school_profiles")
         .select("user_id")
-        .eq("organization_id", orgId);
+        .eq("organization_id", scopeOrgId);
 
       if (collegeFilter) {
         schoolQuery = schoolQuery.eq("college", collegeFilter);
@@ -129,7 +118,7 @@ export async function GET(req: NextRequest) {
     if (useGeneralPool) {
       query = query.is("organization_id", null);
     } else {
-      query = query.eq("organization_id", orgId);
+      query = query.eq("organization_id", scopeOrgId);
     }
 
     if (schoolUserIds !== null) {
@@ -178,7 +167,7 @@ export async function GET(req: NextRequest) {
       const { data: schoolRows } = await supabase
         .from("school_profiles")
         .select("user_id, school_status, graduation_year, college, degree_type, major, sector_interests, intent")
-        .eq("organization_id", orgId)
+        .eq("organization_id", scopeOrgId)
         .in("user_id", candidateIds);
 
       const schoolMap = new Map(

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -13,6 +13,7 @@ import {
   getSchoolLabel,
   SECTOR_INTEREST_LABELS,
 } from "@/features/school/data/utSchoolsAndMajors";
+import { resolveTenantScope } from "@/features/school/auth/tenant-scope";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -27,6 +28,8 @@ type CachedParse = {
 
 type SearchRequest = {
   q: string;
+  /** Page tenant slug; scoping is anchored to this org, validated server-side. */
+  org?: string;
   userFilters?: Partial<DashboardFilters>;
   cachedParse?: CachedParse;
   dismissedFilterKeys?: string[];
@@ -319,10 +322,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ profiles: [], inferred: null });
     }
 
-    const orgId = sessionClaims?.metadata?.organization_id ?? null;
-    if (!orgId) {
+    // Search runs only within a school tenant, anchored to the page's org slug
+    // (untrusted, validated server-side). General-pool users and non-members
+    // get no results — never another tenant's data.
+    const sessionOrgId = sessionClaims?.metadata?.organization_id ?? null;
+    const scope = await resolveTenantScope({
+      userId,
+      sessionOrgId,
+      slug: body.org ?? null,
+    });
+    if (scope.kind !== "org") {
       return NextResponse.json({ profiles: [], inferred: null });
     }
+    const orgId = scope.orgId;
 
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
     const userFilters = normalizeDashboardFilters(body.userFilters);

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -9,7 +9,7 @@ import {
 } from "@/features/school/data/dashboardFilters";
 import type { ParsedQuery } from "@/lib/searchQueryParser";
 
-export function useGetProfiles(filters?: DashboardFilters) {
+export function useGetProfiles(filters?: DashboardFilters, orgSlug?: string) {
   const { userId } = useAuth();
   const { session } = useSession();
 
@@ -18,7 +18,7 @@ export function useGetProfiles(filters?: DashboardFilters) {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["profiles", filters],
+    queryKey: ["profiles", filters, orgSlug],
     queryFn: async () => {
       const token = await session?.getToken();
 
@@ -30,7 +30,11 @@ export function useGetProfiles(filters?: DashboardFilters) {
         throw { message: "No user id. Please log in." };
       }
 
-      const queryString = filters ? buildProfilesQueryString(filters) : "";
+      const params = new URLSearchParams(
+        filters ? buildProfilesQueryString(filters).replace(/^\?/, "") : "",
+      );
+      if (orgSlug) params.set("org", orgSlug);
+      const queryString = params.toString() ? `?${params.toString()}` : "";
 
       try {
         const response = await fetch(`/api/profiles${queryString}`, {
@@ -143,7 +147,11 @@ export function useProfileByUserId(userId: string, enabled: boolean = true) {
   });
 }
 
-export function useSearchProfiles(query: string, userFilters: DashboardFilters) {
+export function useSearchProfiles(
+  query: string,
+  userFilters: DashboardFilters,
+  orgSlug?: string,
+) {
   const { session } = useSession();
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
@@ -185,6 +193,7 @@ export function useSearchProfiles(query: string, userFilters: DashboardFilters) 
     userFilters,
     dismissedKeys.join(","),
     isDismissMode,
+    orgSlug,
   ];
 
   const searchQuery = useQuery<
@@ -203,6 +212,7 @@ export function useSearchProfiles(query: string, userFilters: DashboardFilters) 
 
       const body = {
         q: debouncedQuery,
+        ...(orgSlug && { org: orgSlug }),
         userFilters,
         ...(isDismissMode && {
           cachedParse,

--- a/src/features/school/auth/tenant-scope.ts
+++ b/src/features/school/auth/tenant-scope.ts
@@ -1,0 +1,61 @@
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
+import { getVerifiedPrimaryEmail } from "@/features/school/auth/org-admin";
+
+const STAFF_EMAIL_DOMAIN = "@mamuncofoundr.com";
+
+/**
+ * Which matching pool a request is allowed to read.
+ *  - `general` → the main pool (profiles where organization_id IS NULL)
+ *  - `org`     → a single school tenant's pool (organization_id = orgId)
+ *  - `denied`  → the viewer may not see the requested tenant; return empty
+ */
+export type TenantScope =
+  | { kind: "denied" }
+  | { kind: "general" }
+  | { kind: "org"; orgId: string };
+
+export async function isMamunStaff(userId: string): Promise<boolean> {
+  const email = await getVerifiedPrimaryEmail(userId);
+  return !!email?.endsWith(STAFF_EMAIL_DOMAIN);
+}
+
+/**
+ * Resolve which pool a matching/search request may read, anchored to the
+ * tenant of the *page* (the `org` slug) rather than the HTTP host.
+ *
+ * The slug is untrusted input from the client; membership is validated
+ * server-side, so a forged or mismatched slug resolves to `denied` and the
+ * caller returns empty results — never another tenant's (or the main) data.
+ *
+ * Rules:
+ *  - On a school page (slug present): the pool is that school's. The viewer
+ *    must be a member of that org, or be Mamun staff (page tenant always wins,
+ *    so staff see the school's pool here — never the general pool).
+ *  - On the apex page (no slug): general users and Mamun staff see the general
+ *    pool. A school user hitting the slug-less endpoint is scoped to their own
+ *    org defensively (middleware normally redirects them to their portal).
+ */
+export async function resolveTenantScope({
+  userId,
+  sessionOrgId,
+  slug,
+}: {
+  userId: string;
+  sessionOrgId: string | null;
+  slug: string | null;
+}): Promise<TenantScope> {
+  if (slug) {
+    const org = await getOrganizationBySlug(slug);
+    if (!org) return { kind: "denied" };
+
+    if (sessionOrgId === org.id) return { kind: "org", orgId: org.id };
+    if (await isMamunStaff(userId)) return { kind: "org", orgId: org.id };
+
+    return { kind: "denied" };
+  }
+
+  if (!sessionOrgId) return { kind: "general" };
+  if (await isMamunStaff(userId)) return { kind: "general" };
+
+  return { kind: "org", orgId: sessionOrgId };
+}

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -25,16 +25,23 @@ export async function sendTemplateEmail<T extends EmailType>({
   const { templateId } = EMAIL_CATALOG[type];
 
   try {
-    await (
+    const result = (await (
       resend.emails.create as unknown as (
         o: Record<string, unknown>,
-      ) => Promise<unknown>
+      ) => Promise<{ data?: { id?: string } | null; error?: unknown }>
     )({
       from,
       to,
       template: { id: templateId, variables },
-    });
-    console.log(`[email] sent ${type} to ${to}`);
+    }));
+
+    // Resend does NOT throw on API errors — it returns { data, error }.
+    if (result?.error) {
+      console.error(`[email] send_error for ${type} to ${to}:`, result.error);
+      return { ok: false, reason: "send_error" };
+    }
+
+    console.log(`[email] sent ${type} to ${to} (id: ${result?.data?.id ?? "unknown"})`);
     return { ok: true };
   } catch (err) {
     console.error(`[email] send_error for ${type} to ${to}:`, err);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -187,6 +187,18 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
         return NextResponse.redirect(new URL("/", req.url));
       }
 
+      // Path-based tenant enforcement: a signed-in school user must not view
+      // another org's /school/<slug> portal. Mirrors the subdomain guard above.
+      // On subdomains the rewrite has already aligned the slug, so this is a
+      // no-op there; it only bites on apex /school/<other-slug> access.
+      const pathSlug = pathname.match(/^\/school\/([^/]+)/)?.[1];
+      const isAuthFlowPath = /\/(sign-in|sign-up|sso-callback|sso-complete)(\/|$)/.test(pathname);
+      if (pathSlug && pathSlug !== org.slug && !isAuthFlowPath) {
+        return NextResponse.redirect(
+          new URL(`/school/${org.slug}/dashboard`, req.url),
+        );
+      }
+
       // FERPA gate
       if (!org.ferpa_dpa_signed_at) {
         const pendingUrl = new URL(`/school/${org.slug}/pending-activation`, req.url);


### PR DESCRIPTION
## Summary

This PR fixes a data-bleed vulnerability where the tenant scope for profile matching and search was anchored to the HTTP `host` header — a forgeable signal — rather than the school's URL slug. A new `resolveTenantScope` utility centralises all tenant-scoping logic, validates the slug server-side, and enforces a strict `general | org | denied` enum so no code path can accidentally fall through to another tenant's data. Middleware is also hardened to redirect school users who attempt to navigate to another org's `/school/<slug>` portal. Separately, the Resend email wrapper is fixed to detect API-level errors that the SDK returns as `{ data, error }` rather than throwing.

## Changes

### Auth / Tenant Scoping
- Introduce `resolveTenantScope` in `src/features/school/auth/tenant-scope.ts` — a typed, async function that maps `(userId, sessionOrgId, slug)` to a `TenantScope` discriminated union (`general | org | denied`). Slug is treated as untrusted input: if it doesn't resolve to a known org, or the viewer isn't a member/staff, the scope is `denied` and callers return empty results rather than leaking data. This makes all tenant-gating logic auditable in one place.
- Replace the `isApexHost` heuristic in `src/app/api/profiles/route.ts` with `resolveTenantScope`. The old approach called the Clerk Users API on every request just to inspect the email domain and had a subtle host-spoofing vector; the new path reads the `org` slug from the query string and validates membership server-side with no Clerk roundtrip for normal users.
- Apply the same refactor to `src/app/api/profiles/search/route.ts` — search is now denied entirely unless `scope.kind === "org"`, preventing general-pool or cross-tenant searches.

### Middleware
- Add path-based tenant enforcement: if a signed-in school user navigates to `/school/<other-slug>/...` directly (apex-domain path), middleware now redirects them to their own portal (`/school/<their-slug>/dashboard`). Auth-flow paths (`sign-in`, `sign-up`, `sso-callback`, `sso-complete`) are exempted so OAuth callbacks aren't broken.

### Client
- `useGetProfiles` and `useSearchProfiles` in `src/features/profile/useProfile.ts` now accept `orgSlug?: string` and include it as the `org` query param (GET) or body field (POST). The React Query key includes `orgSlug` so per-tenant results are cached independently.
- `SchoolDashboardPage` extracts `slug` from `useSchool()` and forwards it to both hooks, wiring the end-to-end tenant anchor.

### Email
- Fix `sendTemplateEmail` in `src/lib/email/send.ts` to check `result.error` after the Resend call — the SDK never throws on API errors, only on network failures. Success logs now include the Resend message ID for traceability.

## Migration / Config
- No new env vars or DB migrations. The `org` query param is a new addition to `/api/profiles` and `/api/profiles/search` — existing callers without it will resolve to either the general pool (no session org) or their session org (school users), matching prior behaviour.

## Testing
- Verified that a school user accessing the apex `/api/profiles` endpoint without the `org` param is scoped to their session org and cannot see general-pool or cross-tenant data.
- Verified that a forged `org` slug (not matching the user's session org and not Mamun staff) returns an empty result set.
- Verified middleware redirect: navigating to `/school/<other-slug>/dashboard` while signed into a different school org redirects correctly.
- Email error path confirmed via Resend sandbox returning a structured error — `send_error` is now logged rather than silently returning `{ ok: true }`.

## Notes
- The `isMamunStaff` helper in `tenant-scope.ts` re-uses `getVerifiedPrimaryEmail` (already in `org-admin.ts`) to avoid duplicating the Clerk fetch pattern.
- On subdomain deployments the middleware rewrite has already aligned the slug before this guard runs, so the path-match is a no-op and adds no latency on those requests.