### PR TITLE
UT-32 | Expand selectable colleges/schools + areas of interests

### DIFF
--- a/src/features/school/components/landing/DepartmentMosaic.tsx
+++ b/src/features/school/components/landing/DepartmentMosaic.tsx
@@ -103,6 +103,78 @@ const TIER_2: Dept[] = [
       { label: "BioTech", bg: "#fdecea", fg: "#922b21" },
     ],
   },
+  {
+    name: "Jackson Geosciences",
+    programs: "Geo Sciences · Env Sci · Energy & Earth Resources",
+    accent: "#ca8a04",
+    chips: [
+      { label: "CleanTech", bg: "#fdf6e3", fg: "#a16207" },
+      { label: "DeepTech", bg: "#fdf6e3", fg: "#a16207" },
+    ],
+  },
+  {
+    name: "Civic Leadership",
+    programs: "BS Civic Leadership",
+    accent: "#4b3f8f",
+    chips: [
+      { label: "Policy", bg: "#eeecf9", fg: "#4b3f8f" },
+      { label: "GovTech", bg: "#eeecf9", fg: "#4b3f8f" },
+    ],
+  },
+  {
+    name: "Education",
+    programs: "Applied Learning · STEM Ed · Youth & Community Studies",
+    accent: "#0f766e",
+    chips: [
+      { label: "EdTech", bg: "#e6f4f3", fg: "#0f766e" },
+      { label: "Impact", bg: "#e6f4f3", fg: "#0f766e" },
+    ],
+  },
+  {
+    name: "Nursing",
+    programs: "BSN · MSN · DNP",
+    accent: "#059669",
+    chips: [
+      { label: "HealthTech", bg: "#e5f5ef", fg: "#059669" },
+      { label: "BioTech", bg: "#e5f5ef", fg: "#059669" },
+    ],
+  },
+  {
+    name: "Pharmacy",
+    programs: "PharmD · Pharmaceutical Sciences",
+    accent: "#7c3aed",
+    chips: [
+      { label: "HealthTech", bg: "#f1eafd", fg: "#7c3aed" },
+      { label: "BioTech", bg: "#f1eafd", fg: "#7c3aed" },
+    ],
+  },
+  {
+    name: "Social Work",
+    programs: "BSW · MSSW",
+    accent: "#65a30d",
+    chips: [
+      { label: "Impact", bg: "#f0f6e3", fg: "#65a30d" },
+      { label: "Policy", bg: "#f0f6e3", fg: "#65a30d" },
+    ],
+  },
+  {
+    name: "Law",
+    programs: "JD · LLM",
+    accent: "#57534e",
+    chips: [
+      { label: "Policy", bg: "#eeece9", fg: "#57534e" },
+      { label: "GovTech", bg: "#eeece9", fg: "#57534e" },
+    ],
+  },
+  {
+    name: "Pre-Med, Pre-Law & Teaching",
+    programs: "Pre-Med · Pre-Law · Pre-Teaching",
+    accent: "#0284c7",
+    chips: [
+      { label: "HealthTech", bg: "#e5f3fb", fg: "#0284c7" },
+      { label: "EdTech", bg: "#e5f3fb", fg: "#0284c7" },
+    ],
+  },
 ];
 
 function Card({ dept }: { dept: Dept }) {
@@ -173,7 +245,7 @@ export default function DepartmentMosaic() {
           className="mb-10 text-center text-sm"
           style={{ color: "#5f7280" }}
         >
-          Founders from across every corner of the University of Texas — 10 schools, one
+          Founders from across every corner of the University of Texas — 18 schools, one
           platform, one mission.
         </p>
 

--- a/src/features/school/components/landing/WhyItWorks.tsx
+++ b/src/features/school/components/landing/WhyItWorks.tsx
@@ -13,6 +13,14 @@ const SCHOOLS = [
   { name: "Architecture", role: "Space · Systems", color: "#333f48" },
   { name: "LBJ", role: "Public Affairs", color: "#9cadb7" },
   { name: "Dell Medical", role: "Health · Clinical", color: "#c0392b" },
+  { name: "Jackson Geosciences", role: "Geosciences · Energy", color: "#ca8a04" },
+  { name: "Civic Leadership", role: "Leadership · Policy", color: "#4b3f8f" },
+  { name: "Education", role: "Education · Impact", color: "#0f766e" },
+  { name: "Nursing", role: "Health · Care", color: "#059669" },
+  { name: "Pharmacy", role: "Pharma · Health", color: "#7c3aed" },
+  { name: "Social Work", role: "Social Work · Impact", color: "#65a30d" },
+  { name: "Law", role: "Law · Policy", color: "#57534e" },
+  { name: "Pre-Professional", role: "Pre-Med · Pre-Law · Teaching", color: "#0284c7" },
 ];
 
 const container = {
@@ -74,7 +82,7 @@ export default function WhyItWorks() {
         >
           An engineer who can&apos;t sell. A business student with no one to
           build. A designer working alone. The matching engine reaches across all
-          10 schools and assembles the team none of them could find on their own.
+          18 schools and assembles the team none of them could find on their own.
         </motion.p>
       </div>
 
@@ -94,7 +102,7 @@ export default function WhyItWorks() {
             className="text-[9px] font-bold tracking-widest uppercase text-center mb-3"
             style={{ color: "#5f7280" }}
           >
-            10 UT Schools · One pool
+            18 UT Schools · One pool
           </p>
           <div className="grid grid-cols-2 gap-x-5 gap-y-3">
             {SCHOOLS.map((s) => (

--- a/src/features/school/data/utSchoolsAndMajors.ts
+++ b/src/features/school/data/utSchoolsAndMajors.ts
@@ -19,7 +19,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Finance', abbreviation: 'MFinance' },
       { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
     ] as const,
-    sectorInterests: ['b2b_saas', 'fintech'] as const,
   },
   cockrell_engineering: {
     label: 'Cockrell Engineering',
@@ -33,7 +32,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Biomedical Engineering', abbreviation: 'Biomedical' },
       { degreeType: 'bachelors', name: 'Chemical Engineering', abbreviation: 'ChE' },
     ] as const,
-    sectorInterests: ['ai_ml', 'deeptech'] as const,
   },
   school_of_information: {
     label: 'School of Information',
@@ -46,7 +44,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Human-Computer Interaction', abbreviation: 'HCI' },
       { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
     ] as const,
-    sectorInterests: ['data', 'ux'] as const,
   },
   natural_sciences: {
     label: 'Natural Sciences',
@@ -58,7 +55,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Chemistry', abbreviation: 'Chemistry' },
       { degreeType: 'bachelors', name: 'Neuroscience', abbreviation: 'Neuroscience' },
     ] as const,
-    sectorInterests: ['healthtech', 'biotech'] as const,
   },
   liberal_arts: {
     label: 'Liberal Arts',
@@ -70,7 +66,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Government', abbreviation: 'Government' },
       { degreeType: 'bachelors', name: 'Plan II Honors', abbreviation: 'Plan II' },
     ] as const,
-    sectorInterests: ['policy', 'impact'] as const,
   },
   moody_communication: {
     label: 'Moody Communication',
@@ -83,7 +78,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Public Relations', abbreviation: 'PR' },
       { degreeType: 'bachelors', name: 'Radio-Television-Film', abbreviation: 'RTF' },
     ] as const,
-    sectorInterests: ['media', 'consumer'] as const,
   },
   college_of_fine_arts: {
     label: 'College of Fine Arts',
@@ -96,7 +90,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Music', abbreviation: 'Music' },
       { degreeType: 'bachelors', name: 'Theatre', abbreviation: 'Theatre' },
     ] as const,
-    sectorInterests: ['edtech', 'consumer'] as const,
   },
   school_of_architecture: {
     label: 'School of Architecture',
@@ -108,7 +101,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Architecture', abbreviation: 'MArch' },
       { degreeType: 'masters', name: 'Urban Design', abbreviation: 'Urban Design' },
     ] as const,
-    sectorInterests: ['proptech', 'cleantech'] as const,
   },
   lbj_public_affairs: {
     label: 'LBJ Public Affairs',
@@ -120,7 +112,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Global Policy', abbreviation: 'Global Policy' },
       { degreeType: 'professional', name: 'Juris Doctor / Public Affairs', abbreviation: 'JD/MPAff' },
     ] as const,
-    sectorInterests: ['govtech', 'impact'] as const,
   },
   dell_medical_school: {
     label: 'Dell Medical School',
@@ -132,7 +123,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'professional', name: 'Doctor of Medicine / Doctor of Philosophy', abbreviation: 'MD/PhD' },
       { degreeType: 'masters', name: 'Health Innovation', abbreviation: 'Health Innovation' },
     ] as const,
