### PR TITLE
MCFM-143 | Add RLS batch 2 migration for remaining unscoped tables

### DIFF
--- a/supabase/migrations/20260617000000_batch2_rls.sql
+++ b/supabase/migrations/20260617000000_batch2_rls.sql
@@ -1,0 +1,80 @@
+-- Migration: Batch 2 RLS policy rollout
+--
+-- Covers the four tables left unscoped after the Batch 1 migration
+-- (20260612000001_activate_org_isolation_rls.sql):
+--
+--   • access codes        — RLS was enabled but no policy existed (deny-all).
+--                           Unlock SELECT for authenticated users; writes stay
+--                           service-role only (service_role bypasses RLS).
+--   • referrals           — RLS was enabled but no policy existed.
+--                           Owner-scoped: a user sees only rows they appear in
+--                           as referrer or referred party.
+--   • user_activity_summary — Had a legacy USING (true) SELECT policy that let
+--                           any authenticated user read all users' activity,
+--                           leaking school-user data to general-pool users.
+--                           Replaced with org-scoped SELECT (JOIN profiles).
+--                           The existing service_role full-access policy is kept.
+--   • user_consents       — RLS was enabled but no policy existed (deny-all).
+--                           Owner-scoped by user_id.
+
+-- ============================================================
+-- access codes  (no user/org column — allow authenticated read)
+-- ============================================================
+DROP POLICY IF EXISTS "access_codes_read" ON "public"."access codes";
+CREATE POLICY "access_codes_read" ON "public"."access codes"
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- ============================================================
+-- referrals  (owner-scoped, no org column)
+-- ============================================================
+DROP POLICY IF EXISTS "referrals_own" ON referrals;
+CREATE POLICY "referrals_own" ON referrals
+  FOR ALL
+  USING (
+    referred_user_id  = auth.jwt() ->> 'sub'
+    OR referrer_user_id = auth.jwt() ->> 'sub'
+  )
+  WITH CHECK (
+    referrer_user_id = auth.jwt() ->> 'sub'
+  );
+
+-- ============================================================
+-- user_activity_summary  (replace permissive USING (true) with org-scoped)
+-- ============================================================
+DROP POLICY IF EXISTS "Users can view others activity for matching" ON user_activity_summary;
+DROP POLICY IF EXISTS "Users can view their own activity"          ON user_activity_summary;
+
+-- Service role full-access policy ("Service role has full access") is already
+-- present in the baseline and covers INSERT/UPDATE/DELETE — leave it in place.
+DROP POLICY IF EXISTS "user_activity_summary_org_isolation" ON user_activity_summary;
+CREATE POLICY "user_activity_summary_org_isolation" ON user_activity_summary
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.user_id = user_activity_summary.user_id
+        AND (
+          (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+            AND p.organization_id IS NULL)
+          OR (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+            AND p.organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+        )
+    )
+  );
+
+-- ============================================================
+-- user_consents  (owner-scoped by user_id)
+-- ============================================================
+DROP POLICY IF EXISTS "user_consents_own" ON user_consents;
+CREATE POLICY "user_consents_own" ON user_consents
+  FOR ALL
+  USING (user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (user_id = auth.jwt() ->> 'sub');
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Batch 2 RLS activated: access codes (read), referrals (owner), user_activity_summary (org-scoped), user_consents (owner).';
+END $$;


### PR DESCRIPTION
# MCFM-143 | Add RLS batch 2 migration for remaining unscoped tables

## Summary
Follows up the Batch 1 RLS rollout (`20260612000001_activate_org_isolation_rls.sql`) by applying correct Row Level Security policies to four tables that were either left in a deny-all state or carried an overly permissive legacy policy. The most critical fix is `user_activity_summary`, which had a USING (true) SELECT policy that exposed every user's activity data to all authenticated users — a cross-org data leak. This migration scopes that table to org isolation (matching the Batch 1 pattern) and adds appropriate owner-scoped or authenticated-read policies to the three remaining tables.

## Changes

### Database — RLS policies

- **`access codes`**: Drop the implicit deny-all and add an `access_codes_read` SELECT policy scoped to `TO authenticated USING (true)`. The table has no user/org column so a blanket authenticated-read is the correct scope; writes continue to be service-role only since service_role bypasses RLS entirely.
- **`referrals`**: Add `referrals_own` ALL policy keyed on `referred_user_id OR referrer_user_id = auth.jwt() ->> 'sub'`. The `WITH CHECK` is narrower — only the referrer may insert/update — preventing a referred user from fabricating or mutating referral records they didn't originate.
- **`user_activity_summary`**: Drop two legacy policies ("Users can view others activity for matching" and "Users can view their own activity") that together allowed any authenticated user to read all rows. Replace with `user_activity_summary_org_isolation` SELECT policy that JOINs `profiles` and matches the requesting user's `organization_id` JWT claim, including a NULL-org general-pool path. The existing service_role full-access policy is intentionally left untouched to preserve background write access.
- **`user_consents`**: Add `user_consents_own` ALL policy scoped to `user_id = auth.jwt() ->> 'sub'` with a matching `WITH CHECK`, so each user can only read and modify their own consent records.

## Migration / Config
- Run `supabase/migrations/20260617000000_batch2_rls.sql` against the target environment. All four changes are idempotent (`DROP POLICY IF EXISTS` before each `CREATE POLICY`).
- No new env vars or third-party setup required.
- Verify `user_activity_summary` behaviour with a user from one org: they should no longer be able to read rows belonging to users in a different org or the general pool.

## Testing
- Manual: authenticate as a general-pool user and query `user_activity_summary` — should only return rows where `profiles.organization_id IS NULL`.
- Manual: authenticate as an org user and query the same table — should only return rows for profiles in that org.
- Manual: attempt to insert a `referrals` row as the referred party (not referrer) — should be blocked by the `WITH CHECK` constraint.

## Notes
- The `user_activity_summary` data leak existed since the Batch 1 migration enabled RLS on the table without replacing the old `USING (true)` policy. This migration is the remediation.
- The NULL-org path in the `user_activity_summary` policy mirrors the Batch 1 org-isolation pattern exactly to keep behaviour consistent across the app.
