### PR TITLE
MCFM-141 | Report Abuse Button

### DIFF
--- a/src/app/(general)/cofoundr-matching/page.tsx
+++ b/src/app/(general)/cofoundr-matching/page.tsx
@@ -27,6 +27,7 @@ import SwipeLimit from "@/components/SwipeLimit";
 import { MdSkipNext } from "react-icons/md";
 import { trackEvent } from "@/lib/posthog-events";
 import { useProfileViewTracking } from "@/features/profile/useProfileViewTracking";
+import ReportProfileButton from "@/features/report/ReportProfileButton";
 
 function CofoundrMatching() {
   const [showMore, setShowMore] = useState(false);
@@ -404,6 +405,10 @@ function CofoundrMatching() {
                               companyName={curProfile.startupName}
                             />
                           )}
+                          <ReportProfileButton
+                            reportedUserId={curProfile.user_id ?? ""}
+                            reportedName={`${curProfile.firstName ?? ""} ${curProfile.lastName ?? ""}`.trim()}
+                          />
                         </div>
                         <p className="text-base text-gray-300 sm:text-lg md:text-xl">
                           {curProfile.title}

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { trackEvent } from "@/lib/posthog-events";
 import { useProfileViewTracking } from "@/features/profile/useProfileViewTracking";
 import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/features/school/data/utSchoolsAndMajors";
 import FilterSidebar, { getFilterChipLabels } from "@/features/school/components/dashboard/FilterSidebar";
+import ReportProfileButton from "@/features/report/ReportProfileButton";
 import {
   type DashboardFilters,
   type RelaxSuggestion,
@@ -593,6 +594,10 @@ export default function SchoolDashboardPage() {
                             : "The Architect"}
                       </span>
                     )}
+                    <ReportProfileButton
+                      reportedUserId={curProfile.user_id ?? ""}
+                      reportedName={`${curProfile.firstName ?? ""} ${curProfile.lastName ?? ""}`.trim()}
+                    />
                   </div>
                 </div>
 

--- a/src/app/api/report-abuse/route.ts
+++ b/src/app/api/report-abuse/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { Resend } from "resend";
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { reportedUserId, reportedName, reason, details } = await req.json();
+
+    const client = await clerkClient();
+    const reporter = await client.users.getUser(userId);
+    const reporterEmail =
+      reporter.emailAddresses.find((e) => e.id === reporter.primaryEmailAddressId)
+        ?.emailAddress ?? "unknown";
+    const reporterName =
+      [reporter.firstName, reporter.lastName].filter(Boolean).join(" ") || "unknown";
+
+    const html = `
+      <h2>Profile Report</h2>
+      <h3>Reported Profile</h3>
+      <p><strong>Name:</strong> ${reportedName ?? "unknown"}</p>
+      <p><strong>User ID:</strong> ${reportedUserId}</p>
+      <h3>Reason</h3>
+      <p>${reason}</p>
+      ${details ? `<h3>Additional Details</h3><p>${details}</p>` : ""}
+      <h3>Reported By</h3>
+      <p><strong>Name:</strong> ${reporterName}</p>
+      <p><strong>Email:</strong> ${reporterEmail}</p>
+      <p><strong>User ID:</strong> ${userId}</p>
+    `;
+
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    const { data } = await resend.emails.send({
+      from: "mamun@mamuncofoundr.com",
+      to: ["mamun@mamuncofoundr.com"],
+      subject: `Profile Report — ${reason}`,
+      html,
+    });
+
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ err }, { status: 500 });
+  }
+}

--- a/src/features/matches/ProfileDetailModal.tsx
+++ b/src/features/matches/ProfileDetailModal.tsx
@@ -17,6 +17,7 @@ import { FaTimes } from "react-icons/fa";
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
 import ProfileViewModal from "@/features/profile/ProfileViewModal";
