### PR TITLE
MCFM-144 | Fix Batch 3 RLS write guards and cofounder-link IDOR

### DIFF
--- a/src/app/api/cofounder-link/[userId]/route.ts
+++ b/src/app/api/cofounder-link/[userId]/route.ts
@@ -24,12 +24,37 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
-    const { userId: requestingUserId } = await auth();
+    const { userId: requestingUserId, sessionClaims } = await auth();
     if (!requestingUserId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { userId } = await params;
+
+    // Access check: caller must be the profile owner or able to see the target
+    // in the matching feed (same org, or both general-pool / null-org).
+    // Blocks the IDOR: a school-org user can't read a different school's links.
+    const isSelf = requestingUserId === userId;
+    if (!isSelf) {
+      const requestingOrgId =
+        ((sessionClaims?.metadata as Record<string, unknown>)
+          ?.organization_id as string | undefined) ?? null;
+
+      const supabase = supa();
+      const { data: targetProfile } = await supabase
+        .from("profiles")
+        .select("organization_id")
+        .eq("user_id", userId)
+        .single();
+
+      const targetOrgId = targetProfile?.organization_id ?? null;
+
+      // Deny if the orgs don't match (covers school↔general and school↔school cross-org)
+      if (requestingOrgId !== targetOrgId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
     const supabase = supa();
 
     const { data: links, error: linkErr } = await supabase

--- a/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
+++ b/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
@@ -21,6 +21,21 @@
 --                       authenticated users — writes go through service role).
 --   • cofounder_links — writes go through service role (bypasses RLS), but
 --                       add a WITH CHECK as defense-in-depth.
+--
+-- Additionally corrects two bugs in Batch 1 that are invisible under service
+-- role (which bypasses RLS) but break routes when switched to user JWT:
+--
+--   • user_profile_actions — Batch 1 policy joined profiles.user_id to
+--                       user_profile_actions.user_id, but the app stores the
+--                       integer profile id (profiles.id) in that column, not
+--                       the Clerk user id. The EXISTS check never matched →
+--                       deny-all under user JWT. Fixed with correct join.
+--   • school_profiles  — existing own-row policy only exposes the caller's
+--                       own row. Routes that enrich peers' cards with school
+--                       data (likes/profiles, profiles feed) got empty results
+--                       under user JWT. Added additive org-scoped SELECT that
+--                       OR-combines with the own-row policy; writes stay
+--                       owner-only.
 
 -- ============================================================
 -- profiles  (regression fix from batch 1)
@@ -204,7 +219,55 @@ CREATE POLICY "cofounder_links_delete_own" ON cofounder_links
     OR user_b_id = auth.jwt() ->> 'sub'
   );
 
+-- ============================================================
+-- user_profile_actions  (correct join: profiles.id, not profiles.user_id)
+--
+-- Batch 1 joined on profiles.user_id = user_profile_actions.user_id, but the
+-- app writes the integer profile id (profiles.id) into that column. Fixed here
+-- to join on profiles.id::text so the EXISTS check resolves correctly under a
+-- user JWT client.
+-- ============================================================
+DROP POLICY IF EXISTS "user_profile_actions_org_isolation" ON user_profile_actions;
+DROP POLICY IF EXISTS "user_profile_actions_owner"         ON user_profile_actions;
+
+CREATE POLICY "user_profile_actions_owner" ON user_profile_actions
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id::text = user_profile_actions.user_id
+        AND p.user_id = auth.jwt() ->> 'sub'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id::text = user_profile_actions.user_id
+        AND p.user_id = auth.jwt() ->> 'sub'
+    )
+  );
+
+-- ============================================================
+-- school_profiles  (additive org-scoped SELECT for peer enrichment)
+--
+-- The existing own-row policy (FOR ALL, user_id = sub) only exposes the
+-- caller's row. Routes that enrich peer profile cards with school data need
+-- to read classmates' rows. This SELECT policy OR-combines with the owner
+-- policy so writes remain owner-only.
+-- ============================================================
+DROP POLICY IF EXISTS "school_profiles_select_org" ON school_profiles;
+
+CREATE POLICY "school_profiles_select_org" ON school_profiles
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
 DO $$
 BEGIN
-  RAISE NOTICE '✅ Batch 3 write guards applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth).';
+  RAISE NOTICE '✅ Batch 3 applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth), user_profile_actions (join fix), school_profiles (org SELECT).';
 END $$;

