### PR TITLE
MCFM-142 | Add calendly links

### DIFF
--- a/src/app/(school)/school/[slug]/profile/page.tsx
+++ b/src/app/(school)/school/[slug]/profile/page.tsx
@@ -663,6 +663,17 @@ export default function SchoolProfilePage({ params }: { params: Promise<{ slug: 
                 </div>
               ))}
             </div>
+            <div className="space-y-1.5">
+              <label className={labelClass}>
+                Scheduling Link{" "}
+                <span className="font-normal text-[var(--ui-text-subtle)]">(Calendly, Cal.com…)</span>
+              </label>
+              <FormInput
+                placeholder="https://calendly.com/your-link"
+                type="url"
+                {...register("schedulingUrl")}
+              />
+            </div>
           </div>
 
           {/* ── Sticky action bar ── */}

--- a/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
+++ b/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
@@ -8,6 +8,7 @@ import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
 type UTBackgroundAndSocialsData = {
   linkedin?: string;
   git?: string;
+  schedulingUrl?: string;
 };
 
 const LABEL_CLS =
@@ -70,6 +71,20 @@ function UTBackgroundAndSocialsForm({
               type="text"
               placeholder="github.com/yourusername"
               {...register("git")}
+            />
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className={LABEL_CLS}>
+              Scheduling Link
+              <span className="ml-1 font-normal normal-case text-[var(--ui-text-subtle)]">
+                (Calendly, Cal.com…)
+              </span>
+            </label>
+            <FormInput
+              type="url"
+              placeholder="https://calendly.com/your-link"
+              {...register("schedulingUrl")}
             />
           </div>
         </div>

--- a/src/lib/mapProfileToFromDBFormat.ts
+++ b/src/lib/mapProfileToFromDBFormat.ts
@@ -24,7 +24,7 @@ export function mapProfileToOnboardingData(
     education: profile.education,
     experience: profile.experience,
     isTechnical: profile.is_technical ? "yes" : "no",
-    schedulingUrl: undefined, // No field provided in DB object, set to undefined
+    schedulingUrl: profile.scheduling_url ?? undefined,
 
     // OnboardingSocialsFormData
     linkedin: profile.linkedin ?? "",
@@ -85,6 +85,7 @@ export function mapOnboardingDatatoProfileDB(data: OnboardingData) {
     twitter: data.twitter || null,
     git: data.git || null,
     personal_website: data.personalWebsite || null,
+    scheduling_url: data.schedulingUrl || null,
 
     has_startup: data.hasStartup === "yes",
     startup_name: data.startupName || null,

--- a/supabase/migrations/20260616000000_add_scheduling_url_to_profiles.sql
+++ b/supabase/migrations/20260616000000_add_scheduling_url_to_profiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS scheduling_url TEXT NULL;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -61,6 +61,7 @@ declare global {
     onboarding_complete: boolean;
     personal_intro: string;
     personal_website: string | null;
+    scheduling_url: string | null;
     pfp_url?: string | null;
     priority_areas: string[]; // array of strings
     looking_for: "technical" | "non-technical" | "either" | null;


### PR DESCRIPTION
# MCFM-142 | Add calendly links

## Summary
  Adds a `scheduling_url` field to founder profiles so users can share a Calendly or Cal.com booking link. The field is surfaced in two
  places: the school profile edit page and the onboarding background/socials step. A new nullable `TEXT` column is added to the
  `profiles` table, the global type definition is extended, and the profile ↔ DB mapping functions are updated to read and write the
  new field.

  ## Changes

  ### Database
  - Add `scheduling_url TEXT NULL` column to `profiles` via migration `20260616000000_add_scheduling_url_to_profiles.sql`, using `IF
  NOT EXISTS` for safety.
  - Extend the `profiles` global type in `types/global.d.ts` to include `scheduling_url: string | null`.

  ### Data Mapping
  - Fix `mapProfileToOnboardingData` in `src/lib/mapProfileToFromDBFormat.ts` to read `profile.scheduling_url` (previously hardcoded to
  `undefined`), making edit flows correctly pre-populate the field.
  - Add `scheduling_url: data.schedulingUrl || null` to `mapOnboardingDatatoProfileDB` so saves persist the value to the DB.

  ### Client
  - Add a "Scheduling Link" URL input to the school profile edit page (`src/app/(school)/school/[slug]/profile/page.tsx`), positioned
  after the social links block, with a placeholder and hint label `(Calendly, Cal.com…)`.
  - Add the same input to the onboarding background/socials form
  (`src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx`), extending the `UTBackgroundAndSocialsData` type to
  include `schedulingUrl?: string`.

  ## Migration / Config
  - Run the Supabase migration: `20260616000000_add_scheduling_url_to_profiles.sql`
    ```sql
    ALTER TABLE profiles ADD COLUMN IF NOT EXISTS scheduling_url TEXT NULL;

  Testing

  - Verify the field appears in the onboarding socials step and saves correctly on completion.
  - Verify the field pre-populates on the school profile edit page for existing profiles that have a scheduling URL set.
  - Confirm a null/empty value saves as NULL in the DB (not an empty string).