### PR TITLE
Finish Batch B to JWT Client

### DIFF
--- a/src/app/api/like/route.ts
+++ b/src/app/api/like/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,11 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Create Supabase client with service role key (bypasses RLS)
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     // Check if like already exists
     const { data: existingLike, error: checkError } = await supabase
@@ -99,11 +95,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Missing likedId" }, { status: 400 });
     }
 
-    // Create Supabase client with service role key (bypasses RLS)
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const { error: deleteError } = await supabase
       .from("likes")

--- a/src/app/api/likes/mutual/route.ts
+++ b/src/app/api/likes/mutual/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function GET() {
   try {
@@ -10,10 +10,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const orgId =
       ((sessionClaims?.metadata as Record<string, unknown>)

--- a/src/app/api/likes/profiles/route.ts
+++ b/src/app/api/likes/profiles/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
 
 export async function GET() {
@@ -11,10 +11,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const orgId =
       ((sessionClaims?.metadata as Record<string, unknown>)

--- a/src/app/api/profile-views/route.ts
+++ b/src/app/api/profile-views/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function POST(request: NextRequest) {
   try {
@@ -23,10 +23,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
       .from("profile_views")

--- a/src/app/api/profiles/seen/route.ts
+++ b/src/app/api/profiles/seen/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -19,10 +19,7 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
       .from("matching_queue")

--- a/src/app/api/skip/route.ts
+++ b/src/app/api/skip/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,11 +20,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Create Supabase client with service role key (bypasses RLS)
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     // Get internal profile IDs for both users
     const { data: userProfile, error: userProfileError } = await supabase

--- a/src/app/api/swipe-count/route.ts
+++ b/src/app/api/swipe-count/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function GET() {
   try {
@@ -21,10 +21,7 @@ export async function GET() {
       });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);


### PR DESCRIPTION
# service-role-to-jwt-batch-b | Replace service role key with JWT-scoped Supabase client across matching endpoints

## Summary
This PR completes Batch B of the ongoing migration away from Supabase service role key usage in API routes. Seven endpoints in the matching flow (`like`, `likes/mutual`, `likes/profiles`, `profile-views`, `profiles/seen`, `skip`, `swipe-count`) were previously instantiating a raw Supabase client with `SUPABASE_SERVICE_ROLE_KEY`, which bypasses RLS entirely. They now use the shared `createServerSupabaseClient()` helper from `@/lib/supabaseServer`, which scopes the client to the authenticated user's JWT. This reduces the blast radius of any future data access bugs by ensuring RLS policies are enforced at the database level for these write-heavy endpoints.

## Changes

### API Routes
- **`/api/like` (POST + DELETE):** Replace two separate service-role `createClient` instantiations with `await createServerSupabaseClient()`. Both the "create like" and "delete like" paths now operate under the caller's JWT identity, allowing Supabase RLS to enforce ownership rules.
- **`/api/likes/mutual` (GET):** Swap out service-role client for `createServerSupabaseClient()` so the mutual-likes query runs under the authenticated org's JWT context.
- **`/api/likes/profiles` (GET):** Same replacement; the profile-hydration query for liked users now respects RLS rather than seeing all rows.
- **`/api/profile-views` (POST):** Profile view recording now uses the JWT-scoped client, removing the need to hold a service role key for this insert path.
- **`/api/profiles/seen` (PATCH):** The `matching_queue` update that marks a profile as seen switches to JWT-scoped client, consistent with the rest of the matching pipeline.
- **`/api/skip` (POST):** Skip recording (which also does a profile lookup for internal IDs) migrated to `createServerSupabaseClient()`. The multi-step lookup-then-insert pattern is unchanged; only the client instantiation changes.
- **`/api/swipe-count` (GET):** Daily swipe count query now runs through the JWT-scoped helper instead of the service role.

## Migration / Config
- No new env vars or DB migrations required.
- `SUPABASE_SERVICE_ROLE_KEY` is no longer referenced by any of these seven routes. Verify the key is still needed elsewhere before considering removal from environment config.

## Testing
- Existing auth guards (`auth()` from Clerk) remain in place on each route — unauthenticated requests are rejected before the Supabase client is ever created.
- Manual smoke testing of like/skip/swipe flows should confirm RLS policies are correctly permissive for the authenticated user's own data.

## Notes
- This is Batch B of a multi-batch migration; prior batches covered other route groups. Check sibling branches/PRs for full scope.
- The `createServerSupabaseClient()` helper is async (note `await`), which was not required by the previous `createClient()` pattern — all call sites have been updated accordingly.