--- a/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
+++ b/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
@@ -1,0 +1,210 @@
+-- Migration: Batch 3 RLS write guards
+--
+-- Batch 1 replaced the original owner-scoped write policies on profiles
+-- (Allow update/delete/insert for owner) with a single FOR ALL org-isolation
+-- policy. This silently removed the owner check on writes — any user in the
+-- same org could UPDATE or DELETE another user's profile.
+--
+-- This migration fixes that regression and applies the same owner-check
+-- pattern to the other tables whose FOR ALL policies only scope by org:
+--
+--   • profiles        — regression fix: split FOR ALL into SELECT (org-scoped)
+--                       + INSERT/UPDATE/DELETE (owner-scoped)
+--   • match_intents   — split FOR ALL into SELECT (org-scoped)
+--                       + writes restricted to from_user_id
+--   • cofounder_invites — split FOR ALL into SELECT (org-scoped)
+--                       + writes restricted to inviter_user_id
+--   • messages        — existing USING (participant check) had no WITH CHECK;
+--                       split into SELECT (participant) + INSERT that also
+--                       asserts sender_id = current user. UPDATE/DELETE are
+--                       intentionally left without a policy (deny-all for
+--                       authenticated users — writes go through service role).
+--   • cofounder_links — writes go through service role (bypasses RLS), but
+--                       add a WITH CHECK as defense-in-depth.
+
+-- ============================================================
+-- profiles  (regression fix from batch 1)
+-- ============================================================
+DROP POLICY IF EXISTS "profiles_org_isolation"  ON profiles;
+DROP POLICY IF EXISTS "profiles_select_org"     ON profiles;
+DROP POLICY IF EXISTS "profiles_insert_own"     ON profiles;
+DROP POLICY IF EXISTS "profiles_update_own"     ON profiles;
+DROP POLICY IF EXISTS "profiles_delete_own"     ON profiles;
+
+-- SELECT: users see profiles in their own org (needed for matching)
+CREATE POLICY "profiles_select_org" ON profiles
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+-- INSERT: can only create your own profile row
+CREATE POLICY "profiles_insert_own" ON profiles
+  FOR INSERT
+  WITH CHECK (user_id = auth.jwt() ->> 'sub');
+
+-- UPDATE: can only update your own profile row
+CREATE POLICY "profiles_update_own" ON profiles
+  FOR UPDATE
+  USING (user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (user_id = auth.jwt() ->> 'sub');
+
+-- DELETE: can only delete your own profile row
+CREATE POLICY "profiles_delete_own" ON profiles
+  FOR DELETE
+  USING (user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- match_intents  (org-scoped SELECT + from_user write guard)
+-- ============================================================
+DROP POLICY IF EXISTS "match_intents_org_isolation" ON match_intents;
+DROP POLICY IF EXISTS "match_intents_select_org"    ON match_intents;
+DROP POLICY IF EXISTS "match_intents_write_own"     ON match_intents;
+
+CREATE POLICY "match_intents_select_org" ON match_intents
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+CREATE POLICY "match_intents_insert_own" ON match_intents
+  FOR INSERT
+  WITH CHECK (from_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "match_intents_update_own" ON match_intents
+  FOR UPDATE
+  USING (from_user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (from_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "match_intents_delete_own" ON match_intents
+  FOR DELETE
+  USING (from_user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- cofounder_invites  (org-scoped SELECT + inviter write guard)
+-- ============================================================
+DROP POLICY IF EXISTS "cofounder_invites_org_isolation" ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_select_org"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_insert_own"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_update_own"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_delete_own"    ON cofounder_invites;
+
+CREATE POLICY "cofounder_invites_select_org" ON cofounder_invites
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+CREATE POLICY "cofounder_invites_insert_own" ON cofounder_invites
+  FOR INSERT
+  WITH CHECK (inviter_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "cofounder_invites_update_own" ON cofounder_invites
+  FOR UPDATE
+  USING (inviter_user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (inviter_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "cofounder_invites_delete_own" ON cofounder_invites
+  FOR DELETE
+  USING (inviter_user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- messages  (participant SELECT + sender INSERT guard)
+--
+-- UPDATE/DELETE are intentionally left without a user-facing policy
+-- (deny-all for authenticated). All message writes go through the
+-- service role in /api/messages/.../send/route.ts which bypasses RLS.
+-- ============================================================
+DROP POLICY IF EXISTS "messages_org_isolation"      ON messages;
+DROP POLICY IF EXISTS "messages_select_participant" ON messages;
+DROP POLICY IF EXISTS "messages_insert_own"         ON messages;
+
+CREATE POLICY "messages_select_participant" ON messages
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM conversation_participants cp
+      JOIN profiles p ON p.user_id = cp.user_id
+      WHERE cp.conversation_id = messages.conversation_id
+        AND cp.user_id = auth.jwt() ->> 'sub'
+        AND (
+          (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+            AND p.organization_id IS NULL)
+          OR (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+            AND p.organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+        )
+    )
+  );
+
+CREATE POLICY "messages_insert_own" ON messages
+  FOR INSERT
+  WITH CHECK (
+    sender_id = auth.jwt() ->> 'sub'
+    AND EXISTS (
+      SELECT 1 FROM conversation_participants cp
+      WHERE cp.conversation_id = messages.conversation_id
+        AND cp.user_id = auth.jwt() ->> 'sub'
+    )
+  );
+
+-- ============================================================
+-- cofounder_links  (defense-in-depth; writes are service-role)
+-- ============================================================
+DROP POLICY IF EXISTS "cofounder_links_org_isolation" ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_select_org"    ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_write_own"     ON cofounder_links;
+
+CREATE POLICY "cofounder_links_select_org" ON cofounder_links
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+-- Writes restricted to a participant in the link (defense-in-depth;
+-- production inserts go through service role in /api/cofounder-invite/.../accept).
+CREATE POLICY "cofounder_links_insert_own" ON cofounder_links
+  FOR INSERT
+  WITH CHECK (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+CREATE POLICY "cofounder_links_update_own" ON cofounder_links
+  FOR UPDATE
+  USING (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  )
+  WITH CHECK (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+CREATE POLICY "cofounder_links_delete_own" ON cofounder_links
+  FOR DELETE
+  USING (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Batch 3 write guards applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth).';
+END $$;


### PR DESCRIPTION
# MCFM-144 | Fix Batch 3 RLS write guards and cofounder-link IDOR

## Summary
This PR completes the RLS hardening started in Batch 1 by fixing two categories of security bugs: (1) a regression where the Batch 1 `FOR ALL` org-isolation policy on `profiles` silently removed the owner check on writes, allowing any user in the same org to UPDATE or DELETE another user's profile; and (2) similar write-guard gaps on `match_intents`, `cofounder_invites`, `messages`, and `cofounder_links`. It also corrects two Batch 1 bugs that were invisible under service role but caused deny-all under user JWT: a wrong join column in `user_profile_actions` and a missing org-scoped SELECT on `school_profiles`. Finally, it patches an IDOR in the `GET /api/cofounder-link/[userId]` route that allowed a user from one school org to read another school's co-founder links.

## Changes

### Database (Migration: `20260617000001_batch3_rls_write_guards.sql`)

- **`profiles` regression fix** — drops the `profiles_org_isolation` `FOR ALL` policy introduced in Batch 1 and replaces it with four operation-specific policies: `SELECT` scoped to org (so matching still works) and `INSERT`/`UPDATE`/`DELETE` scoped to `user_id = auth.jwt() ->> 'sub'` (owner-only). This closes the window where any same-org user could overwrite or delete a peer's profile row.

- **`match_intents` write guard** — same split pattern: org-scoped `SELECT`, plus `INSERT`/`UPDATE`/`DELETE` restricted to `from_user_id = sub`. Previously the `FOR ALL` policy allowed any org-peer to mutate another user's match intent.

- **`cofounder_invites` write guard** — same pattern, writes restricted to `inviter_user_id = sub`. Prevents an org peer from modifying or retracting another user's invite.

- **`messages` sender check** — separates the existing participant-check `USING` into a proper `SELECT` policy, and adds a new `INSERT` policy with `WITH CHECK (sender_id = sub AND participant in conversation)`. `UPDATE`/`DELETE` are intentionally left with no user-facing policy (deny-all for authenticated users); all message writes go through the service role in the send route which bypasses RLS.

- **`cofounder_links` defense-in-depth** — service role handles all writes in production, but adds `INSERT`/`UPDATE`/`DELETE` policies restricted to a participant in the link (`user_a_id = sub OR user_b_id = sub`) as a second line of defense, alongside an org-scoped `SELECT` replacing the old `FOR ALL`.

- **`user_profile_actions` join fix** — Batch 1 joined `profiles.user_id = user_profile_actions.user_id`, but the app writes the integer `profiles.id` (not the Clerk user string) into that column. The `EXISTS` check never matched under user JWT, making the policy deny-all. Fixed by joining `profiles.id::text = user_profile_actions.user_id`.

- **`school_profiles` org-scoped SELECT** — the existing owner-only `FOR ALL` policy only exposed the caller's own row. Routes that enrich peer profile cards (likes, profiles feed) read classmates' `school_profiles` rows. Adds an additive `SELECT` policy scoped by org so peer enrichment works under user JWT; owner-only policies continue to gate writes.

### API (`src/app/api/cofounder-link/[userId]/route.ts`)

- **IDOR guard on co-founder link lookup** — extracts `sessionClaims` from Clerk auth to read the requesting user's `organization_id`. If the caller is not the profile owner, fetches the target's `organization_id` from `profiles` and returns 403 if they differ. This blocks a school-org user from enumerating co-founder links of users in a different school org (or general pool), closing an insecure direct object reference that was not caught by RLS since `cofounder_links` reads go through the API layer.

## Migration / Config

- Run migration `20260617000001_batch3_rls_write_guards.sql` against the target environment. The migration is idempotent (`DROP POLICY IF EXISTS` guards all replacements).
- No new env vars or third-party config required.

## Testing

- Verified RLS policies apply correctly under a user-JWT Supabase client (not service role) by walking through matching, profile updates, and school profile enrichment flows.
- Confirmed the cofounder-link route returns 403 when a cross-org user requests another org's links, and 200 when requesting their own or a same-org peer's links.

## Notes

- The `messages` `UPDATE`/`DELETE` deny-all stance is intentional: the send route uses service role and no current feature exposes message editing or deletion to users.
- The `cofounder_links` participant-based write check is defense-in-depth only — service role bypasses RLS; the policy exists to limit blast radius if a route were ever accidentally switched to user JWT.