-    sectorInterests: ['healthtech', 'biotech'] as const,
   },
 } as const;
 
@@ -183,12 +173,6 @@ export const getProgramsForSchoolAndDegreeType = (
   return getProgramsForSchool(school).filter(
     p => p.degreeType === degreeType,
   );
-};
-
-export const getSectorInterestsForSchool = (
-  school: UTCollege,
-): readonly UTSectorInterest[] => {
-  return UT_SCHOOLS_AND_PROGRAMS[school].sectorInterests;
 };
 
 export const getSchoolLabel = (school: UTCollege): string => {

--- a/src/features/school/data/utSchoolsAndMajors.ts
+++ b/src/features/school/data/utSchoolsAndMajors.ts
@@ -124,6 +124,90 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Health Innovation', abbreviation: 'Health Innovation' },
     ] as const,
   },
+  jackson_geosciences: {
+    label: 'Jackson Geosciences',
+    fullName: 'Jackson School of Geosciences',
+    tier: 'partner',
+    color: 'from-yellow-600 to-yellow-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Geological Sciences', abbreviation: 'Geo Sciences' },
+      { degreeType: 'bachelors', name: 'Environmental Science', abbreviation: 'Env Sci' },
+      { degreeType: 'masters', name: 'Energy and Earth Resources', abbreviation: 'Energy & Earth Resources' },
+    ] as const,
+  },
+  school_of_civic_leadership: {
+    label: 'Civic Leadership',
+    fullName: 'School of Civic Leadership',
+    tier: 'partner',
+    color: 'from-indigo-600 to-indigo-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Civic Leadership', abbreviation: 'BS Civic Leadership' },
+    ] as const,
+  },
+  college_of_education: {
+    label: 'Education',
+    fullName: 'College of Education',
+    tier: 'partner',
+    color: 'from-teal-600 to-teal-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Applied Learning & Development', abbreviation: 'ALD' },
+      { degreeType: 'bachelors', name: 'STEM Education', abbreviation: 'STEM Ed' },
+      { degreeType: 'bachelors', name: 'Youth & Community Studies', abbreviation: 'YCS' },
+      { degreeType: 'masters', name: 'Curriculum & Instruction', abbreviation: 'M.Ed.' },
+    ] as const,
+  },
+  school_of_nursing: {
+    label: 'Nursing',
+    fullName: 'School of Nursing',
+    tier: 'partner',
+    color: 'from-emerald-600 to-emerald-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Nursing', abbreviation: 'BSN' },
+      { degreeType: 'masters', name: 'Nursing', abbreviation: 'MSN' },
+      { degreeType: 'professional', name: 'Doctor of Nursing Practice', abbreviation: 'DNP' },
+    ] as const,
+  },
+  college_of_pharmacy: {
+    label: 'Pharmacy',
+    fullName: 'College of Pharmacy',
+    tier: 'partner',
+    color: 'from-violet-600 to-violet-700',
+    programs: [
+      { degreeType: 'professional', name: 'Doctor of Pharmacy', abbreviation: 'PharmD' },
+      { degreeType: 'masters', name: 'Pharmaceutical Sciences', abbreviation: 'Pharm Sci' },
+    ] as const,
+  },
+  school_of_social_work: {
+    label: 'Social Work',
+    fullName: 'School of Social Work',
+    tier: 'partner',
+    color: 'from-lime-600 to-lime-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Social Work', abbreviation: 'BSW' },
+      { degreeType: 'masters', name: 'Social Work', abbreviation: 'MSSW' },
+    ] as const,
+  },
+  school_of_law: {
+    label: 'Law',
+    fullName: 'School of Law',
+    tier: 'partner',
+    color: 'from-stone-600 to-stone-700',
+    programs: [
+      { degreeType: 'professional', name: 'Juris Doctor', abbreviation: 'JD' },
+      { degreeType: 'masters', name: 'Law', abbreviation: 'LLM' },
+    ] as const,
+  },
+  pre_med_pre_law_teaching: {
+    label: 'Pre-Med, Pre-Law & Teaching',
+    fullName: 'Pre-Med, Pre-Law & Teaching',
+    tier: 'partner',
+    color: 'from-sky-600 to-sky-700',
+    programs: [
+      { degreeType: 'other', name: 'Pre-Med', abbreviation: 'Pre-Med' },
+      { degreeType: 'other', name: 'Pre-Law', abbreviation: 'Pre-Law' },
+      { degreeType: 'other', name: 'Pre-Teaching', abbreviation: 'Pre-Teaching' },
+    ] as const,
+  },
 } as const;
 
 export const DEGREE_TYPE_LABELS: Record<DegreeType, string> = {

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -156,7 +156,7 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
             Select relevant sectors aligned with your program
           </p>
           <div className="flex flex-wrap gap-2">
-            {UT_SCHOOLS_AND_PROGRAMS[utCollegeValue].sectorInterests.map((sector) => (
+            {(Object.keys(SECTOR_INTEREST_LABELS) as UTSectorInterest[]).map((sector) => (
               <label
                 key={sector}
                 className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-all duration-150 ${

--- a/src/features/school/types.d.ts
+++ b/src/features/school/types.d.ts
@@ -44,7 +44,15 @@ declare global {
     | "college_of_fine_arts"
     | "school_of_architecture"
     | "lbj_public_affairs"
-    | "dell_medical_school";
+    | "dell_medical_school"
+    | "school_of_civic_leadership"
+    | "college_of_education"
+    | "school_of_nursing"
+    | "college_of_pharmacy"
+    | "school_of_social_work"
+    | "school_of_law"
+    | "pre_med_pre_law_teaching"
+    | "jackson_geosciences";
 
   type UTDegreeType = "bachelors" | "masters" | "professional" | "other";
 


### PR DESCRIPTION
## Summary
Expands UT Austin's selectable colleges/schools from 10 to 18 (all real UT schools per the official catalog, plus a custom "Pre-Med, Pre-Law & Teaching" grouping for pre-professional tracks), and unifies the "Areas of Interest" picker so every college now offers the same full sector list instead of a curated 2-sector subset. New schools were fact-checked against UT Austin's official academic units listing to ensure nothing else was missing.

## Changes

### Schools & departments data
- `src/features/school/data/utSchoolsAndMajors.ts` — added 8 new entries to `UT_SCHOOLS_AND_PROGRAMS`: Jackson School of Geosciences, School of Civic Leadership, College of Education, School of Nursing, College of Pharmacy, School of Social Work, School of Law, and Pre-Med/Pre-Law & Teaching, each with representative `programs` (degree type, name, abbreviation) matching the existing entry shape.
- `src/features/school/types.d.ts` — extended the `UTCollege` union with the 8 new keys so TypeScript enforces that the type and the data object stay in sync.
- Onboarding (`UTSchoolFields.tsx`) and edit-profile (same component, reused in `profile/page.tsx`) both build their school dropdown via `Object.entries(UT_SCHOOLS_AND_PROGRAMS)`, so the new colleges appear in both flows automatically with no additional code changes — same for the dashboard filter, search-query parser, and cohort reporting, which all iterate the object generically.

### Landing page
- `DepartmentMosaic.tsx` ("Who's building here" section) hardcodes its own department cards rather than deriving from the shared data object (pre-existing pattern) — added matching cards for all 8 new schools to `TIER_2` with distinct accent colors/chips, and updated the subhead from "10 schools" to "18 schools".
- `WhyItWorks.tsx` ("Why it works" flow diagram) has a second, independent hardcoded `SCHOOLS` list — added the same 8 schools with short role tags and colors, and updated both the "10 schools" body copy and the "10 UT Schools · One pool" panel label to 18.

### Areas of interest
- `UTSchoolFields.tsx` — the "Areas of Interest" checkboxes now render every sector in `SECTOR_INTEREST_LABELS` for any selected college, instead of a college-specific 2-sector subset.
- `utSchoolsAndMajors.ts` — removed the now-unused per-college `sectorInterests` field from every entry and deleted the `getSectorInterestsForSchool` helper.

## Testing
- `npx tsc --noEmit` — passes with no errors, confirming the `UTCollege` union and `UT_SCHOOLS_AND_PROGRAMS` object keys stay in sync.
- Started the dev server and fetched the rendered `/school/ut` HTML directly: confirmed all 18 school names appear in both the `DepartmentMosaic` and `WhyItWorks` sections, and "18 schools" / "18 UT Schools" copy is present.
- Onboarding and profile-edit dropdowns are Clerk-auth-gated in this environment and weren't manually clicked through; they consume the same shared data object generically, so the update should propagate automatically — a manual pass is still recommended before merge.

## Notes
- The department list remains duplicated in three independent places (`utSchoolsAndMajors.ts`, `DepartmentMosaic.tsx`, `WhyItWorks.tsx`) with no shared source of truth for the landing-page copies — pre-existing tech debt, not introduced here. Adding a future school still requires updating all three by hand.
- "Pre-Med, Pre-Law & Teaching" is not an accredited UT Austin school (those are advising tracks inside other colleges) but was added as its own selectable entry at the requester's direction.
