### PR TITLE
Release: RLS Policy Migrations (Final) + Service Role to JWT Client Batch 1

### DIFF
--- a/src/app/api/cofounder-link/[userId]/route.ts
+++ b/src/app/api/cofounder-link/[userId]/route.ts
@@ -24,12 +24,37 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
-    const { userId: requestingUserId } = await auth();
+    const { userId: requestingUserId, sessionClaims } = await auth();
     if (!requestingUserId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { userId } = await params;
+
+    // Access check: caller must be the profile owner or able to see the target
+    // in the matching feed (same org, or both general-pool / null-org).
+    // Blocks the IDOR: a school-org user can't read a different school's links.
+    const isSelf = requestingUserId === userId;
+    if (!isSelf) {
+      const requestingOrgId =
+        ((sessionClaims?.metadata as Record<string, unknown>)
+          ?.organization_id as string | undefined) ?? null;
+
+      const supabase = supa();
+      const { data: targetProfile } = await supabase
+        .from("profiles")
+        .select("organization_id")
+        .eq("user_id", userId)
+        .single();
+
+      const targetOrgId = targetProfile?.organization_id ?? null;
+
+      // Deny if the orgs don't match (covers school↔general and school↔school cross-org)
+      if (requestingOrgId !== targetOrgId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
     const supabase = supa();
 
     const { data: links, error: linkErr } = await supabase

--- a/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
+++ b/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
@@ -79,6 +79,9 @@ CREATE POLICY "profiles_delete_own" ON profiles
 DROP POLICY IF EXISTS "match_intents_org_isolation" ON match_intents;
 DROP POLICY IF EXISTS "match_intents_select_org"    ON match_intents;
 DROP POLICY IF EXISTS "match_intents_write_own"     ON match_intents;
+DROP POLICY IF EXISTS "match_intents_insert_own"    ON match_intents;
+DROP POLICY IF EXISTS "match_intents_update_own"    ON match_intents;
+DROP POLICY IF EXISTS "match_intents_delete_own"    ON match_intents;
 
 CREATE POLICY "match_intents_select_org" ON match_intents
   FOR SELECT
@@ -181,6 +184,9 @@ CREATE POLICY "messages_insert_own" ON messages
 DROP POLICY IF EXISTS "cofounder_links_org_isolation" ON cofounder_links;
 DROP POLICY IF EXISTS "cofounder_links_select_org"    ON cofounder_links;
 DROP POLICY IF EXISTS "cofounder_links_write_own"     ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_insert_own"    ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_update_own"    ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_delete_own"    ON cofounder_links;
 
 CREATE POLICY "cofounder_links_select_org" ON cofounder_links
   FOR SELECT

--- a/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
+++ b/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
@@ -21,6 +21,21 @@
 --                       authenticated users — writes go through service role).
 --   • cofounder_links — writes go through service role (bypasses RLS), but
 --                       add a WITH CHECK as defense-in-depth.
+--
+-- Additionally corrects two bugs in Batch 1 that are invisible under service
+-- role (which bypasses RLS) but break routes when switched to user JWT:
+--
+--   • user_profile_actions — Batch 1 policy joined profiles.user_id to
+--                       user_profile_actions.user_id, but the app stores the
+--                       integer profile id (profiles.id) in that column, not
+--                       the Clerk user id. The EXISTS check never matched →
+--                       deny-all under user JWT. Fixed with correct join.
+--   • school_profiles  — existing own-row policy only exposes the caller's
+--                       own row. Routes that enrich peers' cards with school
+--                       data (likes/profiles, profiles feed) got empty results
+--                       under user JWT. Added additive org-scoped SELECT that
+--                       OR-combines with the own-row policy; writes stay
+--                       owner-only.
 
 -- ============================================================
 -- profiles  (regression fix from batch 1)
@@ -204,7 +219,55 @@ CREATE POLICY "cofounder_links_delete_own" ON cofounder_links
     OR user_b_id = auth.jwt() ->> 'sub'
   );
 
+-- ============================================================
+-- user_profile_actions  (correct join: profiles.id, not profiles.user_id)
+--
+-- Batch 1 joined on profiles.user_id = user_profile_actions.user_id, but the
+-- app writes the integer profile id (profiles.id) into that column. Fixed here
+-- to join on profiles.id::text so the EXISTS check resolves correctly under a
+-- user JWT client.
+-- ============================================================
+DROP POLICY IF EXISTS "user_profile_actions_org_isolation" ON user_profile_actions;
+DROP POLICY IF EXISTS "user_profile_actions_owner"         ON user_profile_actions;
+
+CREATE POLICY "user_profile_actions_owner" ON user_profile_actions
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id::text = user_profile_actions.user_id
+        AND p.user_id = auth.jwt() ->> 'sub'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id::text = user_profile_actions.user_id
+        AND p.user_id = auth.jwt() ->> 'sub'
+    )
+  );
+
+-- ============================================================
+-- school_profiles  (additive org-scoped SELECT for peer enrichment)
+--
+-- The existing own-row policy (FOR ALL, user_id = sub) only exposes the
+-- caller's row. Routes that enrich peer profile cards with school data need
+-- to read classmates' rows. This SELECT policy OR-combines with the owner
+-- policy so writes remain owner-only.
+-- ============================================================
+DROP POLICY IF EXISTS "school_profiles_select_org" ON school_profiles;
+
+CREATE POLICY "school_profiles_select_org" ON school_profiles
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
 DO $$
 BEGIN
