### PR TITLE
UT-29 | WCAG UI/UX Compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,26 +1542,6 @@
         "cross-spawn": "^7.0.6"
       }
     },
-    "node_modules/@react-email/render": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.3.2.tgz",
-      "integrity": "sha512-oq8/BD/I/YspeuBjjdLJG6xaf9tsPYk+VWu8/mX9xWbRN0t0ExKSVm9sEBL6RsCpndQA2jbY2VgPEreIrzUgqw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "html-to-text": "^9.0.5",
-        "prettier": "^3.5.3",
-        "react-promise-suspense": "^0.3.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.4.tgz",
@@ -1855,21 +1835,6 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
-      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "selderee": "^0.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -3783,17 +3748,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3862,69 +3816,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -3969,20 +3860,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5161,45 +5038,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html-to-text": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
-      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.11.0",
-        "deepmerge": "^4.3.1",
-        "dom-serializer": "^2.0.0",
-        "htmlparser2": "^8.0.2",
-        "selderee": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5823,17 +5661,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/leac": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
-      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/lenis": {
@@ -6679,21 +6506,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parseley": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
-      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "leac": "^0.6.0",
-        "peberminta": "^0.9.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6735,17 +6547,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/peberminta": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
-      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -6870,7 +6671,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
       "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -7073,25 +6874,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-promise-suspense": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
