### PR TITLE
Fix school user routing, stale JWT, and invalid domain 404s

### DIFF
--- a/src/app/(general)/layout.tsx
+++ b/src/app/(general)/layout.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/header_footer/Header";
 import Socials from "@/components/Socials";
 import Footer from "@/components/header_footer/Footer";
+import SchoolUserGuard from "@/components/SchoolUserGuard";
 
 export default function GeneralLayout({
   children,
@@ -9,6 +10,7 @@ export default function GeneralLayout({
 }) {
   return (
     <>
+      <SchoolUserGuard />
       <Header />
       {children}
       <Socials />

--- a/src/app/(school)/school/[slug]/not-authorized/page.tsx
+++ b/src/app/(school)/school/[slug]/not-authorized/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { FaEnvelopeOpen } from "react-icons/fa";
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
+import { formatAllowedDomainsForCopy } from "@/features/school/auth/email-domain";
+
+export default async function NotAuthorizedPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const org = await getOrganizationBySlug(slug);
+  if (!org) notFound();
+
+  const domainCopy = formatAllowedDomainsForCopy(org.allowed_email_domains);
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 p-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--ui-surface)]">
+        <FaEnvelopeOpen className="h-8 w-8 text-[var(--ui-text-muted)]" />
+      </div>
+
+      <div className="max-w-sm space-y-2">
+        <h1 className="text-2xl font-bold text-[var(--ui-text)]">
+          School email required
+        </h1>
+        <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
+          This portal is only available to {org.name} students and faculty.
+          {domainCopy && (
+            <>
+              {" "}You need a{" "}
+              <span className="font-semibold text-[var(--ui-text)]">
+                {domainCopy}
+              </span>{" "}
+              email address to access this site.
+            </>
+          )}
+        </p>
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <Link
+          href={`/school/${slug}/sign-up`}
+          className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "var(--org-primary)" }}
+        >
+          Sign up with your school email
+        </Link>
+        <Link
+          href={`/school/${slug}/sign-in`}
+          className="text-sm text-[var(--ui-text-muted)] underline underline-offset-4 hover:text-[var(--ui-text)]"
+        >
+          Already have an account? Sign in
+        </Link>
+        <Link
+          href="https://www.mamuncofoundr.com"
+          className="text-xs text-[var(--ui-text-subtle)] hover:text-[var(--ui-text-muted)]"
+        >
+          Go to the main Mamun platform →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SchoolUserGuard.tsx
+++ b/src/components/SchoolUserGuard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useUser, useSession, useAuth } from "@clerk/nextjs";
+import { usePathname } from "next/navigation";
+
+const PUBLIC_PATHS = new Set([
+  "/",
+  "/careers",
+  "/contact-us",
+  "/mission",
+  "/privacy-policy",
+  "/refund-policy",
+  "/pricing",
+  "/founder-archetypes",
+]);
+
+export default function SchoolUserGuard() {
+  const { user, isLoaded } = useUser();
+  const { session } = useSession();
+  const { sessionClaims } = useAuth();
+  const pathname = usePathname();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (!isLoaded || !user || !session) return;
+    // Don't interfere with public pages — school users can browse pricing, etc.
+    if (PUBLIC_PATHS.has(pathname)) return;
+
+    const liveOrgId = user.publicMetadata?.organization_id as string | undefined;
+    const claimsOrgId = (
+      sessionClaims as { metadata?: { organization_id?: string } }
+    )?.metadata?.organization_id;
+
+    if (liveOrgId && !claimsOrgId) {
+      // JWT is stale — organization_id was set after the current session was
+      // minted. Force a token refresh so the middleware sees the updated claims.
+      setIsRefreshing(true);
+      session.touch().then(() => {
+        window.location.reload();
+      });
+    }
+  }, [isLoaded, user, session, sessionClaims, pathname]);
+
+  if (isRefreshing) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div className="rounded-2xl bg-white px-8 py-6 text-center shadow-2xl">
+          <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-gray-800" />
+          <p className="text-sm font-medium text-gray-800">Updating your account…</p>
+          <p className="mt-1 text-xs text-gray-400">You&apos;ll be redirected shortly.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,6 +26,7 @@ const isPublicRoute = createRouteMatcher([
   "/school/:slug",
   "/school/:slug/privacy-policy",
   "/school/:slug/terms-and-conditions",
+  "/school/:slug/not-authorized",
   "/school/:slug/sign-up(.*)",
   "/school/:slug/sign-in(.*)",
   "/school/:slug/sso-callback(.*)",
@@ -141,7 +142,10 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   }
 
   const { userId, sessionClaims, redirectToSignIn } = await auth();
-  const host = req.headers.get("host") ?? "";
+  // x-forwarded-host is set by Vercel and reflects the original hostname even
+  // behind load balancers or proxies that rewrite the Host header.
+  const host =
+    req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? "";
   const isApiRoute = pathname.startsWith("/api/");
   const isStaticAsset = /\.(ico|png|jpg|jpeg|svg|css|js|woff|woff2?|ttf)$/.test(pathname);
 
@@ -209,6 +213,16 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
 
       if (!org) {
         return NextResponse.redirect(new URL("/", req.url));
+      }
+
+      // School users who land on general onboarding (e.g. signed up via the
+      // main site) must be redirected to their school onboarding instead.
+      // This closes the race condition where the user.created webhook sets
+      // organization_id after the user has already been sent to /onboarding.
+      if (isOnboardingRoute(req)) {
+        return NextResponse.redirect(
+          new URL(`/school/${org.slug}/onboarding`, req.url),
+        );
       }
 
       // Path-based tenant enforcement: a signed-in school user must not view
@@ -282,7 +296,11 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
     }
 
     if (isSchoolRoute(req) && !isApiRoute && !isPublicRoute(req)) {
-      return NextResponse.redirect(new URL("/cofoundr-matching", req.url));
+      const pathSlug = pathname.match(/^\/school\/([^/]+)/)?.[1];
+      const dest = pathSlug
+        ? `/school/${pathSlug}/not-authorized`
+        : "/cofoundr-matching";
+      return NextResponse.redirect(new URL(dest, req.url));
     }
 
     if (!sessionClaims?.metadata?.onboardingComplete) {


### PR DESCRIPTION
# Fix school user routing, stale JWT, and invalid domain 404s

## Summary

  This PR fixes three distinct routing bugs that together could land school users in the wrong place: a
  stale JWT causing the middleware to miss a freshly-set `organization_id`, incorrect hostname
  resolution behind Vercel's load balancer sending tenant detection astray, and non-school users
  hitting a protected school route being dropped on an unrelated general page instead of a clear
  rejection screen. The fixes are a middleware host-header correction, a new client-side
  `SchoolUserGuard` component that forces a JWT refresh when claims lag behind user metadata, and a new
  `/school/[slug]/not-authorized` page that gives a clear, actionable error with school-specific
  domain copy.

  ## Changes

  ### Middleware (`src/middleware.ts`)
  - **Fix host detection to use `x-forwarded-host`** instead of bare `Host` header. Vercel's
  infrastructure rewrites `Host` at the edge but preserves the original hostname in `x-forwarded-host`,
  so subdomain-based tenant detection was silently matching the wrong (or empty) hostname in
  production.
  - **Add `/school/:slug/not-authorized` as a public route** so unauthenticated or non-member visitors
  can reach the rejection page without being looped back to sign-in.
  - **Redirect school users who hit `/onboarding`** (the general flow) straight to
  `/school/:slug/onboarding`. This closes a race condition where the `user.created` webhook writes
  `organization_id` to Clerk metadata after the new user was already sent to the general onboarding
  path.
  - **Replace the silent `/cofoundr-matching` redirect** for non-school users accessing a school route
  with a redirect to `/school/[slug]/not-authorized`, extracting the `slug` from the pathname so the
  rejection page is school-specific.

  ### SchoolUserGuard (`src/components/SchoolUserGuard.tsx`)
  - New client component mounted in the general layout that compares
  `user.publicMetadata.organization_id` (live, always fresh from Clerk) against the same field in
  `sessionClaims.metadata` (from the JWT, which can lag). If the JWT is stale — i.e. `organization_id`
  was assigned after the current session token was minted — it calls `session.touch()` to force a token
  refresh and then reloads the page.
  - While the refresh is in flight it renders a full-screen overlay with a spinner so users aren't
  confused by the reload.
  - Skips the check on a hardcoded set of `PUBLIC_PATHS` (home, pricing, careers, etc.) so school users
  can browse public general pages without triggering an unnecessary reload loop.

  ### Not-Authorized Page (`src/app/(school)/school/[slug]/not-authorized/page.tsx`)
  - New async server component that looks up the org by slug (calls `notFound()` for invalid slugs) and
  renders a clear "School email required" screen.
  - Uses `formatAllowedDomainsForCopy` to display the org's allowed email domains (e.g. "a
  `@university.edu` email address"), giving the visitor an actionable next step.
  - Provides CTAs to sign up with a school email, sign in, or navigate back to the main Mamun platform.

  ### General Layout (`src/app/(general)/layout.tsx`)
  - Mounts `<SchoolUserGuard />` at the top of the general layout so the stale-JWT detection runs on
  every general page without requiring per-page wiring.

  ## Testing
  - Verify that a school user whose JWT was minted before their `organization_id` was set sees the
  spinner overlay and is reloaded/redirected correctly after `session.touch()`.
  - Verify that a non-school signed-in user visiting `/school/some-slug/dashboard` is redirected to
  `/school/some-slug/not-authorized` (not `/cofoundr-matching`).
  - Verify that the not-authorized page renders the correct domain copy for orgs with
  `allowed_email_domains` set, and gracefully omits it for orgs without.
  - Verify that a new school user who completes Clerk sign-up via the main site is redirected from
  `/onboarding` to `/school/:slug/onboarding`.
  - Verify that public general pages (home, pricing) are accessible by school users without triggering
  a refresh loop.

  ## Notes
  - `SchoolUserGuard`'s `PUBLIC_PATHS` set is hardcoded. If new public general routes are added, they
  should be added here to prevent unnecessary JWT refreshes for school users browsing those pages.