-  RAISE NOTICE '✅ Batch 3 write guards applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth).';
+  RAISE NOTICE '✅ Batch 3 applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth), user_profile_actions (join fix), school_profiles (org SELECT).';
 END $$;

--- a/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
+++ b/supabase/migrations/20260617000001_batch3_rls_write_guards.sql
@@ -1,0 +1,210 @@
+-- Migration: Batch 3 RLS write guards
+--
+-- Batch 1 replaced the original owner-scoped write policies on profiles
+-- (Allow update/delete/insert for owner) with a single FOR ALL org-isolation
+-- policy. This silently removed the owner check on writes — any user in the
+-- same org could UPDATE or DELETE another user's profile.
+--
+-- This migration fixes that regression and applies the same owner-check
+-- pattern to the other tables whose FOR ALL policies only scope by org:
+--
+--   • profiles        — regression fix: split FOR ALL into SELECT (org-scoped)
+--                       + INSERT/UPDATE/DELETE (owner-scoped)
+--   • match_intents   — split FOR ALL into SELECT (org-scoped)
+--                       + writes restricted to from_user_id
+--   • cofounder_invites — split FOR ALL into SELECT (org-scoped)
+--                       + writes restricted to inviter_user_id
+--   • messages        — existing USING (participant check) had no WITH CHECK;
+--                       split into SELECT (participant) + INSERT that also
+--                       asserts sender_id = current user. UPDATE/DELETE are
+--                       intentionally left without a policy (deny-all for
+--                       authenticated users — writes go through service role).
+--   • cofounder_links — writes go through service role (bypasses RLS), but
+--                       add a WITH CHECK as defense-in-depth.
+
+-- ============================================================
+-- profiles  (regression fix from batch 1)
+-- ============================================================
+DROP POLICY IF EXISTS "profiles_org_isolation"  ON profiles;
+DROP POLICY IF EXISTS "profiles_select_org"     ON profiles;
+DROP POLICY IF EXISTS "profiles_insert_own"     ON profiles;
+DROP POLICY IF EXISTS "profiles_update_own"     ON profiles;
+DROP POLICY IF EXISTS "profiles_delete_own"     ON profiles;
+
+-- SELECT: users see profiles in their own org (needed for matching)
+CREATE POLICY "profiles_select_org" ON profiles
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+-- INSERT: can only create your own profile row
+CREATE POLICY "profiles_insert_own" ON profiles
+  FOR INSERT
+  WITH CHECK (user_id = auth.jwt() ->> 'sub');
+
+-- UPDATE: can only update your own profile row
+CREATE POLICY "profiles_update_own" ON profiles
+  FOR UPDATE
+  USING (user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (user_id = auth.jwt() ->> 'sub');
+
+-- DELETE: can only delete your own profile row
+CREATE POLICY "profiles_delete_own" ON profiles
+  FOR DELETE
+  USING (user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- match_intents  (org-scoped SELECT + from_user write guard)
+-- ============================================================
+DROP POLICY IF EXISTS "match_intents_org_isolation" ON match_intents;
+DROP POLICY IF EXISTS "match_intents_select_org"    ON match_intents;
+DROP POLICY IF EXISTS "match_intents_write_own"     ON match_intents;
+
+CREATE POLICY "match_intents_select_org" ON match_intents
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+CREATE POLICY "match_intents_insert_own" ON match_intents
+  FOR INSERT
+  WITH CHECK (from_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "match_intents_update_own" ON match_intents
+  FOR UPDATE
+  USING (from_user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (from_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "match_intents_delete_own" ON match_intents
+  FOR DELETE
+  USING (from_user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- cofounder_invites  (org-scoped SELECT + inviter write guard)
+-- ============================================================
+DROP POLICY IF EXISTS "cofounder_invites_org_isolation" ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_select_org"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_insert_own"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_update_own"    ON cofounder_invites;
+DROP POLICY IF EXISTS "cofounder_invites_delete_own"    ON cofounder_invites;
+
+CREATE POLICY "cofounder_invites_select_org" ON cofounder_invites
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+CREATE POLICY "cofounder_invites_insert_own" ON cofounder_invites
+  FOR INSERT
+  WITH CHECK (inviter_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "cofounder_invites_update_own" ON cofounder_invites
+  FOR UPDATE
+  USING (inviter_user_id = auth.jwt() ->> 'sub')
+  WITH CHECK (inviter_user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "cofounder_invites_delete_own" ON cofounder_invites
+  FOR DELETE
+  USING (inviter_user_id = auth.jwt() ->> 'sub');
+
+-- ============================================================
+-- messages  (participant SELECT + sender INSERT guard)
+--
+-- UPDATE/DELETE are intentionally left without a user-facing policy
+-- (deny-all for authenticated). All message writes go through the
+-- service role in /api/messages/.../send/route.ts which bypasses RLS.
+-- ============================================================
+DROP POLICY IF EXISTS "messages_org_isolation"      ON messages;
+DROP POLICY IF EXISTS "messages_select_participant" ON messages;
+DROP POLICY IF EXISTS "messages_insert_own"         ON messages;
+
+CREATE POLICY "messages_select_participant" ON messages
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM conversation_participants cp
+      JOIN profiles p ON p.user_id = cp.user_id
+      WHERE cp.conversation_id = messages.conversation_id
+        AND cp.user_id = auth.jwt() ->> 'sub'
+        AND (
+          (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+            AND p.organization_id IS NULL)
+          OR (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+            AND p.organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+        )
+    )
+  );
+
+CREATE POLICY "messages_insert_own" ON messages
+  FOR INSERT
+  WITH CHECK (
+    sender_id = auth.jwt() ->> 'sub'
+    AND EXISTS (
+      SELECT 1 FROM conversation_participants cp
+      WHERE cp.conversation_id = messages.conversation_id
+        AND cp.user_id = auth.jwt() ->> 'sub'
+    )
+  );
+
+-- ============================================================
+-- cofounder_links  (defense-in-depth; writes are service-role)
+-- ============================================================
+DROP POLICY IF EXISTS "cofounder_links_org_isolation" ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_select_org"    ON cofounder_links;
+DROP POLICY IF EXISTS "cofounder_links_write_own"     ON cofounder_links;
+
+CREATE POLICY "cofounder_links_select_org" ON cofounder_links
+  FOR SELECT
+  USING (
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NULL
+      AND organization_id IS NULL)
+    OR
+    (NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '') IS NOT NULL
+      AND organization_id = NULLIF(auth.jwt() -> 'metadata' ->> 'organization_id', '')::uuid)
+  );
+
+-- Writes restricted to a participant in the link (defense-in-depth;
+-- production inserts go through service role in /api/cofounder-invite/.../accept).
+CREATE POLICY "cofounder_links_insert_own" ON cofounder_links
+  FOR INSERT
+  WITH CHECK (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+CREATE POLICY "cofounder_links_update_own" ON cofounder_links
+  FOR UPDATE
+  USING (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  )
+  WITH CHECK (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+CREATE POLICY "cofounder_links_delete_own" ON cofounder_links
+  FOR DELETE
+  USING (
+    user_a_id = auth.jwt() ->> 'sub'
+    OR user_b_id = auth.jwt() ->> 'sub'
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Batch 3 write guards applied: profiles (regression fix), match_intents, cofounder_invites, messages (sender check), cofounder_links (defense-in-depth).';
+END $$;


### PR DESCRIPTION
## Summary
This PR applies Batch 3 of the RLS (Row-Level Security) hardening initiative, fixing a write-access regression introduced in Batch 1 and patching two additional RLS policy bugs that were invisible under service-role clients but broke routes under user JWT clients. It also patches an IDOR vulnerability in the `/api/cofounder-link/[userId]` route that allowed a school-org user to read another school's co-founder link data. Together, these changes complete the transition from broad `FOR ALL` org-isolation policies to properly split `SELECT` (org-scoped) + `INSERT/UPDATE/DELETE` (owner-scoped) policies across all core tables.

## Changes

### Database — RLS Policy Overhaul (`supabase/migrations/20260617000001_batch3_rls_write_guards.sql`)

- **`profiles` (regression fix):** Batch 1 replaced the original owner-scoped write policies with a single `FOR ALL` org-isolation policy, silently removing the owner check on writes — any user in the same org could `UPDATE` or `DELETE` another user's profile. This migration drops `profiles_org_isolation` and recreates split policies: `SELECT` scoped to matching `organization_id`, and `INSERT`/`UPDATE`/`DELETE` restricted to `user_id = auth.jwt() ->> 'sub'`.

- **`match_intents`:** Applied the same FOR-ALL → SELECT+write split: org-scoped `SELECT`, writes restricted to `from_user_id = current user`.

- **`cofounder_invites`:** Same split pattern — org-scoped `SELECT`, writes restricted to `inviter_user_id = current user`.

- **`messages`:** Existing `USING` (participant check) had no `WITH CHECK`, meaning any participant could technically insert any row. Split into a `SELECT` policy (participant in the conversation, within same org) and an `INSERT` policy that both asserts `sender_id = current user` and confirms conversation participation. `UPDATE`/`DELETE` are intentionally left policy-free (deny-all for authenticated users) since message writes go through the service role.

- **`cofounder_links`:** Writes already go through the service role and bypass RLS, but added `INSERT`/`UPDATE`/`DELETE` policies scoped to link participants as defense-in-depth. `SELECT` policy retains org isolation.

- **`user_profile_actions` (join bug fix):** Batch 1's policy joined `profiles.user_id` to `user_profile_actions.user_id`, but the app stores the integer `profiles.id` in that column — not the Clerk user id. The `EXISTS` check never matched under a user JWT, causing deny-all. Fixed by joining on `profiles.id::text = user_profile_actions.user_id`.

- **`school_profiles` (peer enrichment fix):** The existing own-row `FOR ALL` policy only exposed the caller's own row. Routes that enrich peer profile cards with school data (likes, profiles feed) were returning empty results under user JWT. Added an additive org-scoped `SELECT` policy that OR-combines with the owner policy; writes remain owner-only.

### API — IDOR Fix (`src/app/api/cofounder-link/[userId]/route.ts`)

- **Cross-organization access guard:** The `GET /api/cofounder-link/[userId]` endpoint previously authenticated the caller but allowed any authenticated user to read any other user's co-founder links regardless of org membership — a classic IDOR. The fix extracts `organization_id` from the caller's `sessionClaims.metadata`, fetches the target profile's `organization_id` from Supabase, and returns `403 Forbidden` if they don't match. Self-reads (`requestingUserId === userId`) bypass the check to avoid unnecessary DB lookups.

## Migration / Config
- Run the new Supabase migration: `supabase/migrations/20260617000001_batch3_rls_write_guards.sql`
- No new env vars required.

## Testing
- Verified that school org users cannot read another school's co-founder links (IDOR blocked with 403).
- RLS policies validated against the existing Batch 1 regression: profile writes from a same-org non-owner should now be denied under user JWT.
- `user_profile_actions` and `school_profiles` policy fixes should resolve empty-result bugs on like/profiles feed routes when using user JWT client.

## Notes
- All policy changes drop and recreate named policies idempotently (using `DROP POLICY IF EXISTS`) — safe to re-run.
- The `messages` `UPDATE`/`DELETE` deny-all is intentional: production message writes route through the service role in `/api/messages/.../send/route.ts`.
