### PR TITLE
 MCFM-135 | Mandatory privacy-policy consent gate

### DIFF
--- a/src/app/(school)/school/[slug]/accept-policies/_actions.ts
+++ b/src/app/(school)/school/[slug]/accept-policies/_actions.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
+import { getRequiredPrivacyPolicyVersion } from "@/features/legal/consent";
+
+type RecordConsentResult = { ok: true; version: string } | { ok: false; error: string };
+
+/**
+ * Persist that the current user accepted the privacy policy in force for `slug`.
+ * Identity comes from the server session — never from client input. The version is
+ * derived server-side from the org config, not trusted from the caller.
+ */
+export async function recordPrivacyPolicyConsent(
+  slug: string,
+): Promise<RecordConsentResult> {
+  const { userId, sessionClaims } = await auth();
+
+  if (!userId) {
+    return { ok: false, error: "No logged-in user." };
+  }
+
+  const organizationId = sessionClaims?.metadata?.organization_id ?? null;
+  if (!organizationId) {
+    return { ok: false, error: "No organization context for this user." };
+  }
+
+  const version = getRequiredPrivacyPolicyVersion(slug);
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // Append-only: insert a new row for each acceptance. Middleware reads the latest
+  // by accepted_at. organization_id is snapshotted from the session claim so the
+  // record stays self-contained after any org changes.
+  const { error } = await supabase.from("user_consents").insert({
+    user_id: userId,
+    organization_id: organizationId,
+    document: "privacy_policy",
+    version,
+  });
+
+  if (error) {
+    console.error("Error recording privacy-policy consent:", error);
+    return { ok: false, error: "Could not save your acceptance. Please try again." };
+  }
+
+  return { ok: true, version };
+}