-      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7334,20 +7116,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
-    },
-    "node_modules/selderee": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
-      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "parseley": "^0.12.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/src/app/(general)/edit-profile/page.tsx
+++ b/src/app/(general)/edit-profile/page.tsx
@@ -231,8 +231,7 @@ export default function EditProfile() {
                 Profile Picture
               </h2>
               <p className="text-sm text-gray-400">
-                Upload a clear photo of yourself. AI will verify it&apos;s a
-                real human face.
+                Upload a clear photo of yourself with your face visible.
               </p>
             </div>
           </div>

--- a/src/app/(general)/onboarding/form-components/ProfilePhotoForm.tsx
+++ b/src/app/(general)/onboarding/form-components/ProfilePhotoForm.tsx
@@ -139,7 +139,7 @@ function ProfilePhotoForm({ onNext, defaultValues }: ProfilePhotoFormProps) {
             Add your profile photo
           </h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
-            Our AI verifies it contains a real face to keep profiles authentic.
+            Make sure your face is clearly visible in the photo.
           </p>
         </div>
 

--- a/src/app/(school)/school/[slug]/accept-policies/page.tsx
+++ b/src/app/(school)/school/[slug]/accept-policies/page.tsx
@@ -100,7 +100,7 @@ export default function AcceptPoliciesPage() {
               <Link
                 href={`/school/${slug}/privacy-policy`}
                 target="_blank"
-                className="font-semibold underline hover:opacity-70"
+                className="rounded font-semibold underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
                 style={{ color: primary }}
               >
                 Privacy Policy
@@ -109,7 +109,7 @@ export default function AcceptPoliciesPage() {
               <Link
                 href={`/school/${slug}/terms-and-conditions`}
                 target="_blank"
-                className="font-semibold underline hover:opacity-70"
+                className="rounded font-semibold underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
                 style={{ color: primary }}
               >
                 Terms of Use
@@ -171,7 +171,7 @@ export default function AcceptPoliciesPage() {
             type="button"
             onClick={handleContinue}
             disabled={!allChecked || submitting}
-            className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
             style={{ backgroundColor: primary }}
           >
             {submitting ? "Saving…" : "I Agree & Continue"}

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -109,7 +109,7 @@ function SearchResultCard({
                 </span>
               )}
               {profile.isTechnical && (
-                <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2 py-0.5 text-[10px] font-medium text-[#bf5700]">
+                <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2 py-0.5 text-[10px] font-medium text-[#a34800]">
                   {profile.isTechnical === "yes" ? "Technical" : "Non-technical"}
                 </span>
               )}
@@ -296,7 +296,7 @@ export default function SchoolDashboardPage() {
         <p className="text-xs font-semibold uppercase tracking-widest">
           <span className="text-[#84cc16]">Mamun</span>
           <span className="text-[var(--ui-text-muted)]"> &times; </span>
-          <span className="text-[#BF5700]">{schoolName}</span>
+          <span className="text-[#a34800]">{schoolName}</span>
         </p>
         <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">
           UT co-foundr Matching
@@ -410,7 +410,7 @@ export default function SchoolDashboardPage() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by skill, major, industry…"
-            className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#bf5700]/60 outline-none"
+            className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#a34800] outline-none"
           />
           <button
             onClick={() => { setSearchQuery(""); setSearchOpen(false); }}
@@ -454,7 +454,7 @@ export default function SchoolDashboardPage() {
                         key={s.dimension}
                         type="button"
                         onClick={() => handleRelax(s)}
-                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#bf5700] transition hover:bg-[#ffe8d6] cursor-pointer"
+                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#a34800] transition hover:bg-[#ffe8d6] cursor-pointer"
                       >
                         <span className="font-medium">Drop &ldquo;{s.label}&rdquo;</span>
                         <span className="flex-shrink-0 rounded-full bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
@@ -471,7 +471,7 @@ export default function SchoolDashboardPage() {
               )}
               <button
                 onClick={() => setSearchQuery("")}
-                className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"
+                className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
               >
                 Clear search
               </button>
@@ -504,7 +504,7 @@ export default function SchoolDashboardPage() {
                 <button
                   type="button"
                   onClick={() => updateFilters(EMPTY_DASHBOARD_FILTERS)}
-                  className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"
+                  className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
                 >
                   Clear filters
                 </button>
@@ -586,7 +586,7 @@ export default function SchoolDashboardPage() {
                       </span>
                     )}
                     {curProfile.archetype && (
-                      <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                      <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
                         {curProfile.archetype === "the_scaler"
                           ? "The Scaler"
                           : curProfile.archetype === "the_steward"
@@ -602,7 +602,7 @@ export default function SchoolDashboardPage() {
                 </div>
 
                 {curProfile.isTechnical && (
-                  <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                  <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
                     {curProfile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
                   </div>
                 )}
@@ -715,7 +715,7 @@ export default function SchoolDashboardPage() {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#bf5700]"
+                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#a34800]"
                           >
                             {icon}
                             {label}

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -100,10 +100,11 @@ function SearchResultCard({
               </span>
               {profile.utStatus && (
                 <span
-                  className="inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-medium text-white"
-                  style={{
-                    backgroundColor: profile.utStatus === "student" ? "#22c55e" : "#a855f7",
-                  }}
+                  className={`inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-medium ${
+                    profile.utStatus === "student"
+                      ? "bg-emerald-100 text-emerald-800"
+                      : "bg-purple-100 text-purple-800"
+                  }`}
                 >
                   {profile.utStatus === "student" ? "Student" : "Alumni"}
                 </span>
@@ -294,7 +295,7 @@ export default function SchoolDashboardPage() {
       <div className="w-8" />
       <div className="text-center">
         <p className="text-xs font-semibold uppercase tracking-widest">
-          <span className="text-[#84cc16]">Mamun</span>
+          <span className="text-[#4d7c0f]">Mamun</span>
           <span className="text-[var(--ui-text-muted)]"> &times; </span>
           <span className="text-[#a34800]">{schoolName}</span>
         </p>
@@ -577,10 +578,11 @@ export default function SchoolDashboardPage() {
                   <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
                     {curProfile.utStatus && (
                       <span
-                        className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium text-white"
-                        style={{
-                          backgroundColor: curProfile.utStatus === "student" ? "#22c55e" : "#a855f7",
-                        }}
+                        className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ${
+                          curProfile.utStatus === "student"
+                            ? "bg-emerald-100 text-emerald-800"
+                            : "bg-purple-100 text-purple-800"
+                        }`}
                       >
                         {curProfile.utStatus === "student" ? "Student" : "Alumni"}
                       </span>

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -356,7 +356,7 @@ export default function SchoolDashboardPage() {
               key={chip.key}
               type="button"
               onClick={() => updateFilters(chip.onRemove())}
-              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:opacity-90"
+              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:bg-[#a34800]"
             >
               {chip.label}
               <span aria-hidden>&times;</span>

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -98,7 +98,7 @@ export default function AcceptInviteClient({
             {inviterName} invited you to link as co-founders
           </h1>
           {inviterTitle && (
-            <p className="mt-1 text-sm" style={{ color: "#9cadb7" }}>
+            <p className="mt-1 text-sm" style={{ color: "#5f7280" }}>
               {inviterTitle}
             </p>
           )}
@@ -116,7 +116,7 @@ export default function AcceptInviteClient({
               </p>
             )}
             {note && (
-              <p className="text-sm italic" style={{ color: "#9cadb7" }}>
+              <p className="text-sm italic" style={{ color: "#5f7280" }}>
                 &ldquo;{note}&rdquo;
               </p>
             )}
@@ -136,7 +136,7 @@ export default function AcceptInviteClient({
           </button>
         ) : (
           <div className="mb-4 space-y-1.5">
-            <label className="block text-xs font-medium" style={{ color: "#9cadb7" }}>
+            <label className="block text-xs font-medium" style={{ color: "#5f7280" }}>
               Your role
             </label>
             <select
@@ -155,7 +155,7 @@ export default function AcceptInviteClient({
           </div>
         )}
 
-        <p className="mb-6 text-center text-sm" style={{ color: "#9cadb7" }}>
+        <p className="mb-6 text-center text-sm" style={{ color: "#5f7280" }}>
           Accepting will link your profiles as confirmed co-founders, visible on both your cards.
         </p>
 

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -128,8 +128,7 @@ export default function AcceptInviteClient({
           <button
             type="button"
             onClick={() => setEditingRole(true)}
-            className="mb-4 flex cursor-pointer items-center gap-1.5 text-xs font-medium transition hover:opacity-80"
-            style={{ color: "#bf5700" }}
+            className="mb-4 flex cursor-pointer items-center gap-1.5 text-xs font-medium text-[#bf5700] transition hover:text-[#a34800]"
           >
             <FaPencil className="h-3 w-3" />
             Edit my role
@@ -174,8 +173,7 @@ export default function AcceptInviteClient({
             type="button"
             onClick={handleAccept}
             disabled={accepting || declining}
-            className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-            style={{ backgroundColor: "#bf5700" }}
+            className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[#bf5700] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#a34800] disabled:cursor-not-allowed disabled:opacity-50"
           >
             <FaHandshake className="h-4 w-4" />
             {accepting ? "Accepting…" : "Accept"}

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -38,7 +38,7 @@ export default async function InviteAcceptPage({
           <p className="text-base font-semibold" style={{ color: "#333f48" }}>
             This invite is no longer valid
           </p>
-          <p className="mt-2 text-sm" style={{ color: "#9cadb7" }}>
+          <p className="mt-2 text-sm" style={{ color: "#5f7280" }}>
             It may have expired, been revoked, or already accepted.
           </p>
           <Link
@@ -94,11 +94,11 @@ export default async function InviteAcceptPage({
             {inviterName} wants to link as co-founders
           </h1>
           {inviterProfile?.title && (
-            <p className="mt-1 text-sm" style={{ color: "#9cadb7" }}>
+            <p className="mt-1 text-sm" style={{ color: "#5f7280" }}>
               {inviterProfile.title}
             </p>
           )}
-          <p className="mt-4 text-sm" style={{ color: "#9cadb7" }}>
+          <p className="mt-4 text-sm" style={{ color: "#5f7280" }}>
             Sign in or create an account to accept this invite.
           </p>
           <div className="mt-6 flex flex-col gap-3">

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -43,8 +43,7 @@ export default async function InviteAcceptPage({
           </p>
           <Link
             href={`/school/${slug}/dashboard`}
-            className="mt-6 inline-block cursor-pointer rounded-xl px-6 py-2.5 text-sm font-semibold text-white"
-            style={{ backgroundColor: "#bf5700" }}
+            className="mt-6 inline-block cursor-pointer rounded-xl bg-[#bf5700] px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-[#a34800]"
           >
             Go to dashboard
           </Link>
@@ -104,8 +103,7 @@ export default async function InviteAcceptPage({
           <div className="mt-6 flex flex-col gap-3">
             <Link
               href={signInUrl}
-              className="cursor-pointer rounded-xl px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90"
-              style={{ backgroundColor: "#bf5700" }}
+              className="cursor-pointer rounded-xl bg-[#bf5700] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#a34800]"
             >
               Sign in
             </Link>

--- a/src/app/(school)/school/[slug]/layout.tsx
+++ b/src/app/(school)/school/[slug]/layout.tsx
@@ -103,13 +103,16 @@ export default async function SchoolSlugLayout({
             "--org-accent": cfg.branding.accentColor,
             "--org-bg": cfg.branding.backgroundColor,
             "--org-text": cfg.branding.textColor,
-            // Semantic UI tokens — light-mode overrides for school orgs with white bg
+            // Semantic UI tokens — light-mode overrides for school orgs with white bg.
+            // Text/subtle values are chosen to clear WCAG AA (4.5:1) on white — see
+            // the plan doc for the full contrast audit.
             ...(cfg.branding.backgroundColor === "#FFFFFF" ||
             cfg.branding.backgroundColor === "#ffffff"
               ? {
+                  "--ui-bg": "#ffffff",
                   "--ui-text": cfg.branding.textColor,
-                  "--ui-text-muted": "#9cadb7",
-                  "--ui-text-subtle": "rgba(51,63,72,0.45)",
+                  "--ui-text-muted": "#5f7280",
+                  "--ui-text-subtle": "#64757e",
                   "--ui-border": "#e8e4dc",
                   "--ui-border-strong": "#c8c3b8",
                   "--ui-surface": "rgba(51,63,72,0.04)",

--- a/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
@@ -249,7 +249,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
               <p className="text-xs text-[var(--ui-text-muted)]">{error.message}</p>
               <button
                 onClick={() => window.location.reload()}
-                className="mt-2 rounded-lg bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white hover:opacity-90 cursor-pointer"
+                className="mt-2 rounded-lg bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white cursor-pointer hover:bg-[#a34800]"
               >
                 Try Again
               </button>
@@ -302,7 +302,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
             />
             <button
               type="submit"
-              className="rounded-lg bg-[var(--org-primary)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-40 cursor-pointer"
+              className="rounded-lg bg-[var(--org-primary)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-40 cursor-pointer"
               disabled={!messageInput.trim() || isSending || messages.length >= 20}
             >
               {isSending ? "Sending..." : "Send"}

--- a/src/app/(school)/school/[slug]/matches/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/page.tsx
@@ -297,7 +297,7 @@ export default function SchoolMatchesPage({
                           <button
                             onClick={() => profile.user_id && handleMessage(profile.user_id)}
                             disabled={createConversationMutation.isPending}
-                            className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                            className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-semibold text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                           >
                             <FaHandshake className="h-3.5 w-3.5" />
                             It&apos;s a Match!
@@ -332,7 +332,7 @@ export default function SchoolMatchesPage({
                             profile.user_id && handleMessage(profile.user_id)
                           }
                           disabled={createConversationMutation.isPending}
-                          className="rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                          className="rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                         >
                           Message
                         </button>

--- a/src/app/(school)/school/[slug]/not-authorized/page.tsx
+++ b/src/app/(school)/school/[slug]/not-authorized/page.tsx
@@ -42,7 +42,7 @@ export default async function NotAuthorizedPage({
       <div className="flex flex-col items-center gap-3">
         <Link
           href={`/school/${slug}/sign-up`}
-          className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: "var(--org-primary)" }}
         >
           Sign up with your school email

--- a/src/app/(school)/school/[slug]/page.tsx
+++ b/src/app/(school)/school/[slug]/page.tsx
@@ -89,14 +89,14 @@ export default async function SchoolLanding({
       <div className="flex flex-col items-center gap-3 sm:flex-row">
         <Link
           href="/sign-up"
-          className="rounded-lg px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-lg px-6 py-3 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: branding.primaryColor }}
         >
           {landing.ctaPrimaryLabel}
         </Link>
         <Link
           href="/sign-in"
-          className="rounded-lg border px-6 py-3 text-sm font-semibold transition-opacity hover:opacity-70"
+          className="rounded-lg border px-6 py-3 text-sm font-semibold transition-colors hover:bg-black/5"
           style={{
             borderColor: branding.accentColor,
             color: branding.accentColor,

--- a/src/app/(school)/school/[slug]/privacy-policy/page.tsx
+++ b/src/app/(school)/school/[slug]/privacy-policy/page.tsx
@@ -81,7 +81,7 @@ export default async function SchoolPrivacyPolicyPage({
                 <a
                   href={downloadUrl}
                   download
-                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
                   style={{ backgroundColor: primaryColor }}
                 >
                   <svg

--- a/src/app/(school)/school/[slug]/profile/page.tsx
+++ b/src/app/(school)/school/[slug]/profile/page.tsx
@@ -50,7 +50,7 @@ const PILL_RADIO_CLS =
 
 function CharCount({ value, max }: { value: string; max: number }) {
   return (
-    <p className={`text-right text-xs ${(value?.length ?? 0) > max - 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"}`}>
+    <p className={`text-right text-xs ${(value?.length ?? 0) > max - 50 ? "text-amber-700" : "text-[var(--ui-text-subtle)]"}`}>
       {value?.length ?? 0} / {max}
     </p>
   );

--- a/src/app/(school)/school/[slug]/sso-callback/page.tsx
+++ b/src/app/(school)/school/[slug]/sso-callback/page.tsx
@@ -8,7 +8,7 @@ export default function SSOCallbackPage() {
   const complete = `/school/${slug}/sso-complete`;
   return (
     <div className="flex flex-1 items-center justify-center">
-      <div className="text-sm" style={{ color: "#9cadb7" }}>
+      <div className="text-sm" style={{ color: "#5f7280" }}>
         Completing sign-in…
       </div>
       <AuthenticateWithRedirectCallback

--- a/src/app/(school)/school/[slug]/terms-and-conditions/page.tsx
+++ b/src/app/(school)/school/[slug]/terms-and-conditions/page.tsx
@@ -81,7 +81,7 @@ export default async function SchoolTermsPage({
                 <a
                   href={downloadUrl}
                   download
-                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
                   style={{ backgroundColor: primaryColor }}
                 >
                   <svg

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
   --charcoal-black: #1c1c1c;
 
   /* - semantic UI tokens (dark-mode defaults — overridden by school layout for light orgs) - */
+  --ui-bg: #0d0d0d;
   --ui-text: #ffffff;
   --ui-text-muted: rgba(255, 255, 255, 0.5);
   --ui-text-subtle: rgba(255, 255, 255, 0.3);

--- a/src/components/ui/AIWriter.tsx
+++ b/src/components/ui/AIWriter.tsx
@@ -127,11 +127,11 @@ export default function AIWriter({ text, onAccept, fieldType }: AIWriterProps) {
 
           {suggestionMessage && (
             <div className="flex items-center justify-between">
-              <p className="text-sm text-gray-400">{suggestionMessage}</p>
+              <p className="text-sm text-gray-600">{suggestionMessage}</p>
               <button
                 type="button"
                 onClick={rejectSuggestion}
-                className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+                className="rounded-md p-1.5 text-gray-600 transition-colors hover:bg-gray-700 hover:text-white"
               >
                 <FaXmark className="h-4 w-4" />
               </button>

--- a/src/components/ui/LocationSelector.tsx
+++ b/src/components/ui/LocationSelector.tsx
@@ -226,7 +226,7 @@ export default function LocationSelector({
     <div className="space-y-4">
       {/* Country */}
       <div className="flex flex-col gap-y-2">
-        <label className="text-sm font-medium text-gray-300">Country *</label>
+        <label className="text-sm font-medium text-[var(--ui-text)]">Country *</label>
         <select
           className={selectClass}
           value={selectedCountryIso}
@@ -256,7 +256,7 @@ export default function LocationSelector({
       {/* State — US only */}
       {isUS && (
         <div className="flex flex-col gap-y-2">
-          <label className="text-sm font-medium text-gray-300">State *</label>
+          <label className="text-sm font-medium text-[var(--ui-text)]">State *</label>
           <select
             className={selectClass}
             value={selectedStateIso}
@@ -287,7 +287,7 @@ export default function LocationSelector({
 
       {/* City — constrained combobox */}
       <div className="flex flex-col gap-y-2">
-        <label className="text-sm font-medium text-gray-300">City *</label>
+        <label className="text-sm font-medium text-[var(--ui-text)]">City *</label>
         <div ref={comboboxRef} className="relative">
           <input
             ref={inputRef}

--- a/src/features/cofounder/CoFounderLinks.tsx
+++ b/src/features/cofounder/CoFounderLinks.tsx
@@ -41,7 +41,7 @@ export default function CoFounderLinks({ userId, onClickCofounder }: Props) {
                   className="h-9 w-9 flex-shrink-0 rounded-full object-cover"
                 />
               ) : (
-                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#bf5700]/20 text-sm font-bold text-[#bf5700]">
+                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#bf5700]/20 text-sm font-bold text-[#a34800]">
                   {initials}
                 </span>
               )}

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -178,7 +178,7 @@ export default function CoFounderPanel({
           <button
             type="submit"
             disabled={sendInvite.isPending || !email.trim()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:opacity-90 disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:bg-[#a34800] disabled:opacity-50"
           >
             <FaUserPlus className="h-3.5 w-3.5" />
             {sendInvite.isPending ? "Sending…" : "Send invite"}

--- a/src/features/matches/ProfileDetailModal.tsx
+++ b/src/features/matches/ProfileDetailModal.tsx
@@ -348,7 +348,7 @@ export default function ProfileDetailModal({
                   <button
                     onClick={() => onMessage(userId)}
                     disabled={isMessagePending}
-                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                   >
                     <FaHandshake className="h-4 w-4" />
                     It&apos;s a Match!
@@ -376,7 +376,7 @@ export default function ProfileDetailModal({
                 <button
                   onClick={() => onMessage(userId)}
                   disabled={isMessagePending}
-                  className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                 >
                   <FaEnvelope className="h-4 w-4" />
                   Message

--- a/src/features/profile/ProfileViewModal.tsx
+++ b/src/features/profile/ProfileViewModal.tsx
@@ -335,7 +335,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                   className={`flex w-full items-center justify-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 cursor-pointer ${
                     likeStatus?.isLiked
                       ? "bg-pink-500 text-white hover:bg-pink-600"
-                      : "bg-[var(--org-primary)] text-white hover:opacity-90"
+                      : "bg-[var(--org-primary)] text-white hover:bg-[#a34800]"
                   }`}
                 >
                   <FaPaperPlane className="h-4 w-4" />

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -127,7 +127,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
     >
       <Link
         href={`/school/${slug}`}
-        className="text-base font-semibold tracking-tight text-white/70 transition-colors hover:text-white"
+        className="text-base font-semibold tracking-tight text-white transition-[font-weight] duration-300 hover:font-bold"
       >
         {headerText}
       </Link>
@@ -139,12 +139,12 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             key={href}
             href={href}
             className={featured
-              ? "rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
+              ? "rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white transition-[border-color,font-weight] duration-300 hover:font-semibold hover:border-white/60"
               : clsx(
-                  "text-sm font-medium transition-colors border-b-2",
+                  "text-sm font-medium transition-[border-color,font-weight] duration-300 border-b-2",
                   pathname.startsWith(href)
                     ? "text-white border-white"
-                    : "text-white/70 hover:text-white border-transparent",
+                    : "text-white hover:font-semibold border-transparent",
                 )
             }
           >
@@ -157,7 +157,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
         <Link
           href={cofounderHref}
           onClick={handleCofounderClick}
-          className="hidden items-center gap-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white md:flex"
+          className="hidden items-center gap-1.5 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold md:flex"
         >
           <FaUserPlus className="h-3.5 w-3.5" />
           Invite a co-foundr
@@ -165,7 +165,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
 
         <Link
           href={`/school/${slug}/matches`}
-          className="relative flex items-center justify-center text-white/70 transition-colors hover:text-white"
+          className="relative flex items-center justify-center text-white transition-transform duration-300 hover:scale-110"
         >
           <FaHeart className="h-5 w-5 text-white" />
           {savedMatchesCount > 0 && (
@@ -204,7 +204,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
         {/* Mobile hamburger */}
         <button
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          className="cursor-pointer rounded-lg p-1.5 text-white/70 transition-colors hover:text-white md:hidden"
+          className="cursor-pointer rounded-lg p-1.5 text-white transition-transform duration-300 hover:scale-110 md:hidden"
           aria-label="Toggle menu"
         >
           {isMobileMenuOpen ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
@@ -224,8 +224,8 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
                 <Link
                   href={href}
                   className={featured
-                    ? "block rounded-lg border border-white/30 px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
-                    : "block rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                    ? "block rounded-lg border border-white/30 px-3 py-2 text-sm font-medium text-white transition-[border-color,font-weight] duration-300 hover:font-semibold hover:border-white/60"
+                    : "block rounded-lg px-3 py-2 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold"
                   }
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
@@ -236,7 +236,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             <li>
               <Link
                 href={cofounderHref}
-                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold"
                 onClick={() => {
                   handleCofounderClick();
                   setIsMobileMenuOpen(false);

--- a/src/features/school/components/auth/AutoRetry.tsx
+++ b/src/features/school/components/auth/AutoRetry.tsx
@@ -13,7 +13,7 @@ export default function AutoRetry() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm" style={{ color: "#9cadb7" }}>
+      <p className="text-sm" style={{ color: "#5f7280" }}>
         Setting up your account…
       </p>
     </div>

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -215,7 +215,7 @@ export default function SchoolSignIn({
               </>
             )}
           </h1>
-          <p className="text-sm" style={{ color: "#9cadb7" }}>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
             {pendingSecondFactor
               ? `We sent a 6-digit code to ${email}.`
               : `Use your ${allowedCopy} account.`}
@@ -235,7 +235,7 @@ export default function SchoolSignIn({
             </div>
             <div className="mb-4 flex items-center gap-3">
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
-              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#5f7280" }}>
                 or
               </span>
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
@@ -339,7 +339,7 @@ export default function SchoolSignIn({
 
         <div
           className="mt-6 border-t pt-4 text-center text-xs"
-          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
         >
           Don&apos;t have an account?{" "}
           <Link

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -294,8 +294,7 @@ export default function SchoolSignIn({
                 <button
                   type="submit"
                   disabled={submitting || !isLoaded}
-                  className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-                  style={{ backgroundColor: "#bf5700" }}
+                  className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
                 >
                   {submitting ? "Signing in…" : "Sign in"}
                 </button>
@@ -329,8 +328,7 @@ export default function SchoolSignIn({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Verifying…" : "Verify and continue"}
             </button>

--- a/src/features/school/components/auth/SchoolSignUp.tsx
+++ b/src/features/school/components/auth/SchoolSignUp.tsx
@@ -160,7 +160,7 @@ export default function SchoolSignUp({
               </>
             )}
           </h1>
-          <p className="text-sm" style={{ color: "#9cadb7" }}>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
             {pendingVerification
               ? `We sent a 6-digit code to ${email}.`
               : `Sign up with your ${allowedCopy} email.`}
@@ -180,7 +180,7 @@ export default function SchoolSignUp({
             </div>
             <div className="mb-4 flex items-center gap-3">
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
-              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#5f7280" }}>
                 or
               </span>
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
@@ -300,12 +300,12 @@ export default function SchoolSignUp({
               {submitting ? "Creating account…" : "Create account"}
             </button>
 
-            <p className="text-center text-[11px]" style={{ color: "#9cadb7" }}>
+            <p className="text-center text-[11px]" style={{ color: "#5f7280" }}>
               By creating an account, you agree to our{" "}
               <Link
                 href={`/school/${slug}/privacy-policy`}
                 className="font-medium underline hover:opacity-70"
-                style={{ color: "#9cadb7" }}
+                style={{ color: "#5f7280" }}
               >
                 Privacy Policy
               </Link>
@@ -350,7 +350,7 @@ export default function SchoolSignUp({
 
         <div
           className="mt-6 border-t pt-4 text-center text-xs"
-          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
         >
           Already have an account?{" "}
           <Link

--- a/src/features/school/components/auth/SchoolSignUp.tsx
+++ b/src/features/school/components/auth/SchoolSignUp.tsx
@@ -260,8 +260,7 @@ export default function SchoolSignUp({
                     {existingHasPassword && (
                       <Link
                         href={`/school/${slug}/sign-in`}
-                        className="block rounded-lg px-4 py-2 text-center text-xs font-semibold text-white transition-opacity hover:opacity-90"
-                        style={{ backgroundColor: "#bf5700" }}
+                        className="block rounded-lg bg-[#bf5700] px-4 py-2 text-center text-xs font-semibold text-white transition-colors hover:bg-[#a34800]"
                       >
                         Sign in with password
                       </Link>
@@ -294,8 +293,7 @@ export default function SchoolSignUp({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Creating account…" : "Create account"}
             </button>
@@ -304,8 +302,7 @@ export default function SchoolSignUp({
               By creating an account, you agree to our{" "}
               <Link
                 href={`/school/${slug}/privacy-policy`}
-                className="font-medium underline hover:opacity-70"
-                style={{ color: "#5f7280" }}
+                className="font-medium text-[#5f7280] underline transition-colors hover:text-[#a34800]"
               >
                 Privacy Policy
               </Link>
@@ -340,8 +337,7 @@ export default function SchoolSignUp({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Verifying…" : "Verify and continue"}
             </button>

--- a/src/features/school/components/auth/SessionRefreshRedirect.tsx
+++ b/src/features/school/components/auth/SessionRefreshRedirect.tsx
@@ -17,7 +17,7 @@ export default function SessionRefreshRedirect({ to }: { to: string }) {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm" style={{ color: "#9cadb7" }}>
+      <p className="text-sm" style={{ color: "#5f7280" }}>
         Setting up your account…
       </p>
     </div>

--- a/src/features/school/components/contact/UtAboutPanel.tsx
+++ b/src/features/school/components/contact/UtAboutPanel.tsx
@@ -13,15 +13,14 @@ export default function UtAboutPanel() {
     >
       <div className="px-6 py-10 sm:px-12 sm:py-14">
         <p
-          className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
-          style={{ color: "rgba(255,255,255,0.55)" }}
+          className="mb-2 text-[10px] font-medium text-white uppercase tracking-[0.1em]"
         >
           University of Texas at Austin
         </p>
         <h2 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
           Have a school question?
         </h2>
-        <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed text-white/80">
+        <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed text-white">
           For questions about UT programs, events, or anything school-related
           that isn&apos;t about the co-foundr platform, reach out to McCombs
           directly.

--- a/src/features/school/components/contact/UtSupportPanel.tsx
+++ b/src/features/school/components/contact/UtSupportPanel.tsx
@@ -15,7 +15,7 @@ export default function UtSupportPanel() {
       <h2 className="mb-3 text-2xl font-semibold sm:text-3xl" style={{ color: "#333f48" }}>
         Need help with the platform?
       </h2>
-      <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed sm:text-base" style={{ color: "#9cadb7" }}>
+      <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed sm:text-base" style={{ color: "#5f7280" }}>
         Book time with the Mamun team for help with your account, matches, or
         anything else technical on the co-foundr platform.
       </p>
@@ -32,7 +32,7 @@ export default function UtSupportPanel() {
       </Link>
 
       <div className="border-t pt-6" style={{ borderColor: "rgba(0,0,0,0.06)" }}>
-        <p className="mb-1 text-sm" style={{ color: "#9cadb7" }}>
+        <p className="mb-1 text-sm" style={{ color: "#5f7280" }}>
           Or email us at{" "}
           <a
             href="mailto:mamun@mamuncofoundr.com"
@@ -42,7 +42,7 @@ export default function UtSupportPanel() {
             mamun@mamuncofoundr.com
           </a>
         </p>
-        <p className="text-sm" style={{ color: "#9cadb7" }}>
+        <p className="text-sm" style={{ color: "#5f7280" }}>
           Leave your full name and we will get back to you within 1–2 business
           days.
         </p>

--- a/src/features/school/components/dashboard/FilterSidebar.tsx
+++ b/src/features/school/components/dashboard/FilterSidebar.tsx
@@ -91,7 +91,7 @@ function FilterSelect({
                 role="option"
                 aria-selected={!selected}
                 onClick={() => { onChange(""); setOpen(false); }}
-                className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${!selected ? "font-medium text-[#BF5700]" : "text-[#3d1a00]/50"}`}
+                className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${!selected ? "font-medium text-[#a34800]" : "text-[#3d1a00]/70"}`}
               >
                 {placeholder}
               </li>
@@ -101,7 +101,7 @@ function FilterSelect({
                   role="option"
                   aria-selected={opt.value === String(value)}
                   onClick={() => { onChange(opt.value); setOpen(false); }}
-                  className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${opt.value === String(value) ? "font-medium text-[#BF5700]" : "text-[#3d1a00]"}`}
+                  className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${opt.value === String(value) ? "font-medium text-[#a34800]" : "text-[#3d1a00]"}`}
                 >
                   {opt.value === String(value) && <span className="mr-1.5">✓</span>}
                   {opt.label}
@@ -172,7 +172,7 @@ function FilterPanel({
             <button
               type="button"
               onClick={clearAll}
-              className="text-xs font-medium text-[#bf5700] hover:underline cursor-pointer"
+              className="text-xs font-medium text-[#a34800] hover:underline cursor-pointer"
             >
               Clear all
             </button>

--- a/src/features/school/components/landing/CtaBand.tsx
+++ b/src/features/school/components/landing/CtaBand.tsx
@@ -33,7 +33,7 @@ export default function CtaBand() {
         <motion.div
           variants={item}
           className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
-          style={{ color: "rgba(255,255,255,0.5)" }}
+          style={{ color: "#ffffff" }}
         >
           University of Texas
         </motion.div>
@@ -45,7 +45,7 @@ export default function CtaBand() {
         </motion.h2>
         <motion.p
           variants={item}
-          className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white/70"
+          className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white"
         >
           Join the University of Texas co-foundr community — verified, value-aligned, and
           ready to build something that changes the world.
@@ -59,7 +59,7 @@ export default function CtaBand() {
             Create your profile
           </Link>
         </motion.div>
-        <motion.div variants={item} className="text-xs text-white/40">
+        <motion.div variants={item} className="text-xs text-white">
           Exclusively for University of Texas students, alumni, and faculty
         </motion.div>
       </motion.div>

--- a/src/features/school/components/landing/DepartmentMosaic.tsx
+++ b/src/features/school/components/landing/DepartmentMosaic.tsx
@@ -136,7 +136,7 @@ function Card({ dept }: { dept: Dept }) {
       </div>
       <div
         className="mb-2 pl-1 text-[11px]"
-        style={{ color: "#9cadb7" }}
+        style={{ color: "#5f7280" }}
       >
         {dept.programs}
       </div>
@@ -171,7 +171,7 @@ export default function DepartmentMosaic() {
         </h2>
         <p
           className="mb-10 text-center text-sm"
-          style={{ color: "#9cadb7" }}
+          style={{ color: "#5f7280" }}
         >
           Founders from across every corner of the University of Texas — 10 schools, one
           platform, one mission.

--- a/src/features/school/components/landing/Hero.tsx
+++ b/src/features/school/components/landing/Hero.tsx
@@ -36,11 +36,11 @@ export default function Hero() {
         >
           Make it here.
           <br />
-          <span className="text-white/60">Find your founding team.</span>
+          <span className="text-white">Find your founding team.</span>
         </motion.h1>
         <motion.p
           variants={item}
-          className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white/70 sm:text-base"
+          className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white sm:text-base"
         >
           The University of Texas co-foundr matching platform connects value-aligned students,
           alumni, and faculty ready to build something that changes the world.

--- a/src/features/school/components/landing/HowItWorks.tsx
+++ b/src/features/school/components/landing/HowItWorks.tsx
@@ -85,7 +85,7 @@ export default function HowItWorks() {
               </div>
               <div
                 className="text-sm leading-relaxed"
-                style={{ color: "#9cadb7" }}
+                style={{ color: "#5f7280" }}
               >
                 {s.desc}
               </div>

--- a/src/features/school/components/landing/PublicFooter.tsx
+++ b/src/features/school/components/landing/PublicFooter.tsx
@@ -28,69 +28,47 @@ export default function PublicFooter({ slug }: { slug: string }) {
 
           <div className="flex gap-12">
             <div>
-              <div
-                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <div className="mb-3 text-[10px] font-semibold text-white/70 uppercase tracking-[0.08em]">
                 Resources
               </div>
-              <motion.a
+              <a
                 href="https://www.cakeequity.com/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block text-xs hover:text-white transition-colors"
-                style={{ color: "#9cadb7" }}
-                whileHover={{ color: "#ffffff" }}
+                className="block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
               >
                 Create a Cap Table
-              </motion.a>
+              </a>
             </div>
             <div>
-              <div
-                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <div className="mb-3 text-[10px] font-semibold text-white/70 uppercase tracking-[0.08em]">
                 Company
               </div>
-              <motion.div
-                whileHover={{ color: "#ffffff" }}
+              <Link
+                href={`/school/${slug}/privacy-policy`}
+                className="mb-1.5 block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
               >
-                <Link
-                  href={`/school/${slug}/privacy-policy`}
-                  className="mb-1.5 block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Privacy Policy
-                </Link>
-              </motion.div>
-              <motion.div whileHover={{ color: "#ffffff" }}>
-                <Link
-                  href={`/school/${slug}/terms-and-conditions`}
-                  className="mb-1.5 block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Terms &amp; Conditions
-                </Link>
-              </motion.div>
-              <motion.div whileHover={{ color: "#ffffff" }}>
-                <Link
-                  href={`/school/${slug}/contact-us`}
-                  className="block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Contact Us
-                </Link>
-              </motion.div>
+                Privacy Policy
+              </Link>
+              <Link
+                href={`/school/${slug}/terms-and-conditions`}
+                className="mb-1.5 block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
+              >
+                Terms &amp; Conditions
+              </Link>
+              <Link
+                href={`/school/${slug}/contact-us`}
+                className="block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
+              >
+                Contact Us
+              </Link>
             </div>
           </div>
         </motion.div>
 
         <div
-          className="border-t pt-5 text-xs"
-          style={{
-            borderColor: "rgba(255,255,255,0.08)",
-            color: "rgba(255,255,255,0.25)",
-          }}
+          className="border-t pt-5 text-xs text-white/60"
+          style={{ borderColor: "rgba(255,255,255,0.08)" }}
         >
           © 2026 University of Texas Co-Foundr. Powered by Mamun. All rights
           reserved.

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -19,13 +19,13 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
         </a>
         <Link
           href={`/school/${slug}/contact-us`}
-          className="text-xs sm:text-sm font-medium text-white/75 hover:text-white whitespace-nowrap"
+          className="text-xs sm:text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold whitespace-nowrap"
         >
           Contact us
         </Link>
         <Link
           href={`/school/${slug}/privacy-policy`}
-          className="text-xs sm:text-sm font-medium text-white/75 hover:text-white whitespace-nowrap"
+          className="text-xs sm:text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold whitespace-nowrap"
         >
           Privacy Policy
         </Link>

--- a/src/features/school/components/landing/WhyItWorks.tsx
+++ b/src/features/school/components/landing/WhyItWorks.tsx
@@ -92,7 +92,7 @@ export default function WhyItWorks() {
         >
           <p
             className="text-[9px] font-bold tracking-widest uppercase text-center mb-3"
-            style={{ color: "#9cadb7" }}
+            style={{ color: "#5f7280" }}
           >
             10 UT Schools · One pool
           </p>
@@ -116,7 +116,7 @@ export default function WhyItWorks() {
                   </span>
                   <span
                     className="block text-[9px] leading-snug whitespace-nowrap mt-0.5"
-                    style={{ color: "#9cadb7" }}
+                    style={{ color: "#5f7280" }}
                   >
                     {s.role}
                   </span>
@@ -244,7 +244,7 @@ export default function WhyItWorks() {
         viewport={{ once: true }}
         transition={{ duration: 0.5, delay: 0.2 }}
         className="mt-8 text-center text-xs leading-relaxed"
-        style={{ color: "#9cadb7" }}
+        style={{ color: "#5f7280" }}
       >
         You bring what you&apos;re great at.{" "}
         <strong style={{ color: "#5a6a75", fontWeight: 600 }}>

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -43,7 +43,7 @@ function CharCount({ value, max }: { value: string; max: number }) {
   return (
     <p
       className={`text-right text-xs ${
-        remaining < 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"
+        remaining < 50 ? "text-amber-700" : "text-[var(--ui-text-subtle)]"
       }`}
     >
       {value.length} / {max}

--- a/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
+++ b/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
@@ -118,7 +118,7 @@ function UTProfilePhotoForm({ onNext, defaultValues }: UTProfilePhotoFormProps) 
             Add your profile photo
           </h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
-            Our AI verifies it contains a real face to keep profiles authentic.
+            Make sure your face is clearly visible in the photo.
           </p>
         </div>
 

--- a/src/features/school/policies/PrivacyPolicyTOC.tsx
+++ b/src/features/school/policies/PrivacyPolicyTOC.tsx
@@ -87,7 +87,7 @@ export function PolicyDesktopTOC({
 
   return (
     <nav aria-label="Policy table of contents">
-      <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+      <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-600">
         Contents
       </p>
       <ul className="space-y-0.5">

--- a/src/features/school/policies/ut-terms.tsx
+++ b/src/features/school/policies/ut-terms.tsx
@@ -381,7 +381,7 @@ export default function UTTermsAndConditions({ primaryColor }: Props) {
           For any question about these Terms, you can get in touch with us by emailing us at{" "}
           <a
             href="mailto:mamun@mamuncofoundr.com"
-            className="underline hover:opacity-70"
+            className="rounded underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
             style={{ color: primaryColor }}
           >
             mamun@mamuncofoundr.com


### PR DESCRIPTION
## Summary
Brings the entire UT school site (`/school/ut/*`) up to WCAG 2.1 AA color-contrast compliance, following a full audit triggered by a reported violation on the cofounder page. The official UT brand color `#BF5700` is kept unchanged everywhere it already passes AA (fills, borders, large text); only the *contexts* that failed — muted/subtle body text, low-opacity white-on-orange text, small orange text on tinted backgrounds, and solid-color status badges — were remediated. Fixes are applied at the token/pattern level (shared CSS custom properties, a small palette of new AA-safe hex values) rather than one-off per element, so styling stays visually consistent site-wide. One real bug was also found and fixed along the way: three of four `PublicFooter` links had non-functional hover states due to a `motion.div`/inline-style conflict.

## Changes

### Design tokens & foundation
- `src/app/(school)/school/[slug]/layout.tsx`: for white-background orgs, `--ui-text-muted` moves from `#9cadb7` (2.31:1 on white — fails) to `#5f7280` (5.0:1), and `--ui-text-subtle` moves from `rgba(51,63,72,0.45)` (~2.4:1) to `#64757e` (4.8:1). Also defines `--ui-bg: #ffffff"` for these orgs, fixing a previously-undefined token that left a sticky bar transparent.
- `src/app/globals.css`: adds the matching `--ui-bg: #0d0d0d` dark-mode default alongside the existing `--ui-text*` tokens.
- These two tokens alone cover roughly 230 usages across the school portal, since nearly all muted/subtle text reads from them.

### Muted text — auth, landing, invite pages
- Replaces ~26 inline `color: "#9cadb7"` literals with `#5f7280` across sign-in/sign-up, invite-accept flows, SSO/session-redirect loading states, and landing sections (`HowItWorks`, `DepartmentMosaic`, `WhyItWorks`, `UtSupportPanel`) — everywhere this color sits on a light background and previously read at 2.31:1.
- Deliberately leaves `#9cadb7` untouched on the dark footer and `ValuesPillars`, where it renders on `#333f48` and already passes at 4.66:1.

### Header & hero — white-on-orange text and hover redesign
- `SchoolHeader.tsx`, `PublicSchoolHeader.tsx`, `Hero.tsx`, `CtaBand.tsx`, `UtAboutPanel.tsx`: converts every `text-white/40…/75` and `rgba(255,255,255,0.x)` on the `#BF5700` background to solid `text-white`. Verified computationally that white on `#BF5700` has essentially no safe opacity headroom below 100% (even 95% opacity drops to 4.31:1), so partial-opacity white was not a viable middle ground anywhere on this background.
- Replaces `hover:opacity-N` hover affordances with color-independent alternatives, since dimming opacity on a white-on-orange subtree was found to *reduce* contrast on hover rather than provide a safe effect (e.g. `opacity-90` drops white-on-`#BF5700` from 4.59:1 to 3.91:1). Text links now use `hover:font-semibold`/`hover:font-bold` with a `transition-[font-weight]` (or `transition-[border-color,font-weight]` where a border also changes) at `duration-300`, since `transition-colors` doesn't animate `font-weight`. Icon-only controls (heart/matches link, hamburger) use `hover:scale-110` instead.

### Buttons & links — hover:opacity-90 removal (site-wide)
- Across ~15 files (`accept-policies`, `privacy-policy`, `terms-and-conditions`, `matches`, `invite/[token]`, `not-authorized`, `dashboard`, `CoFounderPanel`, `ProfileDetailModal`, `ProfileViewModal`, `SchoolSignIn`, `SchoolSignUp`, etc.), replaces `hover:opacity-90` on solid `#BF5700`/`var(--org-primary)` buttons with `hover:bg-[#a34800]` (a darker in-family orange, 5.99–6.03:1 on white).
- Where a button/link uses a **dynamic** per-org color (`style={{ backgroundColor: primaryColor }}` or similar) rather than the hardcoded UT hex, hardcoding `#a34800` would break other orgs' branding — those instead get a color-independent hover (`shadow-sm transition-shadow hover:shadow-md`, or `hover:bg-black/5` for text links), preserving the site's multi-tenant extensibility.
- Fixes several cases where the inline `style` background/color was overriding a co-located Tailwind `hover:` class due to CSS cascade specificity (the hover was silently dead) — resolved by moving the base color into the Tailwind class itself (`bg-[#bf5700]`) so `hover:bg-[#a34800]` can actually apply.

### Footer
- `PublicFooter.tsx`: raises `rgba(255,255,255,0.4)` section headers to `text-white/70` and the `rgba(255,255,255,0.25)` copyright line to `text-white/60`.
- Fixes a real bug: three of four footer links (Privacy Policy, Terms & Conditions, Contact Us) wrapped their `Link` in a `motion.div` with `whileHover={{ color: "#ffffff" }}`, but the child `Link`'s own inline `style={{ color: "#9cadb7" }}` took precedence, so the animated hover never visually applied. Removed the `motion.div` wrappers, moved the base color to a Tailwind class (`text-[#9cadb7]`), and standardized all four links to a single working `transition-colors duration-300 hover:text-white`.

### Small orange text on tinted backgrounds
- `#BF5700` text on `#fff6f0`/tint backgrounds measures 4.30:1, under the 4.5:1 AA minimum for normal text (it only fails on the light-orange tint — the same color on plain white passes at 4.59:1). Standardizes this small-text usage to `#a34800` (6.03:1 white / 5.65:1 tint) in `dashboard/page.tsx` (badges, search/relax UI, clear-filter links, wordmark), `FilterSidebar.tsx` (dropdown options, "Clear all"), and `CoFounderLinks.tsx` (avatar-fallback initials). Fills, borders, and icon-only controls using `#bf5700` are left as-is since those only need the 3:1 UI-component threshold, which the tint background already clears.
- Also catches two opacity-related regressions found in the same code: a search placeholder at `placeholder:text-[#bf5700]/60` (well under AA) made solid, and a `FilterSidebar` unselected-option state at `text-[#3d1a00]/50` (3.15:1) raised to `/70` (5.78:1).

### Status badges & accent colors
- `dashboard/page.tsx`: converts the solid Student/Alumni badges (white text on `#22c55e`/`#a855f7`, 2.28:1/3.96:1) to the tint-chip pattern already used for startup tags elsewhere on the page — `bg-emerald-100 text-emerald-800` / `bg-purple-100 text-purple-800` (6.78:1+).
- Darkens the lime "Mamun" wordmark from `#84cc16` (1.98:1) to `#4d7c0f` (4.99:1).
- Darkens amber character-count warnings from `text-amber-400` (1.67:1) to `text-amber-700` (5.02:1) in `profile/page.tsx` and `UTAboutYouForm.tsx`.

## Testing
- Every new/changed color pairing was verified against its actual background with a WCAG relative-luminance script (target: ≥4.5:1 normal text, ≥3:1 large text/UI components).
- `npx tsc --noEmit` and `npx eslint` run clean after each batch of changes.

## Notes
- Two unrelated one-line copy edits are included in the `31b6013` commit (`edit-profile/page.tsx`, `ProfilePhotoForm.tsx`): removed a claim that "AI will verify it's a real human face," replaced with "Make sure your face is clearly visible in the photo." Not part of the contrast work — appears to have been bundled in pre-existing uncommitted changes at the time of the first commit.
- Two further batches are in progress on this branch but not yet committed: (1) `text-gray-400`/`text-gray-300` fixes on light UT surfaces (`PrivacyPolicyTOC.tsx`, `LocationSelector.tsx`, `AIWriter.tsx`), and (2) cleanup of stray `dark:` Tailwind utilities on light UT pages plus the unused `--foreground` CSS variable. These are intentionally being committed separately per the project's one-batch-per-commit workflow.
