### PR TITLE
UT-25 | Chat callout UX changes + extending text input for multi-line messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5039,15 +5039,12 @@
         "node": ">= 0.4"
       }
     },
-<<<<<<< Updated upstream
-=======
     "node_modules/heic-to": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
       "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
       "license": "LGPL-3.0"
     },
->>>>>>> Stashed changes
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",

--- a/src/app/(general)/messages/[conversationId]/page.tsx
+++ b/src/app/(general)/messages/[conversationId]/page.tsx
@@ -29,6 +29,7 @@ function ConversationPage({ params }: ConversationPageProps) {
   const [sendError, setSendError] = React.useState<string | null>(null);
   const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     params.then((resolvedParams) => {
@@ -47,9 +48,15 @@ function ConversationPage({ params }: ConversationPageProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
+  // Grow the message box to fit its content, up to a max height
+  React.useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [messageInput]);
 
+  const sendCurrentMessage = async () => {
     if (!messageInput.trim() || isSending) return;
 
     setIsSending(true);
@@ -88,6 +95,11 @@ function ConversationPage({ params }: ConversationPageProps) {
     } finally {
       setIsSending(false);
     }
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await sendCurrentMessage();
   };
 
   return (
@@ -168,12 +180,12 @@ function ConversationPage({ params }: ConversationPageProps) {
         {/* Notifications - Always Visible */}
         <div className="space-y-3">
           {/* Privacy Notice */}
-          <div className="rounded-lg border border-white bg-(--charcoal-black) p-3">
-            <div className="mb-2 flex items-center gap-2 text-yellow-400">
+          <div className="rounded-lg border border-blue-500/30 bg-blue-500/20 p-3">
+            <div className="mb-2 flex items-center gap-2 text-blue-400">
               <div className="h-4 w-4 rounded-full bg-blue-500"></div>
               <span className="text-sm font-medium">Privacy Notice</span>
             </div>
-            <p className="text-xs text-white">
+            <p className="text-xs text-blue-300">
               This is a starting point to connect outside of Mamun. Messages are
               not encrypted, so please don&apos;t write any sensitive data in
               the chat.
@@ -290,11 +302,12 @@ function ConversationPage({ params }: ConversationPageProps) {
 
             <form
               onSubmit={handleSendMessage}
-              className="flex items-center gap-3"
+              className="flex items-end gap-3"
             >
               <div className="flex-1">
-                <input
-                  type="text"
+                <textarea
+                  ref={textareaRef}
+                  rows={1}
                   placeholder={
                     messages.length >= 20
                       ? "Message limit reached"
@@ -302,7 +315,13 @@ function ConversationPage({ params }: ConversationPageProps) {
                   }
                   value={messageInput}
                   onChange={(e) => setMessageInput(e.target.value)}
-                  className="w-full rounded-lg border border-white/30 bg-[var(--charcoal-black)] px-4 py-2 text-white placeholder-white/30 transition-colors focus:border-white focus:outline-none"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      sendCurrentMessage();
+                    }
+                  }}
+                  className="max-h-40 w-full resize-none overflow-y-auto rounded-lg border border-white/30 bg-[var(--charcoal-black)] px-4 py-2 text-white placeholder-white/30 transition-colors focus:border-white focus:outline-none"
                   disabled={isSending || messages.length >= 20}
                   maxLength={1000}
                 />
@@ -325,7 +344,7 @@ function ConversationPage({ params }: ConversationPageProps) {
               </button>
             </form>
             <p className="mt-2 text-center text-xs text-white/30">
-              Press Enter or click Send to send your message
+              Press Enter to send, Shift+Enter for a new line
             </p>
           </div>
         </motion.div>

--- a/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
@@ -36,6 +36,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
   const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
   const [showProfile, setShowProfile] = React.useState<boolean>(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     params.then((resolvedParams) => {
@@ -62,9 +63,15 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
+  // Grow the message box to fit its content, up to a max height
+  React.useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [messageInput]);
 
+  const sendCurrentMessage = async () => {
     if (!messageInput.trim() || isSending) return;
 
     setIsSending(true);
@@ -102,6 +109,11 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
     } finally {
       setIsSending(false);
     }
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await sendCurrentMessage();
   };
 
   return (
@@ -200,8 +212,8 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
 
       {/* Notices */}
       <div className="mb-4 space-y-2">
-        <div className="rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] p-3">
-          <p className="text-xs text-[var(--ui-text-muted)]">
+        <div className="rounded-lg border border-blue-300 bg-blue-50 p-3">
+          <p className="text-xs font-medium text-blue-700">
             This is a starting point to connect outside of Mamun. Messages are
             not encrypted, so please don&apos;t share sensitive data here.
           </p>
@@ -286,9 +298,10 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
             />
           </div>
 
-          <form onSubmit={handleSendMessage} className="flex items-center gap-2">
-            <input
-              type="text"
+          <form onSubmit={handleSendMessage} className="flex items-end gap-2">
+            <textarea
+              ref={textareaRef}
+              rows={1}
               placeholder={
                 messages.length >= 20
                   ? "Message limit reached"
@@ -296,7 +309,13 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
               }
               value={messageInput}
               onChange={(e) => setMessageInput(e.target.value)}
-              className="flex-1 rounded-lg border border-[var(--ui-border)] bg-white px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--org-primary)] focus:outline-none"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  sendCurrentMessage();
+                }
+              }}
+              className="max-h-40 flex-1 resize-none overflow-y-auto rounded-lg border border-[var(--ui-border)] bg-white px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--org-primary)] focus:outline-none"
               disabled={isSending || messages.length >= 20}
               maxLength={1000}
             />


### PR DESCRIPTION
## Summary
This PR upgrades the message composer on both the general and school conversation pages from a single-line `<input>` to an auto-growing `<textarea>`, so users can write multi-line messages without losing the ability to send with Enter. It also fixes a corrupted `package-lock.json` that had leftover Git conflict markers from a stash/upstream merge, which was causing JSON parsing errors (e.g. on `npm install`).

## Changes

### Messages — expanding textarea
- Replace `<input type="text">` with `<textarea rows={1}>` in both `src/app/(general)/messages/[conversationId]/page.tsx` and `src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx`, using a `textareaRef` plus a `React.useEffect` keyed on `messageInput` that resets `el.style.height` to `"auto"` and then sets it to `Math.min(el.scrollHeight, 160)}px` so the box grows with content but caps out (`max-h-40`, `resize-none`, `overflow-y-auto` handle the visual clamp/scroll).
- Extract the send logic out of `handleSendMessage` into a standalone `sendCurrentMessage` async function so it can be triggered both from form submit and from a keyboard handler without needing a synthetic form event.
- Add an `onKeyDown` handler on the textarea that intercepts `Enter` (without `Shift`) to call `sendCurrentMessage()` directly and `e.preventDefault()`s the default newline insertion, preserving `Shift+Enter` for inserting a literal line break.
- Update the form's flex alignment from `items-center` to `items-end` so the Send button stays anchored to the bottom of the input as it grows, and change the helper caption from "Press Enter or click Send to send your message" to "Press Enter to send, Shift+Enter for a new line" to match the new behavior.
- Restyle the privacy/notice banner on both pages (blue-tinted border/background/text on the general page; `blue-300`/`blue-50`/`blue-700` on the school page) — a visual cleanup unrelated to the textarea change but bundled in the same touch of these files.

### Build — package-lock.json
- Remove leftover `<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes` conflict markers around the `node_modules/heic-to` entry in `package-lock.json`. These markers made the file invalid JSON, breaking tooling that parses the lockfile (npm install, CI, etc.). The `heic-to` dependency entry itself is retained.

## Testing
- No automated tests included; changes are UI behavior (textarea growth/Enter-to-send) and a lockfile fix.

## Notes
- The notice-banner color changes are cosmetic and bundled with the textarea work rather than being a separate concern — worth calling out in review if they should have been split out.