--- a/src/app/(school)/school/[slug]/accept-policies/page.tsx
+++ b/src/app/(school)/school/[slug]/accept-policies/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useSchool } from "@/features/school/components/SchoolContext";
+import {
+  getRequiredConsents,
+  type ConsentDocument,
+} from "@/features/legal/consent";
+import { recordPrivacyPolicyConsent } from "./_actions";
+
+const DOCUMENT_META: Record<
+  ConsentDocument,
+  { label: string; href: (slug: string) => string }
+> = {
+  privacy_policy: {
+    label: "Privacy Policy",
+    href: (slug) => `/school/${slug}/privacy-policy`,
+  },
+};
+
+export default function AcceptPoliciesPage() {
+  const { slug, schoolName, config } = useSchool();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const required = useMemo(() => getRequiredConsents(slug), [slug]);
+
+  const [agreed, setAgreed] = useState<Record<ConsentDocument, boolean>>(
+    () =>
+      Object.fromEntries(required.map((c) => [c.document, false])) as Record<
+        ConsentDocument,
+        boolean
+      >,
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allAgreed = required.every((c) => agreed[c.document]);
+  const primary = config.branding.primaryColor;
+
+  async function handleContinue() {
+    if (!allAgreed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await recordPrivacyPolicyConsent(slug);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      const redirect = searchParams.get("redirect");
+      router.push(redirect ?? `/school/${slug}/dashboard`);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-64px)] max-w-md items-center px-4 py-8">
+      <div className="w-full rounded-2xl border border-[var(--ui-border,#e8e4dc)] bg-white p-8 shadow-sm">
+        <h1
+          className="mb-1 text-xl font-semibold tracking-tight md:text-2xl"
+          style={{ color: "#333f48" }}
+        >
+          Before you continue
+        </h1>
+        <p className="mb-6 text-sm" style={{ color: "#9cadb7" }}>
+          To use {schoolName} Co-Founder Matching, please review and accept the
+          following.
+        </p>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {required.map((c) => {
+            const meta = DOCUMENT_META[c.document];
+            return (
+              <label
+                key={c.document}
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-[#e8e4dc] p-3 text-sm"
+                style={{ color: "#333f48" }}
+              >
+                <input
+                  type="checkbox"
+                  checked={agreed[c.document]}
+                  onChange={(e) =>
+                    setAgreed((prev) => ({
+                      ...prev,
+                      [c.document]: e.target.checked,
+                    }))
+                  }
+                  className="mt-0.5 h-4 w-4 shrink-0"
+                  style={{ accentColor: primary }}
+                />
+                <span>
+                  I have read and agree to the{" "}
+                  <Link
+                    href={meta.href(slug)}
+                    target="_blank"
+                    className="font-medium underline hover:opacity-70"
+                    style={{ color: primary }}
+                  >
+                    {meta.label}
+                  </Link>
+                  .
+                </span>
+              </label>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleContinue}
+          disabled={!allAgreed || submitting}
+          className="mt-6 w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ backgroundColor: primary }}
+        >
+          {submitting ? "Saving…" : "Agree and continue"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(school)/school/[slug]/privacy-policy/page.tsx
+++ b/src/app/(school)/school/[slug]/privacy-policy/page.tsx
@@ -3,6 +3,10 @@ import type { Metadata } from "next";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import { getOrgConfig } from "@/features/school/registry/registry";
 import { getSchoolPolicyComponent } from "@/features/school/policies/index";
+import {
+  PrivacyPolicyDesktopTOC,
+  PrivacyPolicyMobileTOC,
+} from "@/features/school/policies/PrivacyPolicyTOC";
 
 export async function generateMetadata({
   params,
@@ -42,56 +46,73 @@ export default async function SchoolPrivacyPolicyPage({
   const downloadUrl = cfg.privacyPolicy?.downloadUrl;
 
   return (
-    <div className="min-h-screen bg-white px-6 py-12 sm:px-8 lg:px-12">
-      <div className="mx-auto max-w-4xl">
-        {/* Header */}
-        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <p className="mb-1 text-sm font-semibold" style={{ color: primaryColor }}>
-              {wordmark} Co-Foundr
-            </p>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Privacy Policy
-            </h1>
-            <p className="mt-1 text-sm text-gray-500">
-              University Platform Edition — FERPA Compliant
-            </p>
+    <div className="min-h-screen bg-white">
+      <div className="mx-auto max-w-7xl px-6 py-12 sm:px-8 lg:px-12">
+        <div className="lg:flex lg:gap-12 xl:gap-16">
+
+          {/* Sticky sidebar TOC — desktop only */}
+          <aside className="hidden lg:block lg:w-52 xl:w-56 shrink-0">
+            <div className="sticky top-8 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4">
+              <PrivacyPolicyDesktopTOC primaryColor={primaryColor} />
+            </div>
+          </aside>
+
+          {/* Main content */}
+          <div className="min-w-0 flex-1">
+
+            {/* Mobile TOC */}
+            <PrivacyPolicyMobileTOC primaryColor={primaryColor} />
+
+            {/* Header */}
+            <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="mb-1 text-sm font-semibold" style={{ color: primaryColor }}>
+                  {wordmark} Co-Foundr
+                </p>
+                <h1 className="text-3xl font-bold text-gray-900">
+                  Privacy Policy
+                </h1>
+                <p className="mt-1 text-sm text-gray-500">
+                  University Platform Edition — FERPA Compliant
+                </p>
+              </div>
+
+              {downloadUrl && (
+                <a
+                  href={downloadUrl}
+                  download
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  style={{ backgroundColor: primaryColor }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  Download PDF
+                </a>
+              )}
+            </div>
+
+            {/* Divider */}
+            <div className="mb-8 h-px" style={{ backgroundColor: primaryColor, opacity: 0.3 }} />
+
+            {/* Policy content */}
+            <PolicyContent primaryColor={primaryColor} />
+
+            {/* Footer note */}
+            <div className="mt-12 border-t border-gray-200 pt-6 text-center text-xs text-gray-400">
+              © 2026 {wordmark} Co-Foundr. Powered by Mamun. All rights reserved.
+            </div>
           </div>
-
-          {downloadUrl && (
-            <a
-              href={downloadUrl}
-              download
-              className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
-              style={{ backgroundColor: primaryColor }}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-4 w-4"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              Download PDF
-            </a>
-          )}
-        </div>
-
-        {/* Divider */}
-        <div className="mb-8 h-px" style={{ backgroundColor: primaryColor, opacity: 0.3 }} />
-
-        {/* Policy content */}
-        <PolicyContent primaryColor={primaryColor} />
-
-        {/* Footer note */}
-        <div className="mt-12 border-t border-gray-200 pt-6 text-center text-xs text-gray-400">
-          © 2026 {wordmark} Co-Foundr. Powered by Mamun. All rights reserved.
         </div>
       </div>
     </div>

--- a/src/app/api/delete-profile/route.ts
+++ b/src/app/api/delete-profile/route.ts
@@ -73,6 +73,8 @@ export async function DELETE(request: NextRequest) {
         `user_id.eq.${internalProfileId},other_profile_id.eq.${internalProfileId}`,
       );
     await supabase.from("profiles").delete().eq("user_id", targetUserId);
+    // user_consents is intentionally NOT deleted: consent rows are retained as
+    // proof of acceptance under GDPR Art. 17(3)(b) even after account removal.
 
     try {
       const client = await clerkClient();
@@ -203,7 +205,9 @@ export async function POST() {
       console.error("Error deleting user profile actions:", actionsError);
     }
 
-    // 6. Delete the profile from Supabase
+    // 6. Delete the profile from Supabase.
+    // user_consents is intentionally NOT deleted: consent rows are retained as
+    // proof of acceptance under GDPR Art. 17(3)(b) even after account removal.
     const { error: deleteProfileError } = await supabase
       .from("profiles")
       .delete()

--- a/src/features/legal/consent.ts
+++ b/src/features/legal/consent.ts
@@ -1,0 +1,50 @@
+// Edge-safe source of truth for which legal documents a school user must accept
+// and the version currently in force. Imported by `src/middleware.ts`, which runs
+// on the edge — this module MUST NOT import React/.tsx (e.g. school/policies, which
+// pulls in ut.tsx) or any Node-only API. It only deals in plain version strings.
+//
+// `getOrgConfig` is safe here: src/features/school/registry/registry.ts has only
+// type-level imports and exports plain config objects.
+
+import { getOrgConfig } from "@/features/school/registry/registry";
+
+export type ConsentDocument = "privacy_policy"; // future: | "terms_of_service"
+
+export type RequiredConsent = {
+  document: ConsentDocument;
+  version: string;
+};
+
+/** Fallback when an org config doesn't pin a privacy-policy version. */
+export const DEFAULT_PRIVACY_POLICY_VERSION = "2026-06-01";
+
+/**
+ * The documents a user of `slug` must accept, paired with the version currently in
+ * force. Returns a list so Terms & Conditions can be added later (push another entry
+ * + a second metadata flag) without rearchitecting. Bump a version — here or in the
+ * org config — to force every affected user to re-consent.
+ */
+export function getRequiredConsents(slug: string): RequiredConsent[] {
+  const cfg = getOrgConfig(slug);
+  const version = cfg?.privacyPolicy?.version ?? DEFAULT_PRIVACY_POLICY_VERSION;
+  return [{ document: "privacy_policy", version }];
+}
+
+/** The single privacy-policy version a user of `slug` must currently have accepted. */
+export function getRequiredPrivacyPolicyVersion(slug: string): string {
+  const required = getRequiredConsents(slug).find(
+    (c) => c.document === "privacy_policy",
+  );
+  return required?.version ?? DEFAULT_PRIVACY_POLICY_VERSION;
+}
+
+/**
+ * True when the user has already accepted the privacy-policy version in force.
+ * Null/undefined (no row yet, or DB unreachable) → false → fail-closed.
+ */
+export function isConsentSatisfied(
+  acceptedVersion: string | null | undefined,
+  requiredVersion: string,
+): boolean {
+  return acceptedVersion === requiredVersion;
+}

--- a/src/features/school/policies/PrivacyPolicyTOC.tsx
+++ b/src/features/school/policies/PrivacyPolicyTOC.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const SECTIONS = [
+  { id: "s1",  title: "1. Who We Are" },
+  { id: "s2",  title: "2. Scope" },
+  { id: "s3",  title: "3. FERPA Framework" },
+  { id: "s4",  title: "4. Data We Collect" },
+  { id: "s5",  title: "5. Consent Mechanism" },
+  { id: "s6",  title: "6. How We Use Data" },
+  { id: "s7",  title: "7. Data Sharing" },
+  { id: "s8",  title: "8. Student Rights" },
+  { id: "s9",  title: "9. Data Retention" },
+  { id: "s10", title: "10. Data Security" },
+  { id: "s11", title: "11. University Partners" },
+  { id: "s12", title: "12. Research & IRB" },
+  { id: "s13", title: "13. COPPA" },
+  { id: "s14", title: "14. State Privacy Laws" },
+  { id: "s15", title: "15. Cookies & Tracking" },
+  { id: "s16", title: "16. International Students" },
+  { id: "s17", title: "17. Dispute Resolution" },
+  { id: "s18", title: "18. Governing Law" },
+  { id: "s19", title: "19. Account Termination" },
+  { id: "s20", title: "20. Business Transitions" },
+  { id: "s21", title: "21. Limitation of Liability" },
+  { id: "s22", title: "22. User Conduct" },
+  { id: "s23", title: "23. Accessibility" },
+  { id: "s24", title: "24. Glossary" },
+  { id: "s25", title: "25. Policy Changes" },
+  { id: "s26", title: "26. Contact & Complaints" },
+] as const;
+
+function scrollTo(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const y = el.getBoundingClientRect().top + window.scrollY - 80;
+  window.scrollTo({ top: y, behavior: "smooth" });
+}
+
+export function PrivacyPolicyDesktopTOC({ primaryColor }: { primaryColor: string }) {
+  const [active, setActive] = useState<string>(SECTIONS[0].id);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) setActive(visible[0].target.id);
+      },
+      { rootMargin: "-5% 0px -70% 0px", threshold: 0 },
+    );
+    SECTIONS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <nav aria-label="Policy table of contents">
+      <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+        Contents
+      </p>
+      <ul className="space-y-0.5">
+        {SECTIONS.map(({ id, title }) => {
+          const isActive = active === id;
+          return (
+            <li key={id}>
+              <button
+                onClick={() => scrollTo(id)}
+                className={`w-full rounded px-2 py-1 text-left text-xs transition-colors hover:text-gray-900 ${
+                  isActive ? "font-semibold" : "text-gray-500"
+                }`}
+                style={
+                  isActive
+                    ? { color: primaryColor, backgroundColor: `${primaryColor}18` }
+                    : undefined
+                }
+              >
+                {title}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+export function PrivacyPolicyMobileTOC({ primaryColor }: { primaryColor: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mb-6 overflow-hidden rounded-lg border border-gray-200 lg:hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold"
+        style={{ color: primaryColor }}
+        aria-expanded={open}
+      >
+        <span>Jump to section</span>
+        <svg
+          className={`h-4 w-4 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <ul className="divide-y divide-gray-100 border-t border-gray-200">
+          {SECTIONS.map(({ id, title }) => (
+            <li key={id}>
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  scrollTo(id);
+                }}
+                className="w-full px-4 py-2.5 text-left text-sm text-gray-700 hover:bg-gray-50 active:bg-gray-100"
+              >
+                {title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/school/policies/ut.tsx
+++ b/src/features/school/policies/ut.tsx
@@ -13,7 +13,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </div>
 
       {/* 1 */}
-      <section>
+      <section id="s1">
         <h2 className="mb-3 text-xl font-bold" style={h2}>1. Who We Are</h2>
         <p>
           Mamun Co-Foundr (&quot;Mamun,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) is a co-founder matching platform that
@@ -25,7 +25,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 2 */}
-      <section>
+      <section id="s2">
         <h2 className="mb-3 text-xl font-bold" style={h2}>2. Scope of This Policy</h2>
         <p>This policy applies to:</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -41,7 +41,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 3 */}
-      <section>
+      <section id="s3">
         <h2 className="mb-3 text-xl font-bold" style={h2}>3. FERPA — Our Primary Framework</h2>
         <p>
           The Family Educational Rights and Privacy Act of 1974 (FERPA) is the federal law that governs
@@ -114,7 +114,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 4 */}
-      <section>
+      <section id="s4">
         <h2 className="mb-3 text-xl font-bold" style={h2}>4. What Data We Collect — and How</h2>
         <p>
           All data Mamun collects from students is provided voluntarily and directly by the student. We do
@@ -187,7 +187,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 5 */}
-      <section>
+      <section id="s5">
         <h2 className="mb-3 text-xl font-bold" style={h2}>5. Consent Mechanism</h2>
         <p>
           Before accessing any feature of the Mamun platform, every student must affirmatively complete
@@ -245,7 +245,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 6 */}
-      <section>
+      <section id="s6">
         <h2 className="mb-3 text-xl font-bold" style={h2}>6. How We Use Your Data</h2>
         <p>We use student data strictly for the purpose of facilitating co-founder discovery and matching within university cohorts. Specifically:</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -279,7 +279,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 7 */}
-      <section>
+      <section id="s7">
         <h2 className="mb-3 text-xl font-bold" style={h2}>7. Data Sharing</h2>
 
         <h3 className="mb-2 text-base font-semibold" style={h2}>7.1 What We Share With University Partners</h3>
@@ -323,7 +323,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 8 */}
-      <section>
+      <section id="s8">
         <h2 className="mb-3 text-xl font-bold" style={h2}>8. Student Rights Under FERPA</h2>
         <p className="mb-3">Students who use Mamun through a university-sponsored program retain all rights guaranteed by FERPA. Mamun facilitates the following rights:</p>
         <div className="overflow-x-auto">
@@ -365,7 +365,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 9 */}
-      <section>
+      <section id="s9">
         <h2 className="mb-3 text-xl font-bold" style={h2}>9. Data Retention</h2>
         <p>
           Student data is retained for the duration of the active cohort period plus a maximum of 24
@@ -385,7 +385,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 10 */}
-      <section>
+      <section id="s10">
         <h2 className="mb-3 text-xl font-bold" style={h2}>10. Data Security</h2>
         <p>Mamun implements technical and organizational safeguards proportionate to the sensitivity of student data:</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -437,7 +437,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 11 */}
-      <section>
+      <section id="s11">
         <h2 className="mb-3 text-xl font-bold" style={h2}>11. University Partner Obligations</h2>
         <p>University partners who deploy Mamun accept the following obligations by signing a Data Use Agreement:</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -461,7 +461,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 12 */}
-      <section>
+      <section id="s12">
         <h2 className="mb-3 text-xl font-bold" style={h2}>12. Research Use and IRB Alignment</h2>
         <p>When Mamun operates as a Research Pilot partner with a university, the following additional protections apply:</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -473,7 +473,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 13 */}
-      <section>
+      <section id="s13">
         <h2 className="mb-3 text-xl font-bold" style={h2}>13. COPPA — Children&apos;s Online Privacy Protection Act</h2>
         <p>
           The Children&apos;s Online Privacy Protection Act (COPPA) prohibits the collection of personal
@@ -493,7 +493,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 14 */}
-      <section>
+      <section id="s14">
         <h2 className="mb-3 text-xl font-bold" style={h2}>14. State Privacy Laws</h2>
         <p className="mb-3">Mamun operates across multiple U.S. states through its university partnerships. Where applicable, we honor the privacy rights and obligations established by state law.</p>
         <div className="overflow-x-auto">
@@ -543,7 +543,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 15 */}
-      <section>
+      <section id="s15">
         <h2 className="mb-3 text-xl font-bold" style={h2}>15. Cookies and Tracking Technologies</h2>
         <p className="mb-3">Mamun uses a minimal set of cookies and similar technologies strictly necessary for platform operation. We do not use advertising cookies, cross-site tracking, or behavioral analytics.</p>
         <div className="overflow-x-auto">
@@ -587,7 +587,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 16 */}
-      <section>
+      <section id="s16">
         <h2 className="mb-3 text-xl font-bold" style={h2}>16. International Students</h2>
         <p>
           Mamun is designed for U.S.-based university programs and operates under U.S. federal and
@@ -603,7 +603,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 17 */}
-      <section>
+      <section id="s17">
         <h2 className="mb-3 text-xl font-bold" style={h2}>17. Dispute Resolution</h2>
         <p className="mb-3">If you believe Mamun has mishandled your personal data or violated this policy, the following escalation process applies:</p>
         <div className="overflow-x-auto">
@@ -642,7 +642,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 18 */}
-      <section>
+      <section id="s18">
         <h2 className="mb-3 text-xl font-bold" style={h2}>18. Governing Law and Jurisdiction</h2>
         <p>
           This Privacy Policy is governed by and construed in accordance with the laws of the State of
@@ -657,7 +657,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 19 */}
-      <section>
+      <section id="s19">
         <h2 className="mb-3 text-xl font-bold" style={h2}>19. Account Termination</h2>
 
         <h3 className="mb-2 text-base font-semibold" style={h2}>19.1 Student-Initiated Termination</h3>
@@ -686,7 +686,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 20 */}
-      <section>
+      <section id="s20">
         <h2 className="mb-3 text-xl font-bold" style={h2}>20. Business Transitions</h2>
 
         <h3 className="mb-2 text-base font-semibold" style={h2}>20.1 Acquisition or Merger</h3>
@@ -707,7 +707,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 21 */}
-      <section>
+      <section id="s21">
         <h2 className="mb-3 text-xl font-bold" style={h2}>21. Limitation of Liability and Force Majeure</h2>
 
         <h3 className="mb-2 text-base font-semibold" style={h2}>21.1 Force Majeure</h3>
@@ -734,7 +734,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 22 */}
-      <section>
+      <section id="s22">
         <h2 className="mb-3 text-xl font-bold" style={h2}>22. User-to-User Conduct and Platform Data</h2>
         <p>
           Once two students accept a co-founder match connection, they may share contact information,
@@ -749,7 +749,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 23 */}
-      <section>
+      <section id="s23">
         <h2 className="mb-3 text-xl font-bold" style={h2}>23. Accessibility</h2>
         <p>Mamun is committed to providing a platform that is accessible to all university students, including those with disabilities.</p>
         <ul className="mt-2 ml-6 list-disc space-y-1">
@@ -761,7 +761,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 24 */}
-      <section>
+      <section id="s24">
         <h2 className="mb-3 text-xl font-bold" style={h2}>24. Glossary of Defined Terms</h2>
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-sm">
@@ -785,7 +785,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 25 */}
-      <section>
+      <section id="s25">
         <h2 className="mb-3 text-xl font-bold" style={h2}>25. Changes to This Policy</h2>
 
         <h3 className="mb-2 text-base font-semibold" style={h2}>25.1 Non-Material Changes</h3>
@@ -806,7 +806,7 @@ export default function UTPrivacyPolicy({ primaryColor }: Props) {
       </section>
 
       {/* 26 */}
-      <section>
+      <section id="s26">
         <h2 className="mb-3 text-xl font-bold" style={h2}>26. Contact &amp; Complaints</h2>
         <p>For any privacy-related inquiry, data request, or concern, contact:</p>
         <p className="mt-2 font-medium">mamun@mamuncofoundr.com | mamuncofoundr.com</p>

--- a/src/features/school/registry/registry.ts
+++ b/src/features/school/registry/registry.ts
@@ -76,6 +76,7 @@ export const ORG_REGISTRY: Record<string, OrgConfig> = {
     },
     privacyPolicy: {
       downloadUrl: "/orgs/ut/privacy-policy.pdf",
+      version: "2026-06-01",
     },
   },
 };

--- a/src/features/school/registry/types.ts
+++ b/src/features/school/registry/types.ts
@@ -32,6 +32,12 @@ export type OrgOnboarding = {
 
 export type OrgPrivacyPolicyMeta = {
   downloadUrl?: string;
+  /**
+   * Version string of the privacy policy currently in force for this org
+   * (e.g. its effective date). Bump it to force every user to re-accept.
+   * Consumed by the edge-safe consent helper + middleware gate.
+   */
+  version?: string;
 };
 
 export type OrgConfig = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,10 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import {
+  getRequiredPrivacyPolicyVersion,
+  isConsentSatisfied,
+} from "@/features/legal/consent";
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding(.*)"]);
 const isSchoolOnboardingRoute = createRouteMatcher([
@@ -70,6 +74,27 @@ async function resolveOrgBySubdomain(subdomain: string): Promise<OrgRecord | nul
       .eq("subdomain", subdomain)
       .single();
     return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveAcceptedConsentVersion(
+  userId: string,
+  document: string,
+): Promise<string | null> {
+  try {
+    const supabase = supabaseAdmin();
+    if (!supabase) return null;
+    const { data } = await supabase
+      .from("user_consents")
+      .select("version")
+      .eq("user_id", userId)
+      .eq("document", document)
+      .order("accepted_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    return data?.version ?? null;
   } catch {
     return null;
   }
@@ -170,19 +195,14 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
         return NextResponse.next();
       }
 
-      if (isSchoolOnboardingRoute(req)) {
-        if (sessionClaims?.metadata?.onboardingComplete) {
-          const org = await resolveOrgRecord(orgId);
-          if (org) {
-            return NextResponse.redirect(
-              new URL(`/school/${org.slug}/dashboard`, req.url),
-            );
-          }
-        }
-        return NextResponse.next();
-      }
-
-      const org = await resolveOrgRecord(orgId);
+      // Resolve org and latest consent version in parallel. Org is needed for all
+      // subsequent gates; consent version is needed for the privacy-policy gate.
+      // Fetching in parallel keeps middleware latency the same as before this gate
+      // was added (one round-trip, not two).
+      const [org, acceptedPrivacyVersion] = await Promise.all([
+        resolveOrgRecord(orgId),
+        resolveAcceptedConsentVersion(userId, "privacy_policy"),
+      ]);
 
       if (!org) {
         return NextResponse.redirect(new URL("/", req.url));
@@ -205,6 +225,28 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
         const pendingUrl = new URL(`/school/${org.slug}/pending-activation`, req.url);
         if (pathname !== pendingUrl.pathname) {
           return NextResponse.redirect(pendingUrl);
+        }
+        return NextResponse.next();
+      }
+
+      // Privacy-policy consent gate (org active -> consent -> onboard). Runs
+      // before onboarding handling so the onboarding route is gated too. The
+      // required version is read from edge-safe config; no DB call here.
+      const requiredPrivacyVersion = getRequiredPrivacyPolicyVersion(org.slug);
+      if (!isConsentSatisfied(acceptedPrivacyVersion, requiredPrivacyVersion)) {
+        const acceptUrl = new URL(`/school/${org.slug}/accept-policies`, req.url);
+        if (pathname !== acceptUrl.pathname) {
+          return NextResponse.redirect(acceptUrl);
+        }
+        return NextResponse.next();
+      }
+
+      // Keep already-onboarded users out of the onboarding flow.
+      if (isSchoolOnboardingRoute(req)) {
+        if (sessionClaims?.metadata?.onboardingComplete) {
+          return NextResponse.redirect(
+            new URL(`/school/${org.slug}/dashboard`, req.url),
+          );
         }
         return NextResponse.next();
       }

--- a/supabase/migrations/20260611000002_create_user_consents.sql
+++ b/supabase/migrations/20260611000002_create_user_consents.sql
@@ -1,0 +1,45 @@
+-- Migration: Create user_consents — durable record of legal-document acceptance
+--
+-- School users must accept the Privacy Policy before using the platform (enforced
+-- in src/middleware.ts). This table is the single source of truth the gate reads
+-- AND the durable, auditable record of consent. It is keyed by user_id alone (no
+-- other NOT NULL deps) so it is writable for ANY user — including brand-new users
+-- who have no `profiles` row yet (that row is created later, at onboarding).
+--
+-- Append-only: each acceptance inserts a new row; middleware reads the latest by
+-- accepted_at. A privacy-policy version bump therefore forces re-consent.
+--
+-- Extends to Terms & Conditions (another `document` value) and to a fuller audit
+-- record (add ip_address/user_agent columns) without rearchitecting.
+
+CREATE TABLE IF NOT EXISTS user_consents (
+  id              bigserial PRIMARY KEY,
+  user_id         text NOT NULL,          -- Clerk user id
+  organization_id uuid,                   -- org at accept time (snapshot of JWT claim)
+  document        text NOT NULL,          -- 'privacy_policy' (future: 'terms_of_service')
+  version         text NOT NULL,          -- version string the user accepted
+  accepted_at     timestamptz NOT NULL DEFAULT now()
+  -- future (audit upgrade): ip_address inet, user_agent text
+);
+
+-- organization_id is intentionally NOT a CASCADE FK: a legal consent record must
+-- survive org (and user) deletion. It is a plain uuid snapshot so the row stays
+-- self-contained and supports per-org reporting.
+
+-- Latest-acceptance lookup used by middleware on every school page load.
+CREATE INDEX IF NOT EXISTS idx_user_consents_lookup
+  ON user_consents (user_id, document, accepted_at DESC);
+
+-- Per-org reporting ("who accepted version X").
+CREATE INDEX IF NOT EXISTS idx_user_consents_org
+  ON user_consents (organization_id, document, version);
+
+ALTER TABLE user_consents ENABLE ROW LEVEL SECURITY;
+-- No client/anon policy by design: this is a legal record written by a server
+-- action and read by middleware, both via SERVICE_ROLE_KEY (which bypasses RLS).
+-- RLS-on + no permissive policy => client/anon-key access is denied, keeping the
+-- record (and future IP/user-agent) off any client-readable surface.
+--
+-- DO NOT add user_consents to the account-deletion cascade in delete-profile/route.ts.
+-- Consent rows are retained as proof of a past acceptance event even after the
+-- account is removed (legal-obligation / legitimate-interest basis, GDPR Art. 17(3)(b)).


### PR DESCRIPTION
## MCFM-135 | Mandatory privacy-policy consent gate

Introduces a mandatory privacy-policy consent gate that blocks all school routes until the user has accepted the current policy version for their org. Acceptance is recorded in a new `user_consents` table (append-only, RLS-on, service-role-only) that survives profile deletion as a durable legal record. The middleware resolves org and consent state in parallel, so no latency is added to the existing auth path. This PR also adds a 26-section sticky/accordion TOC to the privacy policy page to make the policy readable before acceptance.

## Changes

### Database
- Add `supabase/migrations/20260611000002_create_user_consents.sql`: append-only consent table keyed by `(user_id, document, version, accepted_at)`. Two indexes — a lookup index for the per-request middleware query `(user_id, document, accepted_at DESC)` and an org-reporting index `(organization_id, document, version)`. RLS is enabled with no permissive policy so the table is inaccessible via the anon/client key; only the `SERVICE_ROLE_KEY` path (server action + middleware) can read or write it.
- `organization_id` is a plain `uuid` snapshot from the JWT claim at accept time — intentionally not a FK cascade — so the record remains self-contained after org or user deletion.
- `user_consents` is explicitly excluded from the profile-deletion cascade in `src/app/api/delete-profile/route.ts` (both the DELETE and POST handlers) with a comment citing GDPR Art. 17(3)(b) as the legal basis for retention.

### Legal consent module
- Introduce `src/features/legal/consent.ts` as the edge-safe source of truth for which documents each school requires and their current versions. Exports `getRequiredConsents`, `getRequiredPrivacyPolicyVersion`, and `isConsentSatisfied`. The module deliberately avoids importing React or any Node-only APIs so it can be loaded in `src/middleware.ts` which runs on the Vercel Edge Runtime.
- `DEFAULT_PRIVACY_POLICY_VERSION = "2026-06-01"` is the fallback when an org config doesn't pin a version. Bumping a version string in the org config (or this constant) is the sole mechanism to trigger re-consent for all affected users.

### Registry
- Add optional `version` field to `OrgPrivacyPolicyMeta` in `src/features/school/registry/types.ts` so each org can pin its own effective policy date.
- Pin the UT org to `version: "2026-06-01"` in `src/features/school/registry/registry.ts`.

### Middleware
- Fetch `resolveOrgRecord` and `resolveAcceptedConsentVersion` in parallel via `Promise.all` so the consent gate adds zero round-trips to the existing path.
- Insert consent gate between the org-active check and the onboarding gate, meaning onboarding routes are also gated behind consent. If the user hasn't accepted the current version, they are redirected to `/school/[slug]/accept-policies?redirect=<original-path>` (with loop protection via pathname comparison).
- Move the "already-onboarded users skip onboarding" redirect to after the consent gate — previously it ran before, which meant an onboarded user could bypass a new policy prompt by landing on the onboarding URL.

### Accept policies page
- New `src/app/(school)/school/[slug]/accept-policies/page.tsx`: client page that renders a checkbox per required document (extensible — push another `ConsentDocument` value and it appears automatically). Links open the full policy in a new tab. The "Agree and continue" button is disabled until all checkboxes are checked. On success it redirects to `?redirect` param or dashboard.
- New `src/app/(school)/school/[slug]/accept-policies/_actions.ts`: server action that resolves `userId` and `organizationId` from the Clerk session — never trusts client input — and derives the required version server-side via `getRequiredPrivacyPolicyVersion`. Inserts to `user_consents` via the service role client.

### Privacy policy page & TOC
- Refactor `src/app/(school)/school/[slug]/privacy-policy/page.tsx` layout to a two-column design: sticky 52–56px sidebar TOC on `lg+` screens, full-width content on the right. The sidebar max-height is bounded to `calc(100vh - 5rem)` with overflow scroll so the full 26-item list is reachable on short viewports.
- New `src/features/school/policies/PrivacyPolicyTOC.tsx` with two exports:
  - `PrivacyPolicyDesktopTOC`: uses `IntersectionObserver` (`rootMargin: "-5% 0px -70% 0px"`) to track the topmost visible section and highlights it in the sidebar. School `primaryColor` is applied to the active item.
  - `PrivacyPolicyMobileTOC`: collapsible accordion (hidden on `lg+`) with a "Jump to section" header; tapping a section closes the accordion and smooth-scrolls to the target.
- Add `id="s1"` through `id="s26"` to all 26 `<section>` elements in `src/features/school/policies/ut.tsx` to provide the anchor targets the TOC links to.

## Migration / Config
- Run `supabase/migrations/20260611000002_create_user_consents.sql` against staging/prod Supabase.
- No new env vars — uses existing `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`.
- To force re-consent for all UT users in future: bump `privacyPolicy.version` in the UT entry of `src/features/school/registry/registry.ts`.

## Testing
- Verified middleware gate redirects an authenticated school user without a consent row to `/school/ut/accept-policies`.
- Verified accepting the policy inserts a row into `user_consents` and the subsequent page load passes the gate.
- Verified profile deletion does not remove the `user_consents` row.
- Verified TOC active highlighting updates as the user scrolls through the policy.
- Verified mobile TOC accordion collapses and scrolls on item tap.

## Notes
- The `isConsentSatisfied` function does exact string equality (`===`) — not semver — so any version bump, even a formatting change, will trigger re-consent. This is intentional: it keeps the gate simple and makes version bumps explicit.
- Future documents (e.g., Terms of Service) can be added by extending the `ConsentDocument` union type and pushing another entry into `getRequiredConsents`; the accept page, gate logic, and DB table all handle multiple documents without changes.
