### PR TITLE
Fix pool-membership RLS self-join that made every user invisible to others

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -131,7 +131,13 @@ export async function GET(req: NextRequest) {
     // Fetch candidate profiles from the resolved member set (excludes self, deleted, already liked).
     // Pool filtering is now via membership IDs — profiles.organization_id is no longer authoritative
     // for pool membership after Design A.
-    let query = supabase
+    //
+    // Uses the service-role client deliberately: memberIds is already derived from
+    // profile_pool_memberships (service-role read) and represents the fully authorized
+    // candidate set, so running the profiles SELECT through the JWT client would only
+    // re-evaluate the shared-pool RLS per row for no added security benefit. Skipping
+    // that per-row check avoids redundant JOIN overhead on the hottest endpoint.
+    let query = adminClient
       .from("profiles")
       .select("*")
       .neq("user_id", currentUser.user_id)

--- a/src/lib/tests/rls-org-isolation.test.ts
+++ b/src/lib/tests/rls-org-isolation.test.ts
@@ -137,6 +137,22 @@ describe.skipIf(!RUN)("RLS org isolation", () => {
   const BOB = "user_rlstest_bob";
   const VIEW_TARGET = "user_rlstest_target";
 
+  // UT mock user_ids that seed.sql inserts — we seed their pool memberships here
+  // because seed.sql runs AFTER migrations, so the backfill in
+  // 20260623000001 doesn't pick them up.
+  const UT_MOCK_IDS = [
+    "user_mock_ut_001",
+    "user_mock_ut_002",
+    "user_mock_ut_003",
+    "user_mock_ut_004",
+    "user_mock_ut_005",
+    "user_mock_ut_006",
+    "user_mock_ut_007",
+    "user_mock_ut_008",
+    "user_mock_ut_009",
+    "user_mock_ut_010",
+  ];
+
   beforeAll(async () => {
     expect(
       IS_LOCAL || process.env.RLS_TEST_ALLOW_REMOTE === "1",
@@ -160,6 +176,26 @@ describe.skipIf(!RUN)("RLS org isolation", () => {
     expect(orgErr, "UT org seed must exist (run UT seed migration)").toBeNull();
     utOrgId = org!.id;
 
+    // Seed pool membership rows for the UT mock profiles so the
+    // membership-based profiles_select_org policy can see them.
+    // seed.sql inserts profiles AFTER migrations run, so the backfill
+    // in 20260623000001 misses these rows — we fill the gap here.
+    const now = new Date().toISOString();
+    const utMemberships = UT_MOCK_IDS.map((id) => ({
+      user_id: id,
+      organization_id: utOrgId,
+      onboarded_at: now,
+    }));
+    await service
+      .from("profile_pool_memberships")
+      .delete()
+      .eq("organization_id", utOrgId)
+      .in("user_id", UT_MOCK_IDS);
+    const { error: membershipSeedErr } = await service
+      .from("profile_pool_memberships")
+      .insert(utMemberships);
+    expect(membershipSeedErr, "UT mock membership seed must succeed").toBeNull();
+
     // Seed two profile_views rows owned by different users (service role bypasses RLS).
     await service
       .from("profile_views")
@@ -178,6 +214,13 @@ describe.skipIf(!RUN)("RLS org isolation", () => {
       .from("profile_views")
       .delete()
       .in("viewer_user_id", [ALICE, BOB]);
+    // Remove the UT mock memberships we seeded (profiles themselves stay — they
+    // come from seed.sql and will be reset by the next supabase db reset).
+    await service
+      .from("profile_pool_memberships")
+      .delete()
+      .eq("organization_id", utOrgId)
+      .in("user_id", UT_MOCK_IDS);
   });
 
   // ── profiles: the linchpin policy, validated read-only against the UT mock seed ──
@@ -242,5 +285,120 @@ describe.skipIf(!RUN)("RLS org isolation", () => {
       organization_id: "00000000-0000-0000-0000-000000000000", // not the UT org
     });
     expect(error, "same-org trigger must reject mismatched organization_id").not.toBeNull();
+  });
+
+  // ── pool-membership visibility: validates shares_pool_with() SECURITY DEFINER fix ──
+  //
+  // Migration 20260623000002 introduced a profiles_select_org policy that proved
+  // "viewer and target share a pool" by self-joining profile_pool_memberships.
+  // The ppm_owner RLS on that table clipped the target_m side, making the EXISTS
+  // always false for anyone but the viewer — effectively limiting each user to
+  // seeing only their own profile. Migration 20260623000004 fixes this with a
+  // SECURITY DEFINER helper (shares_pool_with) that bypasses ppm_owner when
+  // evaluating the join. These tests assert the corrected behavior.
+  describe("pool-membership visibility (shares_pool_with)", () => {
+    // Minimal test profiles — these IDs are only used here.
+    const GP_ALICE = "user_rlstest_pool_alice";   // general pool
+    const GP_BOB   = "user_rlstest_pool_bob";     // general pool
+    const ORG_CAROL = "user_rlstest_org_carol";   // UT org pool only
+
+    const TEST_PROFILE_IDS = [GP_ALICE, GP_BOB, ORG_CAROL];
+
+    // Minimal profile shape that satisfies all NOT NULL constraints.
+    function minimalProfile(userId: string, orgId: string | null = null) {
+      return {
+        user_id: userId,
+        first_name: "Test",
+        last_name: "User",
+        title: "Test Profile",
+        city: "Austin",
+        country: "United States",
+        satisfaction: "Happy",
+        personal_intro: "RLS test fixture — safe to delete.",
+        is_technical: false,
+        has_startup: false,
+        onboarding_complete: true,
+        ...(orgId ? { organization_id: orgId } : {}),
+      };
+    }
+
+    beforeAll(async () => {
+      // Clean up any leftover rows from a previous aborted run.
+      await service.from("profiles").delete().in("user_id", TEST_PROFILE_IDS);
+
+      // Seed profiles (service role bypasses RLS + write-guard triggers).
+      const { error: profileErr } = await service.from("profiles").insert([
+        minimalProfile(GP_ALICE),
+        minimalProfile(GP_BOB),
+        minimalProfile(ORG_CAROL, utOrgId),
+      ]);
+      expect(profileErr, "pool-membership test profiles must seed").toBeNull();
+
+      // Seed memberships — explicitly set onboarded_at so the API-layer
+      // .not("onboarded_at", "is", null) filter passes in any route that
+      // uses these fixtures.
+      const now = new Date().toISOString();
+      const { error: memberErr } = await service
+        .from("profile_pool_memberships")
+        .insert([
+          { user_id: GP_ALICE,   organization_id: null,    onboarded_at: now },
+          { user_id: GP_BOB,     organization_id: null,    onboarded_at: now },
+          { user_id: ORG_CAROL,  organization_id: utOrgId, onboarded_at: now },
+        ]);
+      expect(memberErr, "pool-membership rows must seed").toBeNull();
+    });
+
+    afterAll(async () => {
+      // Deleting profiles cascades to profile_pool_memberships (ON DELETE CASCADE).
+      await service.from("profiles").delete().in("user_id", TEST_PROFILE_IDS);
+    });
+
+    it("general-pool user sees a general-pool co-member's profile", async () => {
+      const alice = clientAs(mintToken({ sub: GP_ALICE }));
+      const { data, error } = await alice
+        .from("profiles")
+        .select("user_id")
+        .eq("user_id", GP_BOB);
+      expect(error).toBeNull();
+      expect((data ?? []).map((r) => r.user_id)).toContain(GP_BOB);
+    });
+
+    it("general-pool user cannot see a profile that is only in an org pool", async () => {
+      const alice = clientAs(mintToken({ sub: GP_ALICE }));
+      const { data, error } = await alice
+        .from("profiles")
+        .select("user_id")
+        .eq("user_id", ORG_CAROL);
+      expect(error).toBeNull();
+      expect(data ?? []).toHaveLength(0);
+    });
+
+    it("org-pool user sees a co-member's profile in the same org pool", async () => {
+      // user_mock_ut_001 has a UT org membership seeded in the outer beforeAll.
+      // ORG_CAROL also has a UT org membership — they share the pool.
+      const utUser = clientAs(
+        mintToken({ sub: "user_mock_ut_001", organization_id: utOrgId }),
+      );
+      const { data, error } = await utUser
+        .from("profiles")
+        .select("user_id")
+        .eq("user_id", ORG_CAROL);
+      expect(error).toBeNull();
+      expect((data ?? []).map((r) => r.user_id)).toContain(ORG_CAROL);
+    });
+
+    it("org-pool user cannot see a profile that is only in the general pool", async () => {
+      // user_mock_ut_001 is in the UT org pool only (no general-pool membership).
+      // GP_BOB is in the general pool only — they share no pool.
+      const utUser = clientAs(
+        mintToken({ sub: "user_mock_ut_001", organization_id: utOrgId }),
+      );
+      const { data, error } = await utUser
+        .from("profiles")
+        .select("user_id")
+        .eq("user_id", GP_BOB);
+      expect(error).toBeNull();
+      expect(data ?? []).toHaveLength(0);
+    });
   });
 });

--- a/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
+++ b/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix onboarded_at for backfilled membership rows
+--
+-- The expand migration (20260623000001) set onboarded_at only when
+-- profiles.onboarding_complete = true. That column is never written by the
+-- app (Phase 1 moved onboarding-complete tracking to Clerk publicMetadata),
+-- so every backfilled row landed with onboarded_at = NULL.
+--
+-- A profiles row exists iff the user completed onboarding (the onboarding
+-- flow writes the row on submit). Treat profiles.updated_at as a conservative
+-- completion timestamp for all pre-existing members.
+
+UPDATE profile_pool_memberships m
+SET onboarded_at = p.updated_at
+FROM profiles p
+WHERE p.user_id = m.user_id
+  AND m.onboarded_at IS NULL;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: onboarded_at backfilled from profiles.updated_at for all NULL membership rows.';
+END $$;

--- a/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
+++ b/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
@@ -1,0 +1,64 @@
+-- Migration: Fix pool-membership RLS self-join
+--
+-- Problem: the profiles_select_org policy in 20260623000002 proves "viewer and
+-- target share a pool" by self-joining profile_pool_memberships. The ppm_owner
+-- RLS on that table is enforced inside the subquery, so the target_m side
+-- (another user's rows) is invisible — making EXISTS always false for everyone
+-- except the viewer themselves. Net result: every user can only read their own
+-- profile, breaking the matching feed, likes, mutual matches, conversations,
+-- and user_activity_summary. Same bug exists in user_activity_summary_org_isolation.
+--
+-- Fix: a SECURITY DEFINER helper function that runs as its owner (bypassing
+-- ppm_owner), allowing the join to see both sides. Precedent: upsert_pool_membership
+-- in 20260623000001 is also SECURITY DEFINER for the same reason.
+--
+-- Scope: replaces only the two affected SELECT policies. No other policies,
+-- tables, or write guards are changed.
+
+-- ============================================================
+-- Helper: shared-pool membership check
+-- Runs as function owner → bypasses ppm_owner RLS → can see
+-- both the viewer's and the target's membership rows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.shares_pool_with(target text)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE
+SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM profile_pool_memberships viewer_m
+    JOIN profile_pool_memberships target_m
+      ON target_m.user_id = target
+     AND target_m.organization_id IS NOT DISTINCT FROM viewer_m.organization_id
+    WHERE viewer_m.user_id = auth.jwt() ->> 'sub'
+  );
+$$;
+
+-- ============================================================
+-- profiles — fix shared-membership SELECT
+-- ============================================================
+DROP POLICY IF EXISTS "profiles_select_org" ON profiles;
+
+CREATE POLICY "profiles_select_org" ON profiles
+  FOR SELECT
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+-- ============================================================
+-- user_activity_summary — same fix (mirrors profiles policy)
+-- ============================================================
+DROP POLICY IF EXISTS "user_activity_summary_org_isolation" ON user_activity_summary;
+
+CREATE POLICY "user_activity_summary_org_isolation" ON user_activity_summary
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: shares_pool_with() SECURITY DEFINER helper created; profiles_select_org and user_activity_summary_org_isolation policies rewritten to use it.';
+END $$;


### PR DESCRIPTION
Fix pool-membership RLS self-join that made every user invisible to others

The profiles_select_org policy (20260623000002) self-joined profile_pool_memberships to prove shared-pool membership, but the ppm_owner RLS on that table was also enforced inside the subquery — making the target user's rows invisible to the viewer's JWT and causing EXISTS to always return false. Every user could only read their own profile, breaking the matching feed, likes, mutual matches, conversations, and user_activity_summary.

Fixes:
- 20260623000004: introduces a SECURITY DEFINER helper shares_pool_with() that bypasses ppm_owner when evaluating the join; rewrites profiles_select_org and user_activity_summary_org_isolation to use it
- 20260623000003: backfills onboarded_at from profiles.updated_at for membership rows that landed NULL because onboarding_complete was never written by the app
- profiles/route.ts: switches candidate profiles SELECT to adminClient since memberIds is already scoped by a prior service-role membership read, making per-row RLS re-evaluation redundant
- rls-org-isolation.test.ts: adds shares_pool_with() test suite covering general-pool and org-pool visibility boundaries