### PR TITLE
MCFM-133 | Surface different match types on admin dashboard

### DIFF
--- a/src/app/(school)/school/[slug]/admin/page.tsx
+++ b/src/app/(school)/school/[slug]/admin/page.tsx
@@ -11,10 +11,14 @@ import {
   FaChartBar,
   FaFileCsv,
   FaHeart,
+  FaLink,
+  FaHandshake,
+  FaClock,
 } from "react-icons/fa";
 import { FaShieldAlt } from "react-icons/fa";
 import toast from "react-hot-toast";
 import type { OrgConnection } from "@/app/api/school/connections/route";
+import type { MatchConnection } from "@/app/api/school/match-connections/route";
 import { toCsv } from "@/lib/csv";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -45,6 +49,14 @@ type Tab = "roster" | "connections" | "analytics" | "reports";
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
+function toHumanLabel(value: string | null): string | null {
+  if (!value) return null;
+  return value
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 function StatCard({ label, value }: { label: string; value: number | string }) {
   return (
     <div className="rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4">
@@ -66,9 +78,19 @@ export default function SchoolAdminPage() {
   const [rosterLoading, setRosterLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
+  const [connectionsView, setConnectionsView] = useState<
+    "matches" | "conversations"
+  >("matches");
+
   const [connections, setConnections] = useState<OrgConnection[]>([]);
   const [connectionsLoading, setConnectionsLoading] = useState(false);
   const [connectionsFetched, setConnectionsFetched] = useState(false);
+
+  const [matchConnections, setMatchConnections] = useState<MatchConnection[]>(
+    [],
+  );
+  const [matchesLoading, setMatchesLoading] = useState(false);
+  const [matchesFetched, setMatchesFetched] = useState(false);
 
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [analyticsLoading, setAnalyticsLoading] = useState(false);
@@ -115,6 +137,25 @@ export default function SchoolAdminPage() {
     }
   }, [session]);
 
+  const fetchMatchConnections = useCallback(async () => {
+    if (!session) return;
+    setMatchesLoading(true);
+    try {
+      const token = await session.getToken();
+      const res = await fetch("/api/school/match-connections", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Forbidden");
+      const data = await res.json();
+      setMatchConnections(data.connections ?? []);
+    } catch {
+      toast.error("Failed to load match connections.");
+    } finally {
+      setMatchesLoading(false);
+      setMatchesFetched(true);
+    }
+  }, [session]);
+
   const fetchAnalytics = useCallback(async () => {
     if (!session) return;
     setAnalyticsLoading(true);
@@ -139,12 +180,15 @@ export default function SchoolAdminPage() {
   }, [fetchStudents]);
 
   useEffect(() => {
+    if (activeTab === "connections" && !matchesFetched) fetchMatchConnections();
     if (activeTab === "connections" && !connectionsFetched) fetchConnections();
     if (activeTab === "analytics" && !analyticsFetched) fetchAnalytics();
   }, [
     activeTab,
+    matchesFetched,
     connectionsFetched,
     analyticsFetched,
+    fetchMatchConnections,
     fetchConnections,
     fetchAnalytics,
   ]);
@@ -193,7 +237,7 @@ export default function SchoolAdminPage() {
         s.first_name,
         s.last_name,
         s.title ?? "",
-        s.education ?? "",
+        toHumanLabel(s.education) ?? "",
         s.city,
         s.country,
         s.is_technical ? "yes" : "no",
@@ -309,9 +353,14 @@ export default function SchoolAdminPage() {
           )}
           {(activeTab === "connections" || activeTab === "analytics") && (
             <button
-              onClick={
-                activeTab === "connections" ? fetchConnections : fetchAnalytics
-              }
+              onClick={() => {
+                if (activeTab === "analytics") {
+                  fetchAnalytics();
+                } else {
+                  fetchMatchConnections();
+                  fetchConnections();
+                }
+              }}
               className="flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition"
               style={{
                 borderColor: "var(--ui-border-strong)",
@@ -367,7 +416,7 @@ export default function SchoolAdminPage() {
                 {activeStudents.length}
               </span>
             )}
-            {tab.id === "connections" && connections.length > 0 && (
+            {tab.id === "connections" && matchConnections.length > 0 && (
               <span
                 className="rounded-full px-1.5 py-0.5 text-xs"
                 style={{
@@ -375,7 +424,7 @@ export default function SchoolAdminPage() {
                   color: "var(--ui-text-muted)",
                 }}
               >
-                {connections.length}
+                {matchConnections.length}
               </span>
             )}
           </button>
@@ -465,7 +514,7 @@ export default function SchoolAdminPage() {
                         className="px-4 py-3"
                         style={{ color: "var(--ui-text-muted)" }}
                       >
-                        {student.education ?? "—"}
+                        {toHumanLabel(student.education) ?? "—"}
                       </td>
                       <td
                         className="px-4 py-3"
@@ -518,122 +567,331 @@ export default function SchoolAdminPage() {
       {/* ── Connections Tab ── */}
       {activeTab === "connections" && (
         <>
-          {connectionsLoading ? (
-            <div className="flex justify-center py-16">
-              <FaSync
-                className="h-6 w-6 animate-spin"
-                style={{ color: "var(--ui-text-subtle)" }}
-              />
-            </div>
-          ) : connections.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 py-16 text-center">
-              <FaUsers
-                className="h-10 w-10"
-                style={{ color: "var(--ui-text-subtle)" }}
-              />
-              <p style={{ color: "var(--ui-text-muted)" }}>
-                No connections yet.
-              </p>
-            </div>
-          ) : (
-            <div
-              className="overflow-hidden rounded-xl border"
-              style={{ borderColor: "var(--ui-border)" }}
-            >
-              <table className="w-full text-sm">
-                <thead>
-                  <tr
-                    className="border-b"
+          {/* Sub-toggle */}
+          <div
+            className="mb-4 flex gap-1 rounded-lg border p-1 w-fit"
+            style={{
+              borderColor: "var(--ui-border)",
+              backgroundColor: "var(--ui-surface)",
+            }}
+          >
+            {(
+              [
+                { id: "matches", label: "Matches" },
+                { id: "conversations", label: "Conversations" },
+              ] as const
+            ).map((view) => (
+              <button
+                key={view.id}
+                onClick={() => setConnectionsView(view.id)}
+                className="cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium transition"
+                style={
+                  connectionsView === view.id
+                    ? {
+                        backgroundColor: "var(--ui-surface-active)",
+                        color: "var(--ui-text)",
+                      }
+                    : { color: "var(--ui-text-muted)" }
+                }
+              >
+                {view.label}
+                {view.id === "matches" && matchConnections.length > 0 && (
+                  <span
+                    className="ml-1.5 rounded-full px-1.5 py-0.5 text-xs"
                     style={{
-                      borderColor: "var(--ui-border)",
-                      backgroundColor: "var(--ui-surface)",
+                      backgroundColor: "var(--ui-border)",
+                      color: "var(--ui-text-muted)",
                     }}
                   >
-                    {[
-                      "User 1",
-                      "User 2",
-                      "Messages",
-                      "Connected",
-                      "Last Active",
-                    ].map((h) => (
-                      <th
-                        key={h}
-                        className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
-                        style={{ color: "var(--ui-text-muted)" }}
+                    {matchConnections.length}
+                  </span>
+                )}
+                {view.id === "conversations" && connections.length > 0 && (
+                  <span
+                    className="ml-1.5 rounded-full px-1.5 py-0.5 text-xs"
+                    style={{
+                      backgroundColor: "var(--ui-border)",
+                      color: "var(--ui-text-muted)",
+                    }}
+                  >
+                    {connections.length}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+
+          {/* ── Matches view ── */}
+          {connectionsView === "matches" && (
+            <>
+              {matchesLoading ? (
+                <div className="flex justify-center py-16">
+                  <FaSync
+                    className="h-6 w-6 animate-spin"
+                    style={{ color: "var(--ui-text-subtle)" }}
+                  />
+                </div>
+              ) : matchConnections.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 py-16 text-center">
+                  <FaHandshake
+                    className="h-10 w-10"
+                    style={{ color: "var(--ui-text-subtle)" }}
+                  />
+                  <p style={{ color: "var(--ui-text-muted)" }}>
+                    No matches or links yet.
+                  </p>
+                </div>
+              ) : (
+                <div
+                  className="overflow-hidden rounded-xl border"
+                  style={{ borderColor: "var(--ui-border)" }}
+                >
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr
+                        className="border-b"
+                        style={{
+                          borderColor: "var(--ui-border)",
+                          backgroundColor: "var(--ui-surface)",
+                        }}
                       >
-                        {h}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {connections.map((conn, i) => (
-                    <tr
-                      key={conn.conversation_id}
-                      className="border-b transition"
-                      style={{
-                        borderColor: "var(--ui-border)",
-                        backgroundColor:
-                          i % 2 !== 0 ? "var(--ui-surface)" : undefined,
-                      }}
-                    >
-                      <td className="px-4 py-3">
-                        <div
-                          className="font-medium"
-                          style={{ color: "var(--ui-text)" }}
-                        >
-                          {conn.user1.first_name} {conn.user1.last_name}
-                        </div>
-                        {conn.user1.title && (
-                          <div
-                            className="text-xs"
+                        {["Match", "Type Fit", "Date", "Status"].map((h) => (
+                          <th
+                            key={h}
+                            className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
                             style={{ color: "var(--ui-text-muted)" }}
                           >
-                            {conn.user1.title}
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        <div
-                          className="font-medium"
-                          style={{ color: "var(--ui-text)" }}
-                        >
-                          {conn.user2.first_name} {conn.user2.last_name}
-                        </div>
-                        {conn.user2.title && (
-                          <div
-                            className="text-xs"
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {matchConnections.map((conn, i) => {
+                        const nameOf = (
+                          p: MatchConnection["person1"],
+                        ): string => {
+                          if (p.first_name || p.last_name)
+                            return `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim();
+                          return p.email ?? "Unknown";
+                        };
+
+                        const StatusBadge = () => {
+                          if (conn.kind === "linked")
+                            return (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                                <FaLink className="h-2.5 w-2.5" />
+                                Linked
+                              </span>
+                            );
+                          if (conn.kind === "mutual")
+                            return (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+                                <FaHandshake className="h-2.5 w-2.5" />
+                                Mutual
+                              </span>
+                            );
+                          return (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-gray-500/15 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                              <FaClock className="h-2.5 w-2.5" />
+                              Pending
+                            </span>
+                          );
+                        };
+
+                        const TypeBadge = ({
+                          p,
+                        }: {
+                          p: MatchConnection["person1"];
+                        }) => {
+                          if (p.is_technical === null) return null;
+                          return (
+                            <span
+                              className={`inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${
+                                p.is_technical
+                                  ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
+                                  : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
+                              }`}
+                            >
+                              {p.is_technical ? "Tech" : "Non-tech"}
+                            </span>
+                          );
+                        };
+
+                        return (
+                          <tr
+                            key={conn.id}
+                            className="border-b transition"
+                            style={{
+                              borderColor: "var(--ui-border)",
+                              backgroundColor:
+                                i % 2 !== 0
+                                  ? "var(--ui-surface)"
+                                  : undefined,
+                            }}
+                          >
+                            <td className="px-4 py-3">
+                              <div
+                                className="font-medium"
+                                style={{ color: "var(--ui-text)" }}
+                              >
+                                {nameOf(conn.person1)}
+                              </div>
+                              <div
+                                className="text-xs"
+                                style={{ color: "var(--ui-text-muted)" }}
+                              >
+                                × {nameOf(conn.person2)}
+                              </div>
+                            </td>
+                            <td className="px-4 py-3">
+                              <div className="flex flex-wrap gap-1">
+                                <TypeBadge p={conn.person1} />
+                                <TypeBadge p={conn.person2} />
+                              </div>
+                            </td>
+                            <td
+                              className="px-4 py-3 text-xs"
+                              style={{ color: "var(--ui-text-subtle)" }}
+                            >
+                              {new Date(conn.matched_at).toLocaleDateString()}
+                            </td>
+                            <td className="px-4 py-3">
+                              <StatusBadge />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* ── Conversations view ── */}
+          {connectionsView === "conversations" && (
+            <>
+              {connectionsLoading ? (
+                <div className="flex justify-center py-16">
+                  <FaSync
+                    className="h-6 w-6 animate-spin"
+                    style={{ color: "var(--ui-text-subtle)" }}
+                  />
+                </div>
+              ) : connections.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 py-16 text-center">
+                  <FaUsers
+                    className="h-10 w-10"
+                    style={{ color: "var(--ui-text-subtle)" }}
+                  />
+                  <p style={{ color: "var(--ui-text-muted)" }}>
+                    No conversations yet.
+                  </p>
+                </div>
+              ) : (
+                <div
+                  className="overflow-hidden rounded-xl border"
+                  style={{ borderColor: "var(--ui-border)" }}
+                >
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr
+                        className="border-b"
+                        style={{
+                          borderColor: "var(--ui-border)",
+                          backgroundColor: "var(--ui-surface)",
+                        }}
+                      >
+                        {[
+                          "User 1",
+                          "User 2",
+                          "Messages",
+                          "Connected",
+                          "Last Active",
+                        ].map((h) => (
+                          <th
+                            key={h}
+                            className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
                             style={{ color: "var(--ui-text-muted)" }}
                           >
-                            {conn.user2.title}
-                          </div>
-                        )}
-                      </td>
-                      <td
-                        className="px-4 py-3"
-                        style={{ color: "var(--ui-text-muted)" }}
-                      >
-                        {conn.message_count}
-                      </td>
-                      <td
-                        className="px-4 py-3 text-xs"
-                        style={{ color: "var(--ui-text-subtle)" }}
-                      >
-                        {new Date(conn.created_at).toLocaleDateString()}
-                      </td>
-                      <td
-                        className="px-4 py-3 text-xs"
-                        style={{ color: "var(--ui-text-subtle)" }}
-                      >
-                        {conn.last_message_at
-                          ? new Date(conn.last_message_at).toLocaleDateString()
-                          : "—"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {connections.map((conn, i) => (
+                        <tr
+                          key={conn.conversation_id}
+                          className="border-b transition"
+                          style={{
+                            borderColor: "var(--ui-border)",
+                            backgroundColor:
+                              i % 2 !== 0 ? "var(--ui-surface)" : undefined,
+                          }}
+                        >
+                          <td className="px-4 py-3">
+                            <div
+                              className="font-medium"
+                              style={{ color: "var(--ui-text)" }}
+                            >
+                              {conn.user1.first_name} {conn.user1.last_name}
+                            </div>
+                            {conn.user1.title && (
+                              <div
+                                className="text-xs"
+                                style={{ color: "var(--ui-text-muted)" }}
+                              >
+                                {conn.user1.title}
+                              </div>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div
+                              className="font-medium"
+                              style={{ color: "var(--ui-text)" }}
+                            >
+                              {conn.user2.first_name} {conn.user2.last_name}
+                            </div>
+                            {conn.user2.title && (
+                              <div
+                                className="text-xs"
+                                style={{ color: "var(--ui-text-muted)" }}
+                              >
+                                {conn.user2.title}
+                              </div>
+                            )}
+                          </td>
+                          <td
+                            className="px-4 py-3"
+                            style={{ color: "var(--ui-text-muted)" }}
+                          >
+                            {conn.message_count}
+                          </td>
+                          <td
+                            className="px-4 py-3 text-xs"
+                            style={{ color: "var(--ui-text-subtle)" }}
+                          >
+                            {new Date(conn.created_at).toLocaleDateString()}
+                          </td>
+                          <td
+                            className="px-4 py-3 text-xs"
+                            style={{ color: "var(--ui-text-subtle)" }}
+                          >
+                            {conn.last_message_at
+                              ? new Date(
+                                  conn.last_message_at,
+                                ).toLocaleDateString()
+                              : "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/app/api/school/match-connections/route.ts
+++ b/src/app/api/school/match-connections/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { requireOrgAdmin } from "@/features/school/auth/org-admin";
+import {
+  getMatchConnections,
+  type MatchConnection,
+} from "@/features/school/services/matchConnections";
+
+export type { MatchConnection };
+
+export async function GET() {
+  const auth = await requireOrgAdmin();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const connections = await getMatchConnections(auth.orgId);
+    return NextResponse.json({ connections, total: connections.length });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch match connections" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/features/school/services/matchConnections.ts
+++ b/src/features/school/services/matchConnections.ts
@@ -169,10 +169,6 @@ export async function getMatchConnections(
   for (const invite of invites ?? []) {
     const inviteeId = invite.invitee_user_id as string | null;
     const inviterKey = invite.inviter_user_id as string;
-    const key = inviteeId
-      ? pairKey(inviterKey, inviteeId)
-      : `invite:${invite.id}`;
-
     if (inviteeId && seen.has(pairKey(inviterKey, inviteeId))) continue;
 
     const p1 = toPerson(inviterKey);

--- a/src/features/school/services/matchConnections.ts
+++ b/src/features/school/services/matchConnections.ts
@@ -1,0 +1,213 @@
+import { createClient } from "@supabase/supabase-js";
+
+export type MatchKind = "linked" | "mutual" | "pending";
+
+export type MatchPerson = {
+  user_id: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  title: string | null;
+  is_technical: boolean | null;
+  email?: string | null;
+};
+
+export type MatchConnection = {
+  id: string;
+  kind: MatchKind;
+  pending_source?: "intent" | "invite";
+  person1: MatchPerson;
+  person2: MatchPerson;
+  matched_at: string;
+};
+
+function supabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function pairKey(a: string, b: string): string {
+  return [a, b].sort().join(":");
+}
+
+export async function getMatchConnections(
+  orgId: string,
+): Promise<MatchConnection[]> {
+  const supabase = supabaseAdmin();
+
+  // 1. Fetch all active org profiles
+  const { data: profiles, error: profilesError } = await supabase
+    .from("profiles")
+    .select("user_id, first_name, last_name, title, is_technical")
+    .eq("organization_id", orgId)
+    .is("deleted_at", null);
+
+  if (profilesError) throw new Error("Failed to fetch org profiles");
+
+  const profileMap = new Map(
+    (profiles ?? []).map((p) => [p.user_id as string, p]),
+  );
+
+  // 2. Fetch cofounder_links for org
+  const { data: links } = await supabase
+    .from("cofounder_links")
+    .select("id, user_a_id, user_b_id, created_at")
+    .eq("organization_id", orgId)
+    .order("created_at", { ascending: false });
+
+  // 3. Fetch match_intents for org
+  const { data: intents } = await supabase
+    .from("match_intents")
+    .select("id, from_user_id, to_user_id, created_at")
+    .eq("organization_id", orgId)
+    .order("created_at", { ascending: false });
+
+  // 4. Fetch pending cofounder_invites for org
+  const { data: invites } = await supabase
+    .from("cofounder_invites")
+    .select(
+      "id, inviter_user_id, invitee_email, invitee_user_id, created_at",
+    )
+    .eq("organization_id", orgId)
+    .eq("status", "pending")
+    .order("created_at", { ascending: false });
+
+  const results: MatchConnection[] = [];
+  const seen = new Set<string>();
+
+  // Helper: resolve a person from the profile map
+  const toPerson = (userId: string): MatchPerson | null => {
+    const p = profileMap.get(userId);
+    if (!p) return null;
+    return {
+      user_id: p.user_id,
+      first_name: p.first_name,
+      last_name: p.last_name,
+      title: p.title,
+      is_technical: p.is_technical,
+    };
+  };
+
+  // --- Linked (highest precedence) ---
+  for (const link of links ?? []) {
+    const key = pairKey(link.user_a_id, link.user_b_id);
+    if (seen.has(key)) continue;
+    const p1 = toPerson(link.user_a_id);
+    const p2 = toPerson(link.user_b_id);
+    if (!p1 || !p2) continue;
+    seen.add(key);
+    results.push({
+      id: `linked:${key}`,
+      kind: "linked",
+      person1: p1,
+      person2: p2,
+      matched_at: link.created_at,
+    });
+  }
+
+  // --- Mutual Match ---
+  // Group intents by canonical pair key; a pair with both directions = mutual
+  const intentsByPair = new Map<string, { at: string; fromA: boolean }[]>();
+  for (const intent of intents ?? []) {
+    const key = pairKey(intent.from_user_id, intent.to_user_id);
+    const arr = intentsByPair.get(key) ?? [];
+    arr.push({
+      at: intent.created_at,
+      fromA: intent.from_user_id < intent.to_user_id,
+    });
+    intentsByPair.set(key, arr);
+  }
+
+  const oneWayIntents: string[] = [];
+
+  for (const [key, entries] of intentsByPair) {
+    if (seen.has(key)) continue;
+    if (entries.length >= 2) {
+      // mutual
+      const [a, b] = key.split(":");
+      const p1 = toPerson(a);
+      const p2 = toPerson(b);
+      if (!p1 || !p2) continue;
+      const latestAt = entries.reduce(
+        (max, e) => (e.at > max ? e.at : max),
+        entries[0].at,
+      );
+      seen.add(key);
+      results.push({
+        id: `mutual:${key}`,
+        kind: "mutual",
+        person1: p1,
+        person2: p2,
+        matched_at: latestAt,
+      });
+    } else {
+      oneWayIntents.push(key);
+    }
+  }
+
+  // --- Pending: one-sided intents ---
+  for (const intent of intents ?? []) {
+    const key = pairKey(intent.from_user_id, intent.to_user_id);
+    if (seen.has(key)) continue;
+    if (!oneWayIntents.includes(key)) continue;
+    const p1 = toPerson(intent.from_user_id);
+    const p2 = toPerson(intent.to_user_id);
+    if (!p1 || !p2) continue;
+    seen.add(key);
+    results.push({
+      id: `pending-intent:${key}`,
+      kind: "pending",
+      pending_source: "intent",
+      person1: p1,
+      person2: p2,
+      matched_at: intent.created_at,
+    });
+  }
+
+  // --- Pending: cofounder invites ---
+  for (const invite of invites ?? []) {
+    const inviteeId = invite.invitee_user_id as string | null;
+    const inviterKey = invite.inviter_user_id as string;
+    const key = inviteeId
+      ? pairKey(inviterKey, inviteeId)
+      : `invite:${invite.id}`;
+
+    if (inviteeId && seen.has(pairKey(inviterKey, inviteeId))) continue;
+
+    const p1 = toPerson(inviterKey);
+    if (!p1) continue;
+
+    let p2: MatchPerson;
+    if (inviteeId) {
+      const resolved = toPerson(inviteeId);
+      if (!resolved) continue;
+      p2 = resolved;
+      seen.add(pairKey(inviterKey, inviteeId));
+    } else {
+      // email-only invitee
+      p2 = {
+        user_id: null,
+        first_name: null,
+        last_name: null,
+        title: null,
+        is_technical: null,
+        email: invite.invitee_email as string,
+      };
+    }
+
+    results.push({
+      id: `pending-invite:${invite.id}`,
+      kind: "pending",
+      pending_source: "invite",
+      person1: p1,
+      person2: p2,
+      matched_at: invite.created_at,
+    });
+  }
+
+  // Sort by matched_at descending
+  return results.sort((a, b) =>
+    a.matched_at < b.matched_at ? 1 : a.matched_at > b.matched_at ? -1 : 0,
+  );
+}


### PR DESCRIPTION
# MCFM-133 | Surface different match types on admin dashboard

## Summary
The Connections tab on the school admin dashboard previously only showed users who had opened a conversation (chat-based connections). This PR adds a richer "Matches" view that surfaces all match-type activity for the org — linked cofounders, mutual intents, and pending connections — by querying three Supabase tables (`cofounder_links`, `match_intents`, `cofounder_invites`) and classifying each pair by type. The Connections tab is now split into two sub-views ("Matches" and "Conversations") with a toggle, making both signals visible to admins without collapsing them together.

## Changes

### Service
- Add `getMatchConnections(orgId)` in `src/features/school/services/matchConnections.ts` that fetches all active org profiles, then queries `cofounder_links`, `match_intents`, and `cofounder_invites` in parallel. Pairs are de-duplicated via a canonical `pairKey` (sorted user IDs joined with `:`) and classified with explicit precedence: **linked** (confirmed cofounder link) → **mutual** (both users expressed intent) → **pending** (one-sided intent or outstanding invite). Email-only invitees (not yet registered) are represented with a `user_id: null` person record and their email, so the row still renders gracefully. Results are sorted newest-first.

### API
- Add `GET /api/school/match-connections/route.ts`, a thin route handler protected by `requireOrgAdmin` that calls the service and returns `{ connections, total }`. Re-exports the `MatchConnection` type so the client can import it directly from the route file.

### Admin Dashboard UI
- Split the Connections tab into a "Matches" / "Conversations" sub-toggle. Matches is the default view; conversations (the previous table of chat-based connections) is now the secondary view. Each sub-tab shows its own count badge.
- The tab-level Connections badge in the sidebar now reflects `matchConnections.length` (was previously `connections.length`) so it surfaces matching activity rather than only messaging activity.
- The match table columns are: **Match** (person1 × person2 pair), **Type Fit** (Tech/Non-tech badges per person), **Date**, and **Status**. Status is rendered as a colored pill — Linked (green / `FaLink`), Mutual (amber / `FaHandshake`), Pending (gray / `FaClock`).
- The refresh button now triggers both `fetchMatchConnections` and `fetchConnections` when the Connections tab is active, keeping both views in sync.
- Add `toHumanLabel()` helper to convert snake_case education enum values (e.g., `bachelor_degree`) to title-cased display strings; applied in both the roster table and the CSV export.

## Testing
- Verified the Matches sub-view renders linked, mutual, and pending rows with correct badge colors and icons.
- Verified the Conversations sub-view still shows the existing chat-based connection table.
- Verified the tab badge reflects match count, not conversation count.
- Verified email-only pending invite rows display the invitee email where a name would normally appear.
- Verified CSV export shows human-readable education labels.
