### PR TITLE
UT-8 | Inconsistent CTA routing between "Find a co-foundr" and "Find your co-foundr"

### DIFF
--- a/src/app/(general)/page.tsx
+++ b/src/app/(general)/page.tsx
@@ -3,6 +3,7 @@
 import { SignInButton, useAuth } from "@clerk/nextjs";
 import ReactLenis from "lenis/react";
 import Image from "next/image";
+import Link from "next/link";
 import React from "react";
 import { MdKeyboardArrowRight } from "react-icons/md";
 import { motion } from "motion/react";
@@ -30,6 +31,23 @@ function Page() {
   // if (!accessGranted) {
   //   return <AccessCodeForm onSuccess={() => setAccessGranted(true)} />;
   // }
+
+  const ctaContent = (
+    <div className="translate-y flex cursor-pointer items-center rounded-md bg-(--mist-white) px-3 py-2 font-semibold text-nowrap text-(--charcoal-black) sm:px-4 sm:py-2 md:px-5 md:py-3">
+      <p className="text-sm sm:text-base">Find your co-foundr</p>
+      <motion.div
+        className="flex items-center"
+        animate={{ x: [0, 5, 0] }}
+        transition={{
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      >
+        <MdKeyboardArrowRight className="size-5 sm:size-6 md:size-7" />
+      </motion.div>
+    </div>
+  );
 
   return (
     <ReactLenis root>
@@ -142,31 +160,29 @@ function Page() {
               transition={{ duration: 0.8, delay: 1.8, ease: "easeOut" }}
             >
               <div className="flex flex-col items-center">
-                <SignInButton forceRedirectUrl="/cofoundr-matching">
-                  <motion.button
-                    className="cursor-pointer"
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <div className="translate-y flex cursor-pointer items-center rounded-md bg-(--mist-white) px-3 py-2 font-semibold text-nowrap text-(--charcoal-black) sm:px-4 sm:py-2 md:px-5 md:py-3">
-                      <p className="text-sm sm:text-base">
-                        Find your co-foundr
-                      </p>
-                      <motion.div
-                        className="flex items-center"
-                        animate={{ x: [0, 5, 0] }}
-                        transition={{
-                          duration: 1.5,
-                          repeat: Infinity,
-                          ease: "easeInOut",
-                        }}
-                      >
-                        <MdKeyboardArrowRight className="size-5 sm:size-6 md:size-7" />
-                      </motion.div>
-                    </div>
-                  </motion.button>
-                </SignInButton>
+                {isSignedIn ? (
+                  <Link href="/cofoundr-matching">
+                    <motion.div
+                      className="cursor-pointer"
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {ctaContent}
+                    </motion.div>
+                  </Link>
+                ) : (
+                  <SignInButton forceRedirectUrl="/cofoundr-matching">
+                    <motion.button
+                      className="cursor-pointer"
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {ctaContent}
+                    </motion.button>
+                  </SignInButton>
+                )}
 
                 <motion.p
                   className="mt-3 text-center text-xs text-gray-400 sm:mt-4 sm:text-sm"

--- a/src/app/(school)/school/[slug]/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-in/[[...sign-in]]/page.tsx
@@ -1,4 +1,5 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import SchoolSignIn from "@/features/school/components/auth/SchoolSignIn";
 
@@ -10,7 +11,13 @@ export default async function SchoolSignInPage({
   searchParams: Promise<{ mismatch?: string; email?: string; redirect?: string }>;
 }) {
   const { slug } = await params;
-  const { mismatch, email, redirect } = await searchParams;
+  const { mismatch, email, redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
   const org = await getOrganizationBySlug(slug);
   if (!org) notFound();
 
@@ -27,7 +34,7 @@ export default async function SchoolSignInPage({
         schoolName={org.name}
         allowedDomains={org.allowed_email_domains ?? []}
         initialError={initialError}
-        afterAuthRedirect={redirect ?? null}
+        afterAuthRedirect={redirectParam ?? null}
       />
     </div>
   );

--- a/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
@@ -1,4 +1,5 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import SchoolSignUp from "@/features/school/components/auth/SchoolSignUp";
 
@@ -10,7 +11,13 @@ export default async function SchoolSignUpPage({
   searchParams: Promise<{ redirect?: string }>;
 }) {
   const { slug } = await params;
-  const { redirect } = await searchParams;
+  const { redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
   const org = await getOrganizationBySlug(slug);
   if (!org) notFound();
 
@@ -21,7 +28,7 @@ export default async function SchoolSignUpPage({
         slug={org.slug}
         schoolName={org.name}
         allowedDomains={org.allowed_email_domains ?? []}
-        afterAuthRedirect={redirect ?? null}
+        afterAuthRedirect={redirectParam ?? null}
       />
     </div>
   );

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -78,7 +78,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
   const navItems = [
     {
       href: `/school/${slug}/dashboard`,
-      label: "Find a co-foundr",
+      label: "Find your co-foundr",
       featured: true,
     },
     {

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -15,7 +15,7 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
           href="#departments"
           className="border-b border-white/40 pb-0.5 text-xs sm:text-sm font-medium text-white whitespace-nowrap"
         >
-          Find a co-foundr
+          Find your co-foundr
         </a>
         <Link
           href={`/school/${slug}/contact-us`}


### PR DESCRIPTION
## Summary
This PR makes the landing page CTA aware of auth state and closes a gap where already-signed-in users could land on the school sign-in/sign-up pages. On the general landing page, the "Find your co-foundr" button now routes signed-in users straight to `/cofoundr-matching` via a `Link` instead of re-showing the Clerk `SignInButton`. On the school-scoped auth routes, both `sign-in` and `sign-up` pages now check the Clerk session server-side and redirect authenticated users to their dashboard (or a provided `redirect` param) before rendering the auth form. Two nav labels were also updated for consistency ("Find a co-foundr" → "Find your co-foundr").

## Changes

### Landing page CTA
- `src/app/(general)/page.tsx`: Extracted the CTA's inner markup into a shared `ctaContent` constant to avoid duplicating the button JSX between the two auth-state branches.
- Branches on `isSignedIn` (already read via `useAuth()`): signed-in users get a `Link` to `/cofoundr-matching` wrapped in a `motion.div` for hover/tap animation; signed-out users keep the existing `SignInButton` with `forceRedirectUrl="/cofoundr-matching"`. This avoids sending signed-in users through the Clerk sign-in flow just to be redirected back.

### School sign-in / sign-up redirects
- `src/app/(school)/school/[slug]/sign-in/[[...sign-in]]/page.tsx` and `.../sign-up/[[...sign-up]]/page.tsx`: Added a server-side `auth()` check (from `@clerk/nextjs/server`); if `userId` is present, `redirect()` fires immediately to the `redirect` search param if provided, otherwise to `/school/${slug}/dashboard` — before the organization lookup or form rendering happens.
- Renamed the destructured `redirect` search param to `redirectParam` in both files to avoid shadowing the `redirect` function imported from `next/navigation`, and updated the `afterAuthRedirect` prop usage accordingly.

### Nav label consistency
- `src/features/school/components/SchoolHeader.tsx` and `src/features/school/components/landing/PublicSchoolHeader.tsx`: Changed nav copy from "Find a co-foundr" to "Find your co-foundr" to match the landing page CTA wording.

## Testing
- Not explicitly stated in the diff — recommend manually verifying: (1) signed-in vs signed-out states on the general landing page CTA route correctly, (2) visiting `/school/[slug]/sign-in` or `/sign-up` while already authenticated redirects to the dashboard (and honors a `redirect` query param when present), and (3) unauthenticated visits to those pages still render the sign-in/sign-up forms as before.
