### PR TITLE
UT-17 | Add redirect + toast notification gate for users without a completed onboarding

### DIFF
--- a/src/app/(school)/school/[slug]/onboarding/page.tsx
+++ b/src/app/(school)/school/[slug]/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, use } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { completeOnboarding } from "@/app/(general)/onboarding/_actions";
 import { useUserProfile } from "@/features/profile/useProfile";
@@ -14,6 +14,10 @@ import { useSchool } from "@/features/school/components/SchoolContext";
 import { getOrgConfig, STEP3_COMPLETIONS } from "@/features/school/registry/registry";
 import { getCompletedSteps } from "@/features/school/onboarding/getCompletedSteps";
 import { STEP_COMPONENTS } from "@/features/school/onboarding/stepRegistry";
+import {
+  getGatedFeatureLabel,
+  resolvePostOnboardingRedirect,
+} from "@/features/school/onboarding/onboardingRedirect";
 
 export default function SchoolOnboardingPage({
   params,
@@ -34,6 +38,9 @@ export default function SchoolOnboardingPage({
   const { user } = useUser();
   const { session } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get("redirect");
+  const [gatedRedirectNotice, setGatedRedirectNotice] = useState(() => Boolean(redirectParam));
   const draft = useOnboardingDraft();
   const { containerRef, transition } = useStepTransition();
   const { data: existingProfile, isLoading: profileLoading } = useUserProfile();
@@ -110,10 +117,14 @@ export default function SchoolOnboardingPage({
 
       await completeOnboarding(formData, { kind: "school", orgId });
       await user?.reload();
+      // Force a fresh session JWT so middleware's schoolOnboarding check sees this
+      // completion immediately — otherwise the next navigation can bounce right back
+      // into onboarding on a stale token.
+      await session?.getToken({ skipCache: true });
 
       draft.clear();
 
-      router.push(`/school/${slug}/dashboard`);
+      router.push(resolvePostOnboardingRedirect(slug, redirectParam));
     } catch {
       setError("Something went wrong. Please try again.");
     }
@@ -141,6 +152,22 @@ export default function SchoolOnboardingPage({
         </h1>
         <p className="mt-1 text-sm text-[var(--ui-text-muted)]">Student Profile Setup</p>
       </div>
+
+      {gatedRedirectNotice && (
+        <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">
+          <span>
+            ✦ Finish setting up your profile before you can {getGatedFeatureLabel(redirectParam)}.
+          </span>
+          <button
+            type="button"
+            onClick={() => setGatedRedirectNotice(false)}
+            className="shrink-0 text-[var(--ui-text-subtle)] hover:text-[var(--ui-text-muted)]"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {preFilledNotice && (
         <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -3,11 +3,14 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { UserButton, useClerk } from "@clerk/nextjs";
+import { UserButton, useClerk, useUser } from "@clerk/nextjs";
 import { FaHeart, FaBars, FaUserPen, FaTrash, FaUserPlus } from "react-icons/fa6";
 import { FaTimes } from "react-icons/fa";
 import clsx from "clsx";
+import toast from "react-hot-toast";
 import { useLikedProfilesData } from "@/features/likes/useLikes";
+import { useSchool } from "@/features/school/components/SchoolContext";
+import { getGatedFeatureLabel } from "@/features/school/onboarding/onboardingRedirect";
 import type { OrgConfig } from "@/features/school/registry/types";
 
 type SchoolHeaderProps = {
@@ -24,6 +27,27 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const { data: likedProfilesData } = useLikedProfilesData();
   const { signOut } = useClerk();
+  const { orgId } = useSchool();
+  const { isLoaded, user } = useUser();
+
+  const schoolOnboarding = user?.publicMetadata?.schoolOnboarding as
+    | Record<string, boolean>
+    | undefined;
+  const schoolDone =
+    schoolOnboarding?.[orgId] === true ||
+    (user?.publicMetadata?.onboardingComplete === true &&
+      user?.publicMetadata?.organization_id === orgId);
+  const gateCofounderLink = mounted && isLoaded && !schoolDone;
+  const cofounderPath = `/school/${slug}/cofounder`;
+  const cofounderHref = gateCofounderLink
+    ? `/school/${slug}/onboarding?redirect=${encodeURIComponent(cofounderPath)}`
+    : cofounderPath;
+
+  const handleCofounderClick = () => {
+    if (gateCofounderLink) {
+      toast(`Finish setting up your profile before you can ${getGatedFeatureLabel(cofounderPath)}.`);
+    }
+  };
 
   const handleDeleteAccount = async () => {
     const confirmed = confirm(
@@ -131,7 +155,8 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
 
       <div className="ml-4 flex items-center gap-4 md:ml-8 md:gap-6">
         <Link
-          href={`/school/${slug}/cofounder`}
+          href={cofounderHref}
+          onClick={handleCofounderClick}
           className="hidden items-center gap-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white md:flex"
         >
           <FaUserPlus className="h-3.5 w-3.5" />
@@ -210,9 +235,12 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             ))}
             <li>
               <Link
-                href={`/school/${slug}/cofounder`}
+                href={cofounderHref}
                 className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
-                onClick={() => setIsMobileMenuOpen(false)}
+                onClick={() => {
+                  handleCofounderClick();
+                  setIsMobileMenuOpen(false);
+                }}
               >
                 <FaUserPlus className="h-3.5 w-3.5" />
                 Invite a co-foundr

--- a/src/features/school/onboarding/onboardingRedirect.test.ts
+++ b/src/features/school/onboarding/onboardingRedirect.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { getGatedFeatureLabel, resolvePostOnboardingRedirect } from "./onboardingRedirect";
+
+describe("getGatedFeatureLabel", () => {
+  it("maps known feature paths to human-readable labels", () => {
+    expect(getGatedFeatureLabel("/school/ut-austin/cofounder")).toBe("invite a co-founder");
+    expect(getGatedFeatureLabel("/school/ut-austin/matches?tab=messages")).toBe(
+      "view your matches",
+    );
+    expect(getGatedFeatureLabel("/school/ut-austin/profile")).toBe("edit your profile");
+    expect(getGatedFeatureLabel("/school/ut-austin/dashboard")).toBe("access your dashboard");
+    expect(getGatedFeatureLabel("/school/ut-austin/invite/abc123")).toBe("accept your invite");
+  });
+
+  it("falls back to a generic label for unknown or missing paths", () => {
+    expect(getGatedFeatureLabel("/school/ut-austin/some-new-page")).toBe("continue");
+    expect(getGatedFeatureLabel(null)).toBe("continue");
+    expect(getGatedFeatureLabel(undefined)).toBe("continue");
+    expect(getGatedFeatureLabel("")).toBe("continue");
+  });
+});
+
+describe("resolvePostOnboardingRedirect", () => {
+  const slug = "ut-austin";
+
+  it("returns the redirect target when it stays within the school", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/cofounder")).toBe(
+      "/school/ut-austin/cofounder",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/matches?tab=messages")).toBe(
+      "/school/ut-austin/matches?tab=messages",
+    );
+  });
+
+  it("falls back to the dashboard when no redirect is provided", () => {
+    expect(resolvePostOnboardingRedirect(slug, null)).toBe("/school/ut-austin/dashboard");
+    expect(resolvePostOnboardingRedirect(slug, undefined)).toBe("/school/ut-austin/dashboard");
+    expect(resolvePostOnboardingRedirect(slug, "")).toBe("/school/ut-austin/dashboard");
+  });
+
+  it("falls back to the dashboard for redirects outside this school", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/other-school/cofounder")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "https://evil.example.com")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "//evil.example.com")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+  });
+
+  it("falls back to the dashboard rather than looping back into onboarding", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/onboarding")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/onboarding/step2")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+  });
+});

--- a/src/features/school/onboarding/onboardingRedirect.ts
+++ b/src/features/school/onboarding/onboardingRedirect.ts
@@ -1,0 +1,44 @@
+const GATED_FEATURE_LABELS: Record<string, string> = {
+  cofounder: "invite a co-founder",
+  matches: "view your matches",
+  profile: "edit your profile",
+  dashboard: "access your dashboard",
+  invite: "accept your invite",
+};
+const DEFAULT_GATED_FEATURE_LABEL = "continue";
+
+/** Maps a `/school/{slug}/{feature}/...` redirect path to a human-readable label. */
+export function getGatedFeatureLabel(path: string | null | undefined): string {
+  if (!path) return DEFAULT_GATED_FEATURE_LABEL;
+  const segment = path.split("?")[0].split("/").filter(Boolean)[2];
+  return (segment && GATED_FEATURE_LABELS[segment]) || DEFAULT_GATED_FEATURE_LABEL;
+}
+
+/**
+ * Validates a `redirect` query param against the current school before using it as a
+ * post-onboarding navigation target. Falls back to the dashboard for anything outside
+ * `/school/{slug}/` or pointing back into onboarding (avoids open-redirect-style bugs
+ * and onboarding-to-onboarding loops).
+ */
+export function resolvePostOnboardingRedirect(
+  slug: string,
+  rawRedirect: string | null | undefined,
+): string {
+  const fallback = `/school/${slug}/dashboard`;
+  if (!rawRedirect) return fallback;
+  if (!rawRedirect.startsWith("/") || rawRedirect.startsWith("//")) return fallback;
+
+  const schoolPrefix = `/school/${slug}`;
+  if (rawRedirect !== schoolPrefix && !rawRedirect.startsWith(`${schoolPrefix}/`)) return fallback;
+
+  const onboardingPrefix = `${schoolPrefix}/onboarding`;
+  if (
+    rawRedirect === onboardingPrefix ||
+    rawRedirect.startsWith(`${onboardingPrefix}/`) ||
+    rawRedirect.startsWith(`${onboardingPrefix}?`)
+  ) {
+    return fallback;
+  }
+
+  return rawRedirect;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -301,6 +301,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
     if (!schoolDone) {
       const schoolOnboardingUrl = new URL(`/school/${org.slug}/onboarding`, req.url);
       if (pathname !== schoolOnboardingUrl.pathname) {
+        schoolOnboardingUrl.searchParams.set("redirect", `${pathname}${req.nextUrl.search}`);
         return NextResponse.redirect(schoolOnboardingUrl);
       }
       return NextResponse.next();


### PR DESCRIPTION
## Summary
Fixes the UX around the intentional onboarding gate that redirects users away from "Invite a co-founder" (and other gated school routes) when their school onboarding isn't complete. Previously this redirect was silent, so it looked like the invite button was broken. This PR adds explicit messaging (a toast on click and a persistent banner on the onboarding page) and completes an existing-but-unused `redirect` query-param convention so users land back on their original destination — instead of always at the dashboard — once onboarding is finished.

## Changes

### Middleware
- `src/middleware.ts`: when the school-onboarding gate (`!schoolDone`) redirects a user to `/school/{slug}/onboarding`, it now attaches `?redirect=<original pathname + search>`. This reuses the same `redirect` param convention already used by `SchoolSignUp`/`SchoolSignIn`, so any gated route (cofounder invite, matches, profile, etc.) now tells the onboarding page where the user was headed.

### Shared helper
- `src/features/school/onboarding/onboardingRedirect.ts` (new): two pure functions consumed by both the onboarding page and the header nav.
  - `getGatedFeatureLabel(path)` maps a `/school/{slug}/{feature}/...` path to a human-readable label (e.g. `cofounder` → "invite a co-founder"), with a generic "continue" fallback for unmapped or missing paths — keeps banner and toast copy in sync from one source.
  - `resolvePostOnboardingRedirect(slug, rawRedirect)` validates the `redirect` param before using it as a post-submit navigation target: rejects protocol-relative/absolute URLs, anything outside `/school/{slug}/`, and anything pointing back into `/school/{slug}/onboarding` (avoids open-redirect-style bugs and onboarding-to-onboarding loops), falling back to `/school/{slug}/dashboard`.
  - Covered by `onboardingRedirect.test.ts` (10 cases).

### Onboarding page
- `src/app/(school)/school/[slug]/onboarding/page.tsx`: reads the `redirect` search param and shows a dismissible banner above the existing pre-filled-profile notice — "Finish setting up your profile before you can {feature}." — whenever the user arrived via a gated redirect.
- `handleSubmit` now pushes to `resolvePostOnboardingRedirect(slug, redirectParam)` instead of always hardcoding `/school/{slug}/dashboard`, so completing onboarding sends the user to what they originally tried to reach (e.g. straight into the co-founder invite flow).
- Added `await session?.getToken({ skipCache: true })` right after `user?.reload()` in `handleSubmit`. `reload()` only refreshes the client-side Clerk user object (what the header reads); it doesn't refresh the session JWT that `middleware.ts` reads via `sessionClaims.metadata.schoolOnboarding`. Without forcing a fresh token, the immediately-following `router.push` could hit the middleware gate on a stale JWT and bounce the user right back into onboarding they just completed. This mirrors the existing pattern already used in `SchoolSignUp`/`SchoolSignIn`.

### Header nav
- `src/features/school/components/SchoolHeader.tsx`: the "Invite a co-founder" link (desktop and mobile dropdown) now checks onboarding completion client-side via `useUser()`'s `publicMetadata` (mirroring the same `schoolOnboarding`/`onboardingComplete` check already used server-side in `sso-complete/page.tsx`), gated on Clerk's `isLoaded` plus the component's existing `mounted` flag to avoid any hydration mismatch or flicker for already-onboarded users.
- When onboarding isn't done, the link's `href` points directly at `/school/{slug}/onboarding?redirect=...` (skipping the extra middleware round-trip) and an `onClick` fires an immediate `react-hot-toast` message, so incomplete users get instant feedback instead of an unexplained page bounce. The middleware-level fix remains the enforcement backstop for direct URL entry, back/forward navigation, and the brief window before Clerk data loads client-side.

## Migration / Config
None — no schema, env var, or third-party config changes.

## Testing
- `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — clean.
- `npx vitest run` — full suite passes (43 passed, 5 pre-existing skipped), including the new `onboardingRedirect.test.ts` (6 tests: label mapping, unknown/missing paths, valid same-school redirects, missing-redirect fallback, cross-school/absolute/protocol-relative rejection, and onboarding-loop rejection).