+import ReportProfileButton from "@/features/report/ReportProfileButton";
 import {
   getDegreeAbbreviation,
   getSchoolFullName,
@@ -207,6 +208,10 @@ export default function ProfileDetailModal({
                 </div>
 
                 {/* Close button */}
+                <ReportProfileButton
+                  reportedUserId={userId}
+                  reportedName={`${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim()}
+                />
                 <button
                   onClick={onClose}
                   className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 cursor-pointer"

--- a/src/features/profile/ProfileViewModal.tsx
+++ b/src/features/profile/ProfileViewModal.tsx
@@ -24,6 +24,7 @@ import { useProfileByUserId } from "./useProfile";
 import { useToggleLike, useLikeStatus } from "@/features/likes/useLikes";
 import toast from "react-hot-toast";
 import { useQueryClient } from "@tanstack/react-query";
+import ReportProfileButton from "@/features/report/ReportProfileButton";
 
 interface ProfileViewModalProps {
   /** Pass a full profile when you already have the data (avoids an extra fetch). */
@@ -210,6 +211,10 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                     )}
                   </div>
 
+                  <ReportProfileButton
+                    reportedUserId={targetId}
+                    reportedName={`${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim()}
+                  />
                   <button
                     onClick={onClose}
                     className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 cursor-pointer"

--- a/src/features/report/ReportProfileButton.tsx
+++ b/src/features/report/ReportProfileButton.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { motion, AnimatePresence } from "motion/react";
+import { FaFlag } from "react-icons/fa6";
+import { FaTimes } from "react-icons/fa";
+import toast from "react-hot-toast";
+
+interface ReportFormData {
+  reason: string;
+  details: string;
+}
+
+const REPORT_REASONS = [
+  "Fake or scam profile",
+  "Harassment or abusive behavior",
+  "Inappropriate or offensive content",
+  "Spam or solicitation",
+  "Impersonation",
+  "Other",
+];
+
+interface ReportProfileButtonProps {
+  reportedUserId: string;
+  reportedName?: string;
+}
+
+export default function ReportProfileButton({
+  reportedUserId,
+  reportedName,
+}: ReportProfileButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ReportFormData>({ defaultValues: { reason: "", details: "" } });
+
+  const selectedReason = watch("reason");
+
+  const close = () => {
+    setOpen(false);
+    reset();
+  };
+
+  const onSubmit = async (data: ReportFormData) => {
+    try {
+      const res = await fetch("/api/report-abuse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reportedUserId, reportedName, ...data }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success("Report submitted. Thank you.");
+      close();
+    } catch {
+      toast.error("Couldn't submit report. Please try again.");
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-red-500 cursor-pointer"
+        title="Report this profile"
+      >
+        <FaFlag className="h-4 w-4" />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+            onClick={close}
+          >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ type: "spring", damping: 25, stiffness: 300 }}
+              className="relative mx-4 w-full max-w-md rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] p-6 shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                onClick={close}
+                className="absolute top-4 right-4 rounded-full p-2 text-gray-400 transition hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] cursor-pointer"
+              >
+                <FaTimes className="h-4 w-4" />
+              </button>
+
+              <h2 className="mb-1 text-lg font-bold text-[var(--ui-text)]">
+                Report Profile
+              </h2>
+              {reportedName && (
+                <p className="mb-5 text-sm text-[var(--ui-text-muted)]">
+                  Reporting {reportedName}
+                </p>
+              )}
+
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-[var(--ui-text)]">
+                    Why are you reporting this profile?{" "}
+                    <span className="text-red-500">*</span>
+                  </p>
+                  {REPORT_REASONS.map((reason) => (
+                    <label
+                      key={reason}
+                      className={`flex cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 transition-all ${
+                        selectedReason === reason
+                          ? "border-[var(--ui-border-strong)] bg-[var(--ui-surface-active)]"
+                          : "border-[var(--ui-border)] bg-[var(--ui-surface)]"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        value={reason}
+                        {...register("reason", { required: "Please select a reason" })}
+                        className="sr-only"
+                      />
+                      <span
+                        className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all ${
+                          selectedReason === reason
+                            ? "border-[var(--ui-text)] bg-[var(--ui-text)]"
+                            : "border-[var(--ui-border-strong)] bg-transparent"
+                        }`}
+                      />
+                      <span className="text-sm text-[var(--ui-text)]">{reason}</span>
+                    </label>
+                  ))}
+                  {errors.reason && (
+                    <p className="text-xs text-red-400">{errors.reason.message}</p>
+                  )}
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-semibold text-[var(--ui-text)]">
+                    Additional details{" "}
+                    <span className="font-normal text-[var(--ui-text-muted)]">(optional)</span>
+                  </label>
+                  <textarea
+                    rows={3}
+                    placeholder="Add any details that might help us review this report…"
+                    className="w-full resize-none rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-2 focus:ring-[var(--ui-border)] hover:border-[var(--ui-border-strong)]"
+                    {...register("details")}
+                  />
+                </div>
+
+                <div className="flex gap-3 pt-1">
+                  <button
+                    type="button"
+                    onClick={close}
+                    className="flex-1 rounded-xl border border-[var(--ui-border-strong)] px-4 py-2.5 text-sm font-medium text-[var(--ui-text)] transition hover:bg-[var(--ui-surface)] cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="flex-1 rounded-xl bg-red-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-red-600 disabled:opacity-50 cursor-pointer"
+                  >
+                    {isSubmitting ? "Submitting…" : "Submit report"}
+                  </button>
+                </div>
+              </form>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/features/report/ReportProfileButton.tsx
+++ b/src/features/report/ReportProfileButton.tsx
@@ -69,7 +69,7 @@ export default function ReportProfileButton({
           e.stopPropagation();
           setOpen(true);
         }}
-        className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-red-500 cursor-pointer"
+        className="flex-shrink-0 rounded-full p-2 text-gray-500 transition hover:bg-red-50 hover:text-red-500 cursor-pointer"
         title="Report this profile"
       >
         <FaFlag className="h-4 w-4" />


### PR DESCRIPTION
# MCFM-141 | Report Abuse Button

## Summary
  Add a report abuse feature that allows users to flag profiles for review across all profile-viewing surfaces in the app. When a
  report is submitted, the API sends an email notification to the admin via Resend, including the reporter's identity (pulled from
  Clerk), the reported user's ID and name, the selected reason, and any additional details. The feature is surfaced as a flag icon
  button consistently placed in the header row of every profile modal and card.

  ## Changes

  ### API
  - Add `POST /api/report-abuse` route (`src/app/api/report-abuse/route.ts`) that authenticates the reporter via Clerk, resolves their
  name and primary email address from the Clerk API, then sends a structured HTML email to `mamun@mamuncofoundr.com` via Resend. The
  email includes reporter identity, reported user ID/name, reason, and optional details — giving admins enough context to act without
  needing a database table.

  ### Client — ReportProfileButton component
  - Introduce `src/features/report/ReportProfileButton.tsx`, a self-contained "client" component with local open/close state and a
  `react-hook-form`-managed form. Presents six predefined report reasons as animated radio cards (Framer Motion spring transition),
  plus an optional free-text textarea for additional context. Required reason validation is enforced client-side before submission.
  Submits via `fetch` to `/api/report-abuse` and shows a toast on success or failure. The trigger is a flag icon (`FaFlag`) that uses
  `e.stopPropagation()` to avoid bubbling through parent modal click handlers.

  ### Integration — profile surfaces
  - Mount `ReportProfileButton` in four places, each passing `reportedUserId` and a trimmed full name constructed from
  `firstName`/`lastName`:
    - **Cofoundr Matching page** (`src/app/(general)/cofoundr-matching/page.tsx`) — shown on the current swiping candidate's card.
    - **School Dashboard page** (`src/app/(school)/school/[slug]/dashboard/page.tsx`) — shown on the profile card header in the
  school-filtered browsing view.
    - **ProfileDetailModal** (`src/features/matches/ProfileDetailModal.tsx`) — shown alongside the close button in the matches detail
  modal.
    - **ProfileViewModal** (`src/features/profile/ProfileViewModal.tsx`) — shown alongside the close button in the general profile
  viewer modal.

  ## Migration / Config
  - Requires `RESEND_API_KEY` environment variable to be set (already used elsewhere in the project, no new secret needed if already
  configured).

  ## Testing
  - Manual: open any profile modal or card, click the flag icon, select a reason, submit — verify toast appears and admin email is
  received at `mamun@mamuncofoundr.com`.

  ## Notes
  - Reports are email-only; there is no database record or admin dashboard entry for reports. If volume grows, a follow-up could
  persist reports to a DB table.
  - The `from` address is hardcoded to `mamun@mamuncofoundr.com` — ensure this sender domain is verified in Resend.
