### PR TITLE
Migrate remaining API routes from service role client to JWT-based Supabase client

### DIFF
--- a/src/app/api/cofounder-invite/[token]/revoke/route.ts
+++ b/src/app/api/cofounder-invite/[token]/revoke/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
-
-function supa() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-}
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export async function POST(
   _request: NextRequest,
@@ -20,7 +13,7 @@ export async function POST(
     }
 
     const { token } = await params;
-    const supabase = supa();
+    const supabase = await createServerSupabaseClient();
 
     const { data: invite, error: inviteErr } = await supabase
       .from("cofounder_invites")

--- a/src/app/api/cofounder-invite/route.ts
+++ b/src/app/api/cofounder-invite/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
 import { sendCofounderInviteEmail } from "@/lib/email/emails/cofounderInvite";
 import { randomBytes } from "crypto";
-
-function supa() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-}
 
 export async function POST(request: NextRequest) {
   try {
@@ -30,7 +23,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = supa();
+    const supabase = await createServerSupabaseClient();
 
     const { data: inviterProfile, error: profileErr } = await supabase
       .from("profiles")
@@ -199,7 +192,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const supabase = supa();
+    const supabase = await createServerSupabaseClient();
 
     const { data: invites, error: inviteErr } = await supabase
       .from("cofounder_invites")

--- a/src/app/api/cofounder-link/[userId]/route.ts
+++ b/src/app/api/cofounder-link/[userId]/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
-
-function supa() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-}
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 export type CofounderLinkProfile = {
   link_id: string;
@@ -31,6 +24,8 @@ export async function GET(
 
     const { userId } = await params;
 
+    const supabase = await createServerSupabaseClient();
+
     // Access check: caller must be the profile owner or able to see the target
     // in the matching feed (same org, or both general-pool / null-org).
     // Blocks the IDOR: a school-org user can't read a different school's links.
@@ -40,7 +35,6 @@ export async function GET(
         ((sessionClaims?.metadata as Record<string, unknown>)
           ?.organization_id as string | undefined) ?? null;
 
-      const supabase = supa();
       const { data: targetProfile } = await supabase
         .from("profiles")
         .select("organization_id")
@@ -54,8 +48,6 @@ export async function GET(
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
     }
-
-    const supabase = supa();
 
     const { data: links, error: linkErr } = await supabase
       .from("cofounder_links")

--- a/src/app/api/cofounder-link/route.ts
+++ b/src/app/api/cofounder-link/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
-
-function supa() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-}
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 
 // Either party can unlink the pair
 export async function DELETE(request: NextRequest) {
@@ -22,7 +15,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Missing linkId" }, { status: 400 });
     }
 
-    const supabase = supa();
+    const supabase = await createServerSupabaseClient();
 
     const { data: link } = await supabase
       .from("cofounder_links")

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
 import {
   filterProfilesByPreferences,
@@ -16,10 +16,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    );
+    const supabase = await createServerSupabaseClient();
 
     // Tenant context is anchored to the page's org slug (untrusted input,
     // validated server-side), NOT the HTTP host. `denied` → the viewer is not

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
 import { mapProfileToOnboardingData } from "@/lib/mapProfileToFromDBFormat";
 import { parseSearchQuery, type ParsedQuery } from "@/lib/searchQueryParser";
 import {
@@ -336,7 +337,7 @@ export async function POST(req: NextRequest) {
     }
     const orgId = scope.orgId;
 
-    const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+    const supabase = await createServerSupabaseClient();
     const userFilters = normalizeDashboardFilters(body.userFilters);
     const dismissed = new Set(body.dismissedFilterKeys ?? []);
 


### PR DESCRIPTION
# service-role-to-jwt-final-batch | Migrate remaining API routes from service role client to JWT-based Supabase client

## Summary
This is the final batch of a multi-PR migration away from inline Supabase service role key instantiation toward the shared `createServerSupabaseClient()` helper from `@/lib/supabaseServer`. The affected routes are the cofounder invite/revoke endpoints, the cofounder link endpoints, the swipe deck profiles endpoint, and the profile search endpoint. After this change, no route in this batch bypasses Row Level Security via a raw service role key — all database calls now go through the JWT-based server client that respects Supabase RLS policies.

## Changes

### Cofounder Invite Routes (`/api/cofounder-invite`, `/api/cofounder-invite/[token]/revoke`)
- Remove locally-defined `supa()` factory functions that directly instantiated `createClient` with `SUPABASE_SERVICE_ROLE_KEY`, replacing all three call sites (POST invite creation, GET invite listing, POST revoke) with `await createServerSupabaseClient()`.

### Cofounder Link Routes (`/api/cofounder-link`, `/api/cofounder-link/[userId]`)
- Replace inline `supa()` helpers with `createServerSupabaseClient()` in both the DELETE (unlink) handler and the GET (fetch links) handler.
- In `/api/cofounder-link/[userId]/route.ts`, the old code called `supa()` twice — once inside the org-check conditional block and again unconditionally below it. The refactor hoists a single `createServerSupabaseClient()` call to the top of the handler, eliminating the duplicate instantiation.

### Profiles & Search Routes (`/api/profiles`, `/api/profiles/search`)
- Replace the inline `createClient(SUPABASE_URL, SERVICE_KEY)` call in the swipe deck profiles handler with `createServerSupabaseClient()`.
- In the search route, replace `createClient(SUPABASE_URL, SERVICE_KEY)` and convert `import { createClient, SupabaseClient }` to `import type { SupabaseClient }` since `createClient` is no longer imported directly.

## Notes
- This completes the service role → JWT client migration started in prior PRs (Batch A covered likes/skips/swipe-count/profiles endpoints; Batch B covered invite API routes). No service role key usage should remain in these route handlers after this lands.
- All routes still require Clerk authentication (`auth()`) before the Supabase client is used — the migration does not change the auth boundary, only which Supabase credentials are used for DB operations downstream.
