### PR TITLE
UT-20 | Fix dropdown colors + add search bar toggle

### DIFF
--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -30,7 +30,7 @@ const TEXTAREA_CLS =
   "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -183,6 +183,12 @@ function SearchResultCard({
 export default function SchoolDashboardPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const toggleSearch = () => {
+    setSearchOpen((prev) => {
+      if (prev) setSearchQuery("");
+      return !prev;
+    });
+  };
   const [filters, setFilters] = useState<DashboardFilters>(EMPTY_DASHBOARD_FILTERS);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [viewingUserId, setViewingUserId] = useState<string | null>(null);
@@ -312,11 +318,16 @@ export default function SchoolDashboardPage() {
           <IoFilterOutline className="h-4 w-4" />
         </button>
         <button
-          onClick={() => setSearchOpen(true)}
+          onClick={toggleSearch}
           className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] hover:bg-[#ffe8d6] transition cursor-pointer"
-          aria-label="Open search"
+          aria-expanded={searchOpen}
+          aria-label={searchOpen ? "Close search" : "Open search"}
         >
-          <IoSearchOutline className="h-4 w-4" />
+          {searchOpen ? (
+            <IoCloseOutline className="h-4 w-4" />
+          ) : (
+            <IoSearchOutline className="h-4 w-4" />
+          )}
         </button>
       </div>
     </div>
@@ -414,7 +425,7 @@ export default function SchoolDashboardPage() {
             className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#a34800] outline-none"
           />
           <button
-            onClick={() => { setSearchQuery(""); setSearchOpen(false); }}
+            onClick={toggleSearch}
             className="flex-shrink-0 text-[#BF5700] hover:text-[#8a3d00] cursor-pointer"
           >
             <IoCloseOutline className="h-4 w-4" />

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -20,7 +20,7 @@ const LABEL_CLS =
   "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 type UTSchoolFieldsData = {
   utStatus: "student" | "alumni";

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -21,7 +21,7 @@ const TEXTAREA_CLS =
   "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 


### PR DESCRIPTION
## Summary
Small UI polish PR covering two unrelated fixes: dropdown `<option>` elements were using hardcoded dark colors that didn't adapt to the app's theme system, and the dashboard search bar had no way to close once opened except clearing text. Both are cosmetic/UX fixes with no logic or data changes.

## Changes

### Dropdown theming
- `StartupForm.tsx` and `UTStartupForm.tsx`: Replace hardcoded `[&>option]:bg-neutral-900` with theme-aware `[&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]`, so `<option>` items follow the active light/dark theme instead of always rendering as a dark dropdown regardless of the surrounding UI.
- `UTSchoolFields.tsx`: Adds the same `[&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]` styling to its select, which previously had no explicit option styling at all (relying on inconsistent browser/OS defaults).

### Search bar close toggle
- `src/app/(school)/school/[slug]/dashboard/page.tsx`: Introduces a `toggleSearch` handler that flips `searchOpen` and clears `searchQuery` when closing, replacing the previous one-way `onClick={() => setSearchOpen(true)}` open handler and a separate inline close handler with a single shared toggle used by both the trigger button and the close (X) button inside the expanded search bar.
- The trigger button now swaps its icon between `IoSearchOutline` and `IoCloseOutline` based on `searchOpen`, and adds `aria-expanded`/dynamic `aria-label` ("Open search" / "Close search") so the control's state is exposed to assistive tech — previously the icon and label were static regardless of open state.

## Testing
- No automated tests included; changes are visual/interaction-only (dropdown coloring, search toggle state).

## Notes
None.
