### PR TITLE
Release: Onboarding redirect gating, auth-flow redirects, and UT domain/copy fixes

### DIFF
--- a/src/app/(general)/page.tsx
+++ b/src/app/(general)/page.tsx
@@ -3,6 +3,7 @@
 import { SignInButton, useAuth } from "@clerk/nextjs";
 import ReactLenis from "lenis/react";
 import Image from "next/image";
+import Link from "next/link";
 import React from "react";
 import { MdKeyboardArrowRight } from "react-icons/md";
 import { motion } from "motion/react";
@@ -30,6 +31,23 @@ function Page() {
   // if (!accessGranted) {
   //   return <AccessCodeForm onSuccess={() => setAccessGranted(true)} />;
   // }
+
+  const ctaContent = (
+    <div className="translate-y flex cursor-pointer items-center rounded-md bg-(--mist-white) px-3 py-2 font-semibold text-nowrap text-(--charcoal-black) sm:px-4 sm:py-2 md:px-5 md:py-3">
+      <p className="text-sm sm:text-base">Find your co-foundr</p>
+      <motion.div
+        className="flex items-center"
+        animate={{ x: [0, 5, 0] }}
+        transition={{
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      >
+        <MdKeyboardArrowRight className="size-5 sm:size-6 md:size-7" />
+      </motion.div>
+    </div>
+  );
 
   return (
     <ReactLenis root>
@@ -142,31 +160,29 @@ function Page() {
               transition={{ duration: 0.8, delay: 1.8, ease: "easeOut" }}
             >
               <div className="flex flex-col items-center">
-                <SignInButton forceRedirectUrl="/cofoundr-matching">
-                  <motion.button
-                    className="cursor-pointer"
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <div className="translate-y flex cursor-pointer items-center rounded-md bg-(--mist-white) px-3 py-2 font-semibold text-nowrap text-(--charcoal-black) sm:px-4 sm:py-2 md:px-5 md:py-3">
-                      <p className="text-sm sm:text-base">
-                        Find your co-foundr
-                      </p>
-                      <motion.div
-                        className="flex items-center"
-                        animate={{ x: [0, 5, 0] }}
-                        transition={{
-                          duration: 1.5,
-                          repeat: Infinity,
-                          ease: "easeInOut",
-                        }}
-                      >
-                        <MdKeyboardArrowRight className="size-5 sm:size-6 md:size-7" />
-                      </motion.div>
-                    </div>
-                  </motion.button>
-                </SignInButton>
+                {isSignedIn ? (
+                  <Link href="/cofoundr-matching">
+                    <motion.div
+                      className="cursor-pointer"
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {ctaContent}
+                    </motion.div>
+                  </Link>
+                ) : (
+                  <SignInButton forceRedirectUrl="/cofoundr-matching">
+                    <motion.button
+                      className="cursor-pointer"
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {ctaContent}
+                    </motion.button>
+                  </SignInButton>
+                )}
 
                 <motion.p
                   className="mt-3 text-center text-xs text-gray-400 sm:mt-4 sm:text-sm"

--- a/src/app/(school)/school/[slug]/onboarding/page.tsx
+++ b/src/app/(school)/school/[slug]/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, use } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { completeOnboarding } from "@/app/(general)/onboarding/_actions";
 import { useUserProfile } from "@/features/profile/useProfile";
@@ -14,6 +14,10 @@ import { useSchool } from "@/features/school/components/SchoolContext";
 import { getOrgConfig, STEP3_COMPLETIONS } from "@/features/school/registry/registry";
 import { getCompletedSteps } from "@/features/school/onboarding/getCompletedSteps";
 import { STEP_COMPONENTS } from "@/features/school/onboarding/stepRegistry";
+import {
+  getGatedFeatureLabel,
+  resolvePostOnboardingRedirect,
+} from "@/features/school/onboarding/onboardingRedirect";
 
 export default function SchoolOnboardingPage({
   params,
@@ -34,6 +38,9 @@ export default function SchoolOnboardingPage({
   const { user } = useUser();
   const { session } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get("redirect");
+  const [gatedRedirectNotice, setGatedRedirectNotice] = useState(() => Boolean(redirectParam));
   const draft = useOnboardingDraft();
   const { containerRef, transition } = useStepTransition();
   const { data: existingProfile, isLoading: profileLoading } = useUserProfile();
@@ -110,10 +117,14 @@ export default function SchoolOnboardingPage({
 
       await completeOnboarding(formData, { kind: "school", orgId });
       await user?.reload();
+      // Force a fresh session JWT so middleware's schoolOnboarding check sees this
+      // completion immediately — otherwise the next navigation can bounce right back
+      // into onboarding on a stale token.
+      await session?.getToken({ skipCache: true });
 
       draft.clear();
 
-      router.push(`/school/${slug}/dashboard`);
+      router.push(resolvePostOnboardingRedirect(slug, redirectParam));
     } catch {
       setError("Something went wrong. Please try again.");
     }
@@ -141,6 +152,22 @@ export default function SchoolOnboardingPage({
         </h1>
         <p className="mt-1 text-sm text-[var(--ui-text-muted)]">Student Profile Setup</p>
       </div>
+
+      {gatedRedirectNotice && (
+        <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">
+          <span>
+            ✦ Finish setting up your profile before you can {getGatedFeatureLabel(redirectParam)}.
+          </span>
+          <button
+            type="button"
+            onClick={() => setGatedRedirectNotice(false)}
+            className="shrink-0 text-[var(--ui-text-subtle)] hover:text-[var(--ui-text-muted)]"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {preFilledNotice && (
         <div className="mb-6 flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3 text-sm text-[var(--ui-text-muted)]">

--- a/src/app/(school)/school/[slug]/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-in/[[...sign-in]]/page.tsx
@@ -1,4 +1,5 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import SchoolSignIn from "@/features/school/components/auth/SchoolSignIn";
 
@@ -10,7 +11,13 @@ export default async function SchoolSignInPage({
   searchParams: Promise<{ mismatch?: string; email?: string; redirect?: string }>;
 }) {
   const { slug } = await params;
-  const { mismatch, email, redirect } = await searchParams;
+  const { mismatch, email, redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
   const org = await getOrganizationBySlug(slug);
   if (!org) notFound();
 
@@ -27,7 +34,7 @@ export default async function SchoolSignInPage({
         schoolName={org.name}
         allowedDomains={org.allowed_email_domains ?? []}
         initialError={initialError}
-        afterAuthRedirect={redirect ?? null}
+        afterAuthRedirect={redirectParam ?? null}
       />
     </div>
   );

--- a/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
@@ -1,4 +1,5 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import SchoolSignUp from "@/features/school/components/auth/SchoolSignUp";
 
@@ -10,7 +11,13 @@ export default async function SchoolSignUpPage({
   searchParams: Promise<{ redirect?: string }>;
 }) {
   const { slug } = await params;
-  const { redirect } = await searchParams;
+  const { redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
   const org = await getOrganizationBySlug(slug);
   if (!org) notFound();
 
@@ -21,7 +28,7 @@ export default async function SchoolSignUpPage({
         slug={org.slug}
         schoolName={org.name}
         allowedDomains={org.allowed_email_domains ?? []}
-        afterAuthRedirect={redirect ?? null}
+        afterAuthRedirect={redirectParam ?? null}
       />
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,10 @@ import QueryProvider from "./_providers/QueryProvider";
 import { PostHogProvider } from "./_providers/PostHogProvider";
 import { Toaster } from "react-hot-toast";
 import ReferralTracker from "@/components/referrals/referral-tracker";
-import IntroSurveyModal from "@/components/IntroSurveyModal";
+// Disabled: survey modal doesn't reliably dismiss/stay dismissed across
+// client-side navigation (e.g. browser back/forward). Re-enable once the
+// dismissal/persistence logic in IntroSurveyModal is fixed.
+// import IntroSurveyModal from "@/components/IntroSurveyModal";
 
 const satoshi = localFont({
   src: "../../public/fonts/Satoshi-Variable.ttf",
@@ -49,9 +52,9 @@ export default function RootLayout({
               </QueryProvider>
             </PostHogProvider>
           </Suspense>
-          <Suspense fallback={null}>
+          {/* <Suspense fallback={null}>
             <IntroSurveyModal />
-          </Suspense>
+          </Suspense> */}
           <Toaster position="bottom-right" />
         </body>
       </html>

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -3,11 +3,14 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { UserButton, useClerk } from "@clerk/nextjs";
+import { UserButton, useClerk, useUser } from "@clerk/nextjs";
 import { FaHeart, FaBars, FaUserPen, FaTrash, FaUserPlus } from "react-icons/fa6";
 import { FaTimes } from "react-icons/fa";
 import clsx from "clsx";
+import toast from "react-hot-toast";
 import { useLikedProfilesData } from "@/features/likes/useLikes";
+import { useSchool } from "@/features/school/components/SchoolContext";
+import { getGatedFeatureLabel } from "@/features/school/onboarding/onboardingRedirect";
 import type { OrgConfig } from "@/features/school/registry/types";
 
 type SchoolHeaderProps = {
@@ -24,6 +27,27 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const { data: likedProfilesData } = useLikedProfilesData();
   const { signOut } = useClerk();
+  const { orgId } = useSchool();
+  const { isLoaded, user } = useUser();
+
+  const schoolOnboarding = user?.publicMetadata?.schoolOnboarding as
+    | Record<string, boolean>
+    | undefined;
+  const schoolDone =
+    schoolOnboarding?.[orgId] === true ||
+    (user?.publicMetadata?.onboardingComplete === true &&
+      user?.publicMetadata?.organization_id === orgId);
+  const gateCofounderLink = mounted && isLoaded && !schoolDone;
+  const cofounderPath = `/school/${slug}/cofounder`;
+  const cofounderHref = gateCofounderLink
+    ? `/school/${slug}/onboarding?redirect=${encodeURIComponent(cofounderPath)}`
+    : cofounderPath;
+
+  const handleCofounderClick = () => {
+    if (gateCofounderLink) {
+      toast(`Finish setting up your profile before you can ${getGatedFeatureLabel(cofounderPath)}.`);
+    }
+  };
 
   const handleDeleteAccount = async () => {
     const confirmed = confirm(
@@ -131,7 +155,8 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
 
       <div className="ml-4 flex items-center gap-4 md:ml-8 md:gap-6">
         <Link
-          href={`/school/${slug}/cofounder`}
+          href={cofounderHref}
+          onClick={handleCofounderClick}
           className="hidden items-center gap-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white md:flex"
         >
           <FaUserPlus className="h-3.5 w-3.5" />
@@ -210,9 +235,12 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             ))}
             <li>
               <Link
-                href={`/school/${slug}/cofounder`}
+                href={cofounderHref}
                 className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
-                onClick={() => setIsMobileMenuOpen(false)}
+                onClick={() => {
+                  handleCofounderClick();
+                  setIsMobileMenuOpen(false);
+                }}
               >
                 <FaUserPlus className="h-3.5 w-3.5" />
                 Invite a co-foundr

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -78,7 +78,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
   const navItems = [
     {
       href: `/school/${slug}/dashboard`,
-      label: "Find a co-foundr",
+      label: "Find your co-foundr",
       featured: true,
     },
     {

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -15,7 +15,7 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
           href="#departments"
           className="border-b border-white/40 pb-0.5 text-xs sm:text-sm font-medium text-white whitespace-nowrap"
         >
-          Find a co-foundr
+          Find your co-foundr
         </a>
         <Link
           href={`/school/${slug}/contact-us`}

--- a/src/features/school/onboarding/onboardingRedirect.test.ts
+++ b/src/features/school/onboarding/onboardingRedirect.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { getGatedFeatureLabel, resolvePostOnboardingRedirect } from "./onboardingRedirect";
+
+describe("getGatedFeatureLabel", () => {
+  it("maps known feature paths to human-readable labels", () => {
+    expect(getGatedFeatureLabel("/school/ut-austin/cofounder")).toBe("invite a co-founder");
+    expect(getGatedFeatureLabel("/school/ut-austin/matches?tab=messages")).toBe(
+      "view your matches",
+    );
+    expect(getGatedFeatureLabel("/school/ut-austin/profile")).toBe("edit your profile");
+    expect(getGatedFeatureLabel("/school/ut-austin/dashboard")).toBe("access your dashboard");
+    expect(getGatedFeatureLabel("/school/ut-austin/invite/abc123")).toBe("accept your invite");
+  });
+
+  it("falls back to a generic label for unknown or missing paths", () => {
+    expect(getGatedFeatureLabel("/school/ut-austin/some-new-page")).toBe("continue");
+    expect(getGatedFeatureLabel(null)).toBe("continue");
+    expect(getGatedFeatureLabel(undefined)).toBe("continue");
+    expect(getGatedFeatureLabel("")).toBe("continue");
+  });
+});
+
+describe("resolvePostOnboardingRedirect", () => {
+  const slug = "ut-austin";
+
+  it("returns the redirect target when it stays within the school", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/cofounder")).toBe(
+      "/school/ut-austin/cofounder",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/matches?tab=messages")).toBe(
+      "/school/ut-austin/matches?tab=messages",
+    );
+  });
+
+  it("falls back to the dashboard when no redirect is provided", () => {
+    expect(resolvePostOnboardingRedirect(slug, null)).toBe("/school/ut-austin/dashboard");
+    expect(resolvePostOnboardingRedirect(slug, undefined)).toBe("/school/ut-austin/dashboard");
+    expect(resolvePostOnboardingRedirect(slug, "")).toBe("/school/ut-austin/dashboard");
+  });
+
+  it("falls back to the dashboard for redirects outside this school", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/other-school/cofounder")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "https://evil.example.com")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "//evil.example.com")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+  });
+
+  it("falls back to the dashboard rather than looping back into onboarding", () => {
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/onboarding")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+    expect(resolvePostOnboardingRedirect(slug, "/school/ut-austin/onboarding/step2")).toBe(
+      "/school/ut-austin/dashboard",
+    );
+  });
+});

--- a/src/features/school/onboarding/onboardingRedirect.ts
+++ b/src/features/school/onboarding/onboardingRedirect.ts
@@ -1,0 +1,44 @@
+const GATED_FEATURE_LABELS: Record<string, string> = {
+  cofounder: "invite a co-founder",
+  matches: "view your matches",
+  profile: "edit your profile",
+  dashboard: "access your dashboard",
+  invite: "accept your invite",
+};
+const DEFAULT_GATED_FEATURE_LABEL = "continue";
+
+/** Maps a `/school/{slug}/{feature}/...` redirect path to a human-readable label. */
+export function getGatedFeatureLabel(path: string | null | undefined): string {
+  if (!path) return DEFAULT_GATED_FEATURE_LABEL;
+  const segment = path.split("?")[0].split("/").filter(Boolean)[2];
+  return (segment && GATED_FEATURE_LABELS[segment]) || DEFAULT_GATED_FEATURE_LABEL;
+}
+
+/**
+ * Validates a `redirect` query param against the current school before using it as a
+ * post-onboarding navigation target. Falls back to the dashboard for anything outside
+ * `/school/{slug}/` or pointing back into onboarding (avoids open-redirect-style bugs
+ * and onboarding-to-onboarding loops).
+ */
+export function resolvePostOnboardingRedirect(
+  slug: string,
+  rawRedirect: string | null | undefined,
+): string {
+  const fallback = `/school/${slug}/dashboard`;
+  if (!rawRedirect) return fallback;
+  if (!rawRedirect.startsWith("/") || rawRedirect.startsWith("//")) return fallback;
+
+  const schoolPrefix = `/school/${slug}`;
+  if (rawRedirect !== schoolPrefix && !rawRedirect.startsWith(`${schoolPrefix}/`)) return fallback;
+
+  const onboardingPrefix = `${schoolPrefix}/onboarding`;
+  if (
+    rawRedirect === onboardingPrefix ||
+    rawRedirect.startsWith(`${onboardingPrefix}/`) ||
+    rawRedirect.startsWith(`${onboardingPrefix}?`)
+  ) {
+    return fallback;
+  }
+
+  return rawRedirect;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,6 +27,7 @@ const isPublicRoute = createRouteMatcher([
   "/school/:slug",
   "/school/:slug/privacy-policy",
   "/school/:slug/terms-and-conditions",
+  "/school/:slug/contact-us",
   "/school/:slug/not-authorized",
   "/school/:slug/sign-up(.*)",
   "/school/:slug/sign-in(.*)",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -301,6 +301,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
     if (!schoolDone) {
       const schoolOnboardingUrl = new URL(`/school/${org.slug}/onboarding`, req.url);
       if (pathname !== schoolOnboardingUrl.pathname) {
+        schoolOnboardingUrl.searchParams.set("redirect", `${pathname}${req.nextUrl.search}`);
         return NextResponse.redirect(schoolOnboardingUrl);
       }
       return NextResponse.next();

--- a/supabase/migrations/20260706000000_add_eid_utexas_domain.sql
+++ b/supabase/migrations/20260706000000_add_eid_utexas_domain.sql
@@ -1,0 +1,20 @@
+-- Migration: Add eid.utexas.edu to UT Austin's allowed email domains
+--
+-- Some UT students/staff have their primary EID mailbox at @eid.utexas.edu
+-- rather than @utexas.edu. Sign-up was rejecting those addresses because
+-- organizations.allowed_email_domains only listed utexas.edu and
+-- mccombs.utexas.edu. Append the domain (idempotent — no-op if already present).
+
+UPDATE organizations
+SET allowed_email_domains = (
+  SELECT ARRAY(
+    SELECT DISTINCT unnest(allowed_email_domains || ARRAY['eid.utexas.edu'])
+  )
+)
+WHERE slug = 'ut'
+  AND NOT ('eid.utexas.edu' = ANY (allowed_email_domains));
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Added eid.utexas.edu to UT org allowed_email_domains.';
+END $$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -67,6 +67,7 @@ END $$;
 --
 -- allowed_email_domains:
 --   utexas.edu           — primary UT EID emails
+--   eid.utexas.edu       — UT EID mailbox alias
 --   mccombs.utexas.edu   — McCombs subdomain
 --   mamuncofoundr.com    — Mamun internal team (revisit before public launch)
 --
@@ -89,7 +90,7 @@ VALUES (
   'ut',
   'ut',
   'school',
-  ARRAY['utexas.edu', 'mccombs.utexas.edu', 'mamuncofoundr.com'],
+  ARRAY['utexas.edu', 'eid.utexas.edu', 'mccombs.utexas.edu', 'mamuncofoundr.com'],
   '2026-05-01T23:21:50.033129+00:00',
   true,
   '{}'::jsonb


### PR DESCRIPTION
## Summary
Small follow-up PR on top of the (already-merged) multi-tenant architecture work: adds a `redirect`-aware onboarding gate so users who click a school feature before finishing setup are sent to onboarding and returned to where they were headed, makes the general landing page's CTA button destination-aware for signed-in users, redirects already-authenticated users away from the sign-in/sign-up pages, whitelists the UT contact-us page as public, adds `eid.utexas.edu` as an allowed UT email domain, and disables the intro survey modal pending a dismissal-persistence fix.

## Changes

### Onboarding Redirect Gating
- Add `onboardingRedirect.ts` with two pure helpers: `getGatedFeatureLabel` (maps a `/school/{slug}/{feature}` path to a human-readable label like "invite a co-founder") and `resolvePostOnboardingRedirect` (validates a `redirect` query param stays within the current school and doesn't point back into onboarding, falling back to the dashboard otherwise — guards against open-redirect-style bugs and onboarding-to-onboarding loops). Covered by `onboardingRedirect.test.ts`.
- `SchoolHeader.tsx`: gate the "Invite a co-founder" nav link behind per-org onboarding completion (`schoolOnboarding[orgId]`, with a legacy fallback to the old global `onboardingComplete`/`organization_id` check). Unonboarded users get routed to `/school/{slug}/onboarding?redirect=...` with a toast explaining why, instead of the link silently working or erroring downstream.
- `src/middleware.ts`: when redirecting an unonboarded school user into onboarding, append `?redirect=<original path + query>` so the onboarding page can send them back afterward.
- School onboarding page (`onboarding/page.tsx`) reads the `redirect` param, shows a dismissible "Finish setting up your profile before you can..." notice, and routes to `resolvePostOnboardingRedirect(slug, redirectParam)` on completion instead of always going to `/dashboard`. Also forces a fresh session JWT (`session?.getToken({ skipCache: true })`) after completing onboarding so middleware's `schoolOnboarding` check sees the update immediately rather than bouncing the user back into onboarding on a stale token.

### Auth Flow
- School sign-in and sign-up pages (`sign-in/[[...sign-in]]/page.tsx`, `sign-up/[[...sign-up]]/page.tsx`) now check `auth()` server-side and `redirect()` already-authenticated users to their `redirect` target or the dashboard, instead of re-rendering the auth form for a logged-in user.
- General landing page (`(general)/page.tsx`): the primary CTA now branches on `isSignedIn` — signed-in users get a `Link` straight to `/cofoundr-matching`, signed-out users still get the `SignInButton` flow. Extracted the shared button contents into a `ctaContent` constant to avoid duplicating the JSX between the two branches.

### Misc
- Whitelist `/school/:slug/contact-us` as a public middleware route (previously required auth, blocking signed-out visitors from reaching it).
- Add `eid.utexas.edu` to UT's `allowed_email_domains` (migration `20260706000000_add_eid_utexas_domain.sql`, idempotent update) — some UT students'/staff's primary EID mailbox is on that domain rather than `utexas.edu`, and sign-up was rejecting them. `supabase/seed.sql` updated to match for fresh environments.
- Update "Find a co-foundr" → "Find your co-foundr" copy in `SchoolHeader.tsx` and `PublicSchoolHeader.tsx` for consistency with the general site's CTA wording.
- Disable `IntroSurveyModal` in `app/layout.tsx` (commented out, not deleted) — dismissal doesn't reliably persist across client-side back/forward navigation; left as a documented follow-up to re-enable once fixed.

## Migration / Config
- Run `supabase/migrations/20260706000000_add_eid_utexas_domain.sql` — idempotent, safe to re-run.
- No new environment variables.

## Testing
- `onboardingRedirect.test.ts` covers `getGatedFeatureLabel` and `resolvePostOnboardingRedirect`, including the open-redirect and onboarding-loop guard cases.
- No other automated or manual testing evidence in the diff — recommend manually verifying the gated-redirect toast/notice flow on a fresh (unonboarded) school account, and confirming already-signed-in users are correctly redirected off the sign-in/sign-up pages, before merging.

## Notes
- `IntroSurveyModal` is disabled but not removed; re-enabling requires fixing its dismissal/persistence logic first (noted inline in `app/layout.tsx`).
