### PR TITLE
UT Onboarding Sign Up Fixes

### DIFF
--- a/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
+++ b/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
@@ -34,10 +34,12 @@ const PILL_RADIO_CLS =
 function AboutYouForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: AboutYouData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<AboutYouData>) => void;
   defaultValues?: Partial<AboutYouData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -50,6 +52,7 @@ function AboutYouForm({
     reset,
     watch,
     setValue,
+    getValues,
   } = useForm<AboutYouData>({ defaultValues });
 
   const titleValue = watch("title") || "";
@@ -409,6 +412,15 @@ function AboutYouForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
+++ b/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
@@ -25,10 +25,12 @@ const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-mut
 function BackgroundAndSocialsForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: BackgroundAndSocialsData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<BackgroundAndSocialsData>) => void;
   defaultValues?: Partial<BackgroundAndSocialsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -39,6 +41,7 @@ function BackgroundAndSocialsForm({
     handleSubmit,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<BackgroundAndSocialsData>({ defaultValues });
 
@@ -174,6 +177,15 @@ function BackgroundAndSocialsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
+++ b/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
@@ -14,10 +14,12 @@ const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-mut
 function InterestsAndValuesForm({
   onBack,
   onNext,
+  onManualSave,
   defaultValues,
 }: {
   onBack: () => void;
   onNext: (data: InterestsAndValuesFormData) => void;
+  onManualSave?: (data: Partial<InterestsAndValuesFormData>) => void;
   defaultValues?: Partial<InterestsAndValuesFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -46,6 +48,7 @@ function InterestsAndValuesForm({
     reset,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<InterestsAndValuesFormData>({ defaultValues });
 
@@ -74,12 +77,18 @@ function InterestsAndValuesForm({
     if (errCount > 0) triggerShake();
   }, [errCount, triggerShake]);
 
-  const onSubmit = (data: InterestsAndValuesFormData) => {
-    const mergedPriorityAreas = [
+  const withOtherPriority = (
+    data: InterestsAndValuesFormData,
+  ): InterestsAndValuesFormData => ({
+    ...data,
+    priorityAreas: [
       ...(data.priorityAreas || []),
       ...(showOtherInput && otherPriority ? [otherPriority] : []),
-    ];
-    onNext({ ...data, priorityAreas: mergedPriorityAreas });
+    ],
+  });
+
+  const onSubmit = (data: InterestsAndValuesFormData) => {
+    onNext(withOtherPriority(data));
   };
 
   return (
@@ -199,6 +208,15 @@ function InterestsAndValuesForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(withOtherPriority(getValues()))}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -40,10 +40,12 @@ const PILL_RADIO_CLS =
 function StartupForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: StartupFormData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<StartupFormData>) => void;
   defaultValues?: Partial<StartupFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -55,6 +57,7 @@ function StartupForm({
     control,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<StartupFormData>({ defaultValues });
 
@@ -289,6 +292,15 @@ function StartupForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(school)/school/[slug]/page.tsx
+++ b/src/app/(school)/school/[slug]/page.tsx
@@ -88,14 +88,14 @@ export default async function SchoolLanding({
 
       <div className="flex flex-col items-center gap-3 sm:flex-row">
         <Link
-          href="/sign-up"
+          href={`/school/${slug}/sign-up`}
           className="rounded-lg px-6 py-3 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: branding.primaryColor }}
         >
           {landing.ctaPrimaryLabel}
         </Link>
         <Link
-          href="/sign-in"
+          href={`/school/${slug}/sign-in`}
           className="rounded-lg border px-6 py-3 text-sm font-semibold transition-colors hover:bg-black/5"
           style={{
             borderColor: branding.accentColor,

--- a/src/app/(school)/school/[slug]/reset-password/[[...reset-password]]/page.tsx
+++ b/src/app/(school)/school/[slug]/reset-password/[[...reset-password]]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
+import SchoolResetPassword from "@/features/school/components/auth/SchoolResetPassword";
+
+export default async function SchoolResetPasswordPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ email?: string; redirect?: string }>;
+}) {
+  const { slug } = await params;
+  const { email, redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
+  const org = await getOrganizationBySlug(slug);
+  if (!org) notFound();
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-12">
+      <SchoolResetPassword
+        slug={org.slug}
+        schoolName={org.name}
+        allowedDomains={org.allowed_email_domains ?? []}
+        initialEmail={email ?? ""}
+        afterAuthRedirect={redirectParam ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/(school)/school/[slug]/sso-complete/page.tsx
+++ b/src/app/(school)/school/[slug]/sso-complete/page.tsx
@@ -21,7 +21,8 @@ export default async function SSOCompletePage({
 
   const org = await getOrganizationBySlug(slug);
   if (!org) {
-    redirect("/");
+    console.error("sso-complete: org lookup failed for slug", slug);
+    return <AutoRetry />;
   }
 
   const clerk = await clerkClient();

--- a/src/components/forms/CreateProfile.tsx
+++ b/src/components/forms/CreateProfile.tsx
@@ -10,6 +10,7 @@ import OnboardingProgressBar from "@/components/ui/OnboardingProgressBar";
 import { useOnboardingDraft } from "@/hooks/useOnboardingDraft";
 import { useStepTransition } from "@/hooks/useOnboardingAnimation";
 import React, { useState, useEffect } from "react";
+import toast from "react-hot-toast";
 
 type CreateProfileProps = {
   onSubmit: (
@@ -127,6 +128,17 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
     goToStep(stepNumber - 1, "back");
   };
 
+  const handleManualSave = (stepData: Partial<OnboardingData>) => {
+    const merged = { ...formData, ...stepData };
+    setFormData(merged);
+    const ok = draft.save(stepNumber, merged);
+    if (ok) {
+      toast.success("Progress saved");
+    } else {
+      toast.error("Couldn't save — your browser storage may be full or disabled");
+    }
+  };
+
   const handleEditStep = (step: number) => {
     goToStep(step, step < stepNumber ? "back" : "forward");
   };
@@ -178,6 +190,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <AboutYouForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 3)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -185,6 +198,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <StartupForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 4)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -192,6 +206,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <BackgroundAndSocialsForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 5)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -199,6 +214,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <InterestsAndValuesForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 6)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}

--- a/src/features/profile/services/onboardingProfile.ts
+++ b/src/features/profile/services/onboardingProfile.ts
@@ -5,6 +5,7 @@ import {
   mapSchoolProfileToUTData,
   mapUTDataToSchoolProfileRow,
 } from "@/lib/mapProfileToFromDBFormat";
+import { deriveUtStatus } from "@/features/school/onboarding/deriveUtStatus";
 
 // Shared onboarding-profile service used by the unified /api/profile endpoint
 // (and its deprecated /api/ut-profile alias). A user's school membership is
@@ -84,6 +85,13 @@ export async function saveOnboardingProfile({
       status: 400,
       error: "utStatus is required for school profiles",
     };
+  }
+
+  // A self-reported "student" whose graduation year has already passed is
+  // actually alumni — correct it here so the DB stays right even if a client
+  // bug (or a direct API call) submits a stale/inconsistent utStatus.
+  if (isSchool) {
+    formData = { ...formData, utStatus: deriveUtStatus(formData.utStatus, formData.gradYear) };
   }
 
   const supabase = serviceRoleClient();

--- a/src/features/school/components/auth/SchoolResetPassword.tsx
+++ b/src/features/school/components/auth/SchoolResetPassword.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth, useSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  isEmailDomainAllowed,
+  formatAllowedDomainsForCopy,
+} from "@/features/school/auth/email-domain";
+import {
+  checkExistingUser,
+  type ExistingUserInfo,
+} from "@/features/school/auth/school-auth";
+import { completeSchoolSignIn } from "./complete-school-signin";
+
+type Props = {
+  slug: string;
+  schoolName: string;
+  allowedDomains: string[];
+  initialEmail?: string;
+  afterAuthRedirect?: string | null;
+};
+
+/** Pull Clerk's first error message off a thrown error, with a fallback. */
+function clerkErrorMessage(err: unknown, fallback: string): string {
+  if (
+    err &&
+    typeof err === "object" &&
+    "errors" in err &&
+    Array.isArray((err as { errors: { message: string }[] }).errors)
+  ) {
+    return (
+      (err as { errors: { message: string }[] }).errors[0]?.message ?? fallback
+    );
+  }
+  return fallback;
+}
+
+export default function SchoolResetPassword({
+  slug,
+  schoolName,
+  allowedDomains,
+  initialEmail = "",
+  afterAuthRedirect = null,
+}: Props) {
+  const { isLoaded, signIn, setActive } = useSignIn();
+  const { getToken } = useAuth();
+  const router = useRouter();
+
+  const [email, setEmail] = useState(initialEmail);
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [secondFactorCode, setSecondFactorCode] = useState("");
+  // Flow phases: "request" → "reset" → (optional) "secondFactor".
+  const [pendingReset, setPendingReset] = useState(false);
+  const [pendingSecondFactor, setPendingSecondFactor] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [existingUser, setExistingUser] = useState<ExistingUserInfo>({
+    exists: false,
+    hasPassword: false,
+    oauthProviders: [],
+  });
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const allowedCopy = formatAllowedDomainsForCopy(allowedDomains);
+  const existingHasGoogle = existingUser.oauthProviders.includes("oauth_google");
+  // A Google-only account has no password to reset — steer them back to Google.
+  const isGoogleOnly =
+    existingUser.exists && existingHasGoogle && !existingUser.hasPassword;
+
+  useEffect(() => {
+    if (pendingReset) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setExistingUser({ exists: false, hasPassword: false, oauthProviders: [] });
+    const trimmed = email.trim();
+    if (!trimmed || !isEmailDomainAllowed(trimmed, allowedDomains)) return;
+    debounceRef.current = setTimeout(async () => {
+      const info = await checkExistingUser(trimmed);
+      setExistingUser(info);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [email, allowedDomains, pendingReset]);
+
+  async function finish(sessionId: string | null) {
+    // setActive is guaranteed defined here: reached only after `isLoaded`.
+    const { error: assignError } = await completeSchoolSignIn({
+      setActive: setActive!,
+      getToken,
+      router,
+      slug,
+      sessionId,
+      afterAuthRedirect,
+    });
+    if (assignError) setError(assignError);
+  }
+
+  async function handleRequest(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (!isEmailDomainAllowed(email, allowedDomains)) {
+      setError(
+        `This portal is for ${schoolName}. Sign in at mamuncofoundr.com instead, or use a ${allowedCopy} email.`,
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await signIn.create({
+        strategy: "reset_password_email_code",
+        identifier: email,
+      });
+      setPendingReset(true);
+    } catch (err: unknown) {
+      setError(
+        clerkErrorMessage(
+          err,
+          "We couldn't send a reset code. Please try again.",
+        ),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleReset(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords don't match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await signIn.attemptFirstFactor({
+        strategy: "reset_password_email_code",
+        code,
+        password,
+      });
+
+      if (result.status === "complete") {
+        await finish(result.createdSessionId);
+        return;
+      }
+
+      // Account-level MFA can require a second factor after the reset. Mirror
+      // SchoolSignIn's email_code handling. The installed @clerk/types predates
+      // email_code as a typed second factor, hence the casts.
+      if (result.status === "needs_second_factor") {
+        const factors = (result.supportedSecondFactors ??
+          []) as unknown as Array<{
+          strategy: string;
+          emailAddressId?: string;
+        }>;
+        const emailFactor = factors.find((f) => f.strategy === "email_code");
+        if (emailFactor) {
+          await signIn.prepareSecondFactor({
+            strategy: "email_code",
+            emailAddressId: emailFactor.emailAddressId,
+          } as never);
+          setPendingSecondFactor(true);
+        } else {
+          setError(
+            "Additional verification is required. Please contact support.",
+          );
+        }
+        return;
+      }
+
+      setError("We couldn't reset your password. Please try again.");
+    } catch (err: unknown) {
+      setError(clerkErrorMessage(err, "Invalid or expired code. Try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleVerifySecondFactor(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const attempt = await signIn.attemptSecondFactor({
+        strategy: "email_code",
+        code: secondFactorCode,
+      } as never);
+      if (attempt.status === "complete") {
+        await finish(attempt.createdSessionId);
+      } else {
+        setError("Verification could not be completed. Please try again.");
+      }
+    } catch (err: unknown) {
+      setError(clerkErrorMessage(err, "Invalid code. Please try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const heading = pendingSecondFactor
+    ? "Verify it's you"
+    : pendingReset
+      ? "Check your email"
+      : "Reset your password";
+  const subtitle = pendingSecondFactor
+    ? `We sent a verification code to ${email}.`
+    : pendingReset
+      ? `We sent a 6-digit code to ${email}. Enter it with a new password.`
+      : `Enter your ${allowedCopy} email and we'll send a reset code.`;
+
+  const inputClass =
+    "w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20";
+  const codeInputClass =
+    "w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-base tracking-[0.5em] outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20";
+  const labelClass = "mb-1 block text-xs font-medium";
+  const buttonClass =
+    "w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50";
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-2xl border border-[#e8e4dc] bg-white p-8 shadow-sm">
+        <div className="mb-6">
+          <h1
+            className="mb-1 text-xl font-semibold tracking-tight md:text-2xl"
+            style={{ color: "#333f48" }}
+          >
+            {heading}
+          </h1>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
+            {subtitle}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {pendingSecondFactor ? (
+          <form onSubmit={handleVerifySecondFactor} className="space-y-4">
+            <div>
+              <label
+                htmlFor="sf-code"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Verification code
+              </label>
+              <input
+                id="sf-code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                value={secondFactorCode}
+                onChange={(e) => setSecondFactorCode(e.target.value)}
+                className={codeInputClass}
+                maxLength={6}
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className={buttonClass}
+            >
+              {submitting ? "Verifying…" : "Verify and continue"}
+            </button>
+          </form>
+        ) : pendingReset ? (
+          <form onSubmit={handleReset} className="space-y-4">
+            <div>
+              <label
+                htmlFor="code"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Reset code
+              </label>
+              <input
+                id="code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className={codeInputClass}
+                maxLength={6}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="new-password"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                New password
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={inputClass}
+                minLength={8}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="confirm-password"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Confirm new password
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={inputClass}
+                minLength={8}
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className={buttonClass}
+            >
+              {submitting ? "Resetting…" : "Reset password"}
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handleRequest} className="space-y-4">
+            <div>
+              <label
+                htmlFor="email"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                School email
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@utexas.edu"
+                className={inputClass}
+                required
+              />
+              {isGoogleOnly && (
+                <p className="mt-1.5 text-xs" style={{ color: "#7a3a00" }}>
+                  This account uses Google sign-in, so there&apos;s no password
+                  to reset.{" "}
+                  <Link
+                    href={`/school/${slug}/sign-in`}
+                    className="font-semibold hover:underline"
+                    style={{ color: "#bf5700" }}
+                  >
+                    Go to sign in
+                  </Link>
+                  .
+                </p>
+              )}
+            </div>
+
+            <div id="clerk-captcha" />
+
+            {!isGoogleOnly && (
+              <button
+                type="submit"
+                disabled={submitting || !isLoaded}
+                className={buttonClass}
+              >
+                {submitting ? "Sending code…" : "Send reset code"}
+              </button>
+            )}
+          </form>
+        )}
+
+        <div
+          className="mt-6 border-t pt-4 text-center text-xs"
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
+        >
+          Remember your password?{" "}
+          <Link
+            href={`/school/${slug}/sign-in`}
+            className="font-semibold hover:underline"
+            style={{ color: "#bf5700" }}
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -9,10 +9,10 @@ import {
   formatAllowedDomainsForCopy,
 } from "@/features/school/auth/email-domain";
 import {
-  assignSchoolOrg,
   checkExistingUser,
   type ExistingUserInfo,
 } from "@/features/school/auth/school-auth";
+import { completeSchoolSignIn } from "./complete-school-signin";
 import GoogleOAuthButton from "./GoogleOAuthButton";
 
 type Props = {
@@ -73,14 +73,15 @@ export default function SchoolSignIn({
   async function completeSignIn(sessionId: string | null) {
     // setActive is guaranteed defined here: every caller only reaches this
     // after `isLoaded` was already checked truthy in the calling handler.
-    await setActive!({ session: sessionId });
-    const assigned = await assignSchoolOrg(slug);
-    if ("error" in assigned) {
-      setError(assigned.error);
-      return;
-    }
-    await getToken({ skipCache: true });
-    router.push(afterAuthRedirect ?? `/school/${slug}`);
+    const { error: assignError } = await completeSchoolSignIn({
+      setActive: setActive!,
+      getToken,
+      router,
+      slug,
+      sessionId,
+      afterAuthRedirect,
+    });
+    if (assignError) setError(assignError);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -269,13 +270,28 @@ export default function SchoolSignIn({
 
               {showPasswordField && (
                 <div>
-                  <label
-                    htmlFor="password"
-                    className="mb-1 block text-xs font-medium"
-                    style={{ color: "#333f48" }}
-                  >
-                    Password
-                  </label>
+                  <div className="mb-1 flex items-center justify-between">
+                    <label
+                      htmlFor="password"
+                      className="block text-xs font-medium"
+                      style={{ color: "#333f48" }}
+                    >
+                      Password
+                    </label>
+                    <Link
+                      href={`/school/${slug}/reset-password?email=${encodeURIComponent(
+                        email,
+                      )}${
+                        afterAuthRedirect
+                          ? `&redirect=${encodeURIComponent(afterAuthRedirect)}`
+                          : ""
+                      }`}
+                      className="text-xs font-medium hover:underline"
+                      style={{ color: "#bf5700" }}
+                    >
+                      Forgot password?
+                    </Link>
+                  </div>
                   <input
                     id="password"
                     type="password"

--- a/src/features/school/components/auth/complete-school-signin.ts
+++ b/src/features/school/components/auth/complete-school-signin.ts
@@ -1,0 +1,35 @@
+import type { useSignIn, useAuth } from "@clerk/nextjs";
+import type { useRouter } from "next/navigation";
+import { assignSchoolOrg } from "@/features/school/auth/school-auth";
+
+type SetActive = NonNullable<ReturnType<typeof useSignIn>["setActive"]>;
+type GetToken = ReturnType<typeof useAuth>["getToken"];
+type Router = ReturnType<typeof useRouter>;
+
+/**
+ * Shared tail of every successful school auth flow (sign-in and password
+ * reset): activate the Clerk session, (re-)assign the user to the school org,
+ * refresh the JWT so the new org metadata is on the token, then redirect into
+ * the portal. Returns `{ error }` when org assignment fails so the caller can
+ * surface it in its error banner.
+ */
+export async function completeSchoolSignIn(opts: {
+  setActive: SetActive;
+  getToken: GetToken;
+  router: Router;
+  slug: string;
+  sessionId: string | null;
+  afterAuthRedirect?: string | null;
+}): Promise<{ error?: string }> {
+  const { setActive, getToken, router, slug, sessionId, afterAuthRedirect } =
+    opts;
+
+  await setActive({ session: sessionId });
+  const assigned = await assignSchoolOrg(slug);
+  if ("error" in assigned) {
+    return { error: assigned.error };
+  }
+  await getToken({ skipCache: true });
+  router.push(afterAuthRedirect ?? `/school/${slug}`);
+  return {};
+}

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -95,7 +95,7 @@ function UTAboutYouForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 2 of 5
+            Step 2 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">About you</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
+++ b/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
@@ -46,7 +46,7 @@ function UTBackgroundAndSocialsForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 4 of 5
+            Step 4 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">Additional details</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTInterestsForm.tsx
+++ b/src/features/school/onboarding/components/UTInterestsForm.tsx
@@ -142,10 +142,17 @@ function UTInterestsForm({
 
   const selectedAreas = watch("priorityAreas") || [];
 
+  // defaultValues crosses a JSON boundary (localStorage draft / API response),
+  // so its shape isn't guaranteed to match the string[] type at runtime.
+  const defaultPriorityAreas = Array.isArray(defaultValues?.priorityAreas)
+    ? defaultValues.priorityAreas
+    : [];
+
   useEffect(() => {
-    if (defaultValues?.priorityAreas) {
-      reset(defaultValues);
+    if (defaultPriorityAreas.length > 0) {
+      reset({ priorityAreas: defaultPriorityAreas });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValues, reset]);
 
   const errCount = Object.keys(errors).length;
@@ -209,9 +216,7 @@ function UTInterestsForm({
                         value={tag}
                         {...register("priorityAreas")}
                         disabled={isDisabled}
-                        defaultChecked={defaultValues?.priorityAreas?.includes(
-                          tag,
-                        )}
+                        defaultChecked={defaultPriorityAreas.includes(tag)}
                         className="sr-only"
                       />
                       {tag}

--- a/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
+++ b/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
@@ -112,7 +112,7 @@ function UTProfilePhotoForm({ onNext, defaultValues }: UTProfilePhotoFormProps) 
         {/* Header */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 1 of 5
+            Step 1 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">
             Add your profile photo

--- a/src/features/school/onboarding/components/UTReviewForm.tsx
+++ b/src/features/school/onboarding/components/UTReviewForm.tsx
@@ -30,7 +30,7 @@ export default function UTReviewForm({
       {/* Header */}
       <div className="pb-4">
         <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-          Step 5 of 5
+          Step 6 of 6
         </p>
         <h2 className="text-2xl font-bold text-[var(--ui-text)]">Review your info</h2>
         <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -60,6 +60,11 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
     if (corrected && corrected !== utStatusValue) sv("utStatus", corrected);
   }, [utStatusValue, gradYearValue, sv]);
 
+  const currentYear = new Date().getFullYear();
+  const isAlumni = utStatusValue === "alumni";
+  const gradYearMin = isAlumni ? 1965 : currentYear;
+  const gradYearMax = isAlumni ? currentYear : currentYear + 10;
+
   const availableDegreeTypes = utCollegeValue ? getDegreeTypesForSchool(utCollegeValue) : [];
   const availablePrograms =
     utCollegeValue && utDegreeTypeValue
@@ -202,8 +207,14 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
           placeholder="e.g. 2026"
           {...reg("gradYear", {
             valueAsNumber: true,
-            min: { value: 1900, message: "Invalid year" },
-            max: { value: 2035, message: "Invalid year" },
+            min: {
+              value: gradYearMin,
+              message: isAlumni ? "Invalid year" : "Graduation year can't be in the past for students",
+            },
+            max: {
+              value: gradYearMax,
+              message: isAlumni ? "Graduation year can't be in the future for alumni" : "Invalid year",
+            },
           })}
         />
         {errs.gradYear && (

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import {
   UseFormRegister,
   UseFormWatch,
@@ -15,6 +16,7 @@ import {
   DEGREE_TYPE_LABELS,
   SECTOR_INTEREST_LABELS,
 } from "@/features/school/data/utSchoolsAndMajors";
+import { deriveUtStatus } from "@/features/school/onboarding/deriveUtStatus";
 
 const LABEL_CLS =
   "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
@@ -49,6 +51,14 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
   const utCollegeValue = w("utCollege");
   const utDegreeTypeValue = w("utDegreeType");
   const utSectorInterestsValue = w("utSectorInterests") || [];
+  const gradYearValue = w("gradYear");
+
+  // A graduation year that's already passed means the person is alumni,
+  // even if they'd previously selected (or defaulted to) "student".
+  useEffect(() => {
+    const corrected = deriveUtStatus(utStatusValue, gradYearValue);
+    if (corrected && corrected !== utStatusValue) sv("utStatus", corrected);
+  }, [utStatusValue, gradYearValue, sv]);
 
   const availableDegreeTypes = utCollegeValue ? getDegreeTypesForSchool(utCollegeValue) : [];
   const availablePrograms =

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -66,7 +66,7 @@ function UTStartupForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 3 of 5
+            Step 3 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">Startup or idea</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/deriveUtStatus.test.ts
+++ b/src/features/school/onboarding/deriveUtStatus.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { deriveUtStatus, hasGraduationYearPassed } from "./deriveUtStatus";
+
+describe("hasGraduationYearPassed", () => {
+  it("is false when gradYear is undefined", () => {
+    expect(hasGraduationYearPassed(undefined)).toBe(false);
+  });
+
+  it("is false when gradYear is the current year or later", () => {
+    const currentYear = new Date().getFullYear();
+    expect(hasGraduationYearPassed(currentYear)).toBe(false);
+    expect(hasGraduationYearPassed(currentYear + 1)).toBe(false);
+  });
+
+  it("is true when gradYear is before the current year", () => {
+    const currentYear = new Date().getFullYear();
+    expect(hasGraduationYearPassed(currentYear - 1)).toBe(true);
+  });
+});
+
+describe("deriveUtStatus", () => {
+  const currentYear = new Date().getFullYear();
+
+  it("corrects student to alumni when gradYear has already passed", () => {
+    expect(deriveUtStatus("student", currentYear - 1)).toBe("alumni");
+  });
+
+  it("leaves student as-is when gradYear is current or future", () => {
+    expect(deriveUtStatus("student", currentYear)).toBe("student");
+    expect(deriveUtStatus("student", currentYear + 1)).toBe("student");
+  });
+
+  it("leaves student as-is when gradYear is unset", () => {
+    expect(deriveUtStatus("student", undefined)).toBe("student");
+  });
+
+  it("trusts an explicit alumni selection regardless of gradYear", () => {
+    expect(deriveUtStatus("alumni", currentYear + 2)).toBe("alumni");
+  });
+
+  it("passes through an undefined utStatus", () => {
+    expect(deriveUtStatus(undefined, currentYear - 1)).toBeUndefined();
+  });
+});

--- a/src/features/school/onboarding/deriveUtStatus.ts
+++ b/src/features/school/onboarding/deriveUtStatus.ts
@@ -1,0 +1,15 @@
+export function hasGraduationYearPassed(gradYear: number | undefined): boolean {
+  if (gradYear === undefined) return false;
+  return gradYear < new Date().getFullYear();
+}
+
+// A self-reported "student" whose graduation year has already passed is
+// actually alumni; "alumni" is trusted as-is regardless of gradYear since
+// someone can return to school after graduating.
+export function deriveUtStatus(
+  utStatus: "student" | "alumni" | undefined,
+  gradYear: number | undefined,
+): "student" | "alumni" | undefined {
+  if (utStatus === "student" && hasGraduationYearPassed(gradYear)) return "alumni";
+  return utStatus;
+}

--- a/src/features/school/onboarding/stepRegistry.ts
+++ b/src/features/school/onboarding/stepRegistry.ts
@@ -4,6 +4,7 @@ import UTProfilePhotoForm from "@/features/school/onboarding/components/UTProfil
 import UTAboutYouForm from "@/features/school/onboarding/components/UTAboutYouForm";
 import UTStartupForm from "@/features/school/onboarding/components/UTStartupForm";
 import UTBackgroundAndSocialsForm from "@/features/school/onboarding/components/UTBackgroundAndSocialsForm";
+import UTInterestsForm from "@/features/school/onboarding/components/UTInterestsForm";
 
 export type StepProps = {
   onNext: (data: Partial<OnboardingData>) => void;
@@ -19,4 +20,5 @@ export const STEP_COMPONENTS: Record<StepStepId, ComponentType<StepProps>> = {
   about: UTAboutYouForm as ComponentType<StepProps>,
   startup: UTStartupForm as ComponentType<StepProps>,
   background: UTBackgroundAndSocialsForm as ComponentType<StepProps>,
+  priorities: UTInterestsForm as ComponentType<StepProps>,
 };

--- a/src/features/school/registry/registry.ts
+++ b/src/features/school/registry/registry.ts
@@ -59,9 +59,9 @@ export const ORG_REGISTRY: Record<string, OrgConfig> = {
       unlimitedMessages: true,
     },
     onboarding: {
-      totalSteps: 5,
+      totalSteps: 6,
       apiEndpoint: "/api/profile",
-      steps: ["photo", "about", "startup", "background", "review"],
+      steps: ["photo", "about", "startup", "background", "priorities", "review"],
       step2RequiredFields: [
         "firstName",
         "lastName",

--- a/src/features/school/registry/types.ts
+++ b/src/features/school/registry/types.ts
@@ -21,7 +21,13 @@ export type OrgLimits = {
   unlimitedMessages: boolean;
 };
 
-export type OnboardingStepId = "photo" | "about" | "startup" | "background" | "review";
+export type OnboardingStepId =
+  | "photo"
+  | "about"
+  | "startup"
+  | "background"
+  | "priorities"
+  | "review";
 
 export type OrgOnboarding = {
   totalSteps: number;

--- a/src/hooks/useOnboardingDraft.ts
+++ b/src/hooks/useOnboardingDraft.ts
@@ -37,14 +37,16 @@ export function useOnboardingDraft() {
     }
   };
 
-  const save = (step: number, data: OnboardingData) => {
+  const save = (step: number, data: OnboardingData): boolean => {
     try {
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({ step, data: stripPhoto(data) }),
       );
+      return true;
     } catch {
-      // Storage full or unavailable — fail silently
+      // Storage full or unavailable
+      return false;
     }
   };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,6 +31,7 @@ const isPublicRoute = createRouteMatcher([
   "/school/:slug/not-authorized",
   "/school/:slug/sign-up(.*)",
   "/school/:slug/sign-in(.*)",
+  "/school/:slug/reset-password(.*)",
   "/school/:slug/sso-callback(.*)",
   "/school/:slug/sso-complete(.*)",
 ]);
@@ -260,7 +261,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
 
     // MEMBERSHIP / EMAIL-DOMAIN GATE
     // Skip on auth-flow paths (sign-in/up/sso-*): sso-complete assigns org.
-    const isAuthFlowPath = /\/(sign-in|sign-up|sso-callback|sso-complete)(\/|$)/.test(pathname);
+    const isAuthFlowPath = /\/(sign-in|sign-up|reset-password|sso-callback|sso-complete)(\/|$)/.test(pathname);
     if (!isAuthFlowPath) {
       const claimOrgId = sessionClaims?.metadata?.organization_id;
       // Fast path: already assigned to this org via Clerk metadata → skip Clerk API call.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -225,13 +225,36 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   // regardless of the user's global organization_id.
   // ----------------------------------------------------------------
   if (isSchoolContext) {
-    if (isApiRoute || isPublicRoute(req)) {
+    // The bare school landing page ("/school/:slug") is public so anonymous
+    // visitors and users of other orgs can view the marketing page, but it
+    // must not become a dead end for a just-signed-up member of *this* org —
+    // see the dedicated check below, run after org resolution.
+    const isBareSchoolLanding = pathname === `/school/${pathSlug}`;
+
+    if (isApiRoute || (isPublicRoute(req) && !isBareSchoolLanding)) {
       return NextResponse.next();
     }
 
     const org = await resolveOrgBySlug(pathSlug!);
     if (!org) {
       // Unknown slug — let the [slug] layout handle notFound()
+      return NextResponse.next();
+    }
+
+    if (isBareSchoolLanding) {
+      const claimOrgId = sessionClaims?.metadata?.organization_id;
+      if (claimOrgId === org.id) {
+        const schoolOnboarding = sessionClaims?.metadata?.schoolOnboarding;
+        const schoolDone =
+          schoolOnboarding?.[org.id] === true ||
+          (sessionClaims?.metadata?.onboardingComplete === true &&
+            sessionClaims?.metadata?.organization_id === org.id);
+        if (!schoolDone) {
+          return NextResponse.redirect(
+            new URL(`/school/${org.slug}/onboarding`, req.url),
+          );
+        }
+      }
       return NextResponse.next();
     }
 

--- a/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
+++ b/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix onboarded_at for backfilled membership rows
+--
+-- The expand migration (20260623000001) set onboarded_at only when
+-- profiles.onboarding_complete = true. That column is never written by the
+-- app (Phase 1 moved onboarding-complete tracking to Clerk publicMetadata),
+-- so every backfilled row landed with onboarded_at = NULL.
+--
+-- A profiles row exists iff the user completed onboarding (the onboarding
+-- flow writes the row on submit). Treat profiles.updated_at as a conservative
+-- completion timestamp for all pre-existing members.
+
+UPDATE profile_pool_memberships m
+SET onboarded_at = p.updated_at
+FROM profiles p
+WHERE p.user_id = m.user_id
+  AND m.onboarded_at IS NULL;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: onboarded_at backfilled from profiles.updated_at for all NULL membership rows.';
+END $$;

--- a/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
+++ b/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
@@ -1,0 +1,64 @@
+-- Migration: Fix pool-membership RLS self-join
+--
+-- Problem: the profiles_select_org policy in 20260623000002 proves "viewer and
+-- target share a pool" by self-joining profile_pool_memberships. The ppm_owner
+-- RLS on that table is enforced inside the subquery, so the target_m side
+-- (another user's rows) is invisible — making EXISTS always false for everyone
+-- except the viewer themselves. Net result: every user can only read their own
+-- profile, breaking the matching feed, likes, mutual matches, conversations,
+-- and user_activity_summary. Same bug exists in user_activity_summary_org_isolation.
+--
+-- Fix: a SECURITY DEFINER helper function that runs as its owner (bypassing
+-- ppm_owner), allowing the join to see both sides. Precedent: upsert_pool_membership
+-- in 20260623000001 is also SECURITY DEFINER for the same reason.
+--
+-- Scope: replaces only the two affected SELECT policies. No other policies,
+-- tables, or write guards are changed.
+
+-- ============================================================
+-- Helper: shared-pool membership check
+-- Runs as function owner → bypasses ppm_owner RLS → can see
+-- both the viewer's and the target's membership rows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.shares_pool_with(target text)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE
+SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM profile_pool_memberships viewer_m
+    JOIN profile_pool_memberships target_m
+      ON target_m.user_id = target
+     AND target_m.organization_id IS NOT DISTINCT FROM viewer_m.organization_id
+    WHERE viewer_m.user_id = auth.jwt() ->> 'sub'
+  );
+$$;
+
+-- ============================================================
+-- profiles — fix shared-membership SELECT
+-- ============================================================
+DROP POLICY IF EXISTS "profiles_select_org" ON profiles;
+
+CREATE POLICY "profiles_select_org" ON profiles
+  FOR SELECT
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+-- ============================================================
+-- user_activity_summary — same fix (mirrors profiles policy)
+-- ============================================================
+DROP POLICY IF EXISTS "user_activity_summary_org_isolation" ON user_activity_summary;
+
+CREATE POLICY "user_activity_summary_org_isolation" ON user_activity_summary
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: shares_pool_with() SECURITY DEFINER helper created; profiles_select_org and user_activity_summary_org_isolation policies rewritten to use it.';
+END $$;

--- a/supabase/migrations/20260713000000_ensure_mccombs_utexas_domain.sql
+++ b/supabase/migrations/20260713000000_ensure_mccombs_utexas_domain.sql
@@ -1,0 +1,19 @@
+-- Migration: Ensure mccombs.utexas.edu is in UT Austin's allowed email domains
+--
+-- mccombs.utexas.edu has been documented in seed.sql as an allowed UT
+-- domain, but seed.sql is not applied to production — only migrations are.
+-- Ensure the live org row actually has it (idempotent — no-op if already present).
+
+UPDATE organizations
+SET allowed_email_domains = (
+  SELECT ARRAY(
+    SELECT DISTINCT unnest(allowed_email_domains || ARRAY['mccombs.utexas.edu'])
+  )
+)
+WHERE slug = 'ut'
+  AND NOT ('mccombs.utexas.edu' = ANY (allowed_email_domains));
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Ensured mccombs.utexas.edu is in UT org allowed_email_domains.';
+END $$;


### PR DESCRIPTION
## Summary
Fixes a batch of onboarding and sign-up/sign-in issues on the UT (school) portal. Adds a school-scoped password reset flow, makes the "priority areas" step a real editable step in the UT onboarding wizard (previously broken), adds manual "save progress" to the general onboarding flow, and corrects student/alumni status when a self-reported graduation year has already passed. Also includes two Supabase migrations that fix production data/RLS bugs (pool-membership `onboarded_at` backfill and a broken self-join RLS policy that silently restricted every user to only their own profile), plus a migration to guarantee the `mccombs.utexas.edu` domain is allowlisted for UT.

## Changes

### Password reset
- Add `SchoolResetPassword` (`src/features/school/components/auth/SchoolResetPassword.tsx`), a school-branded password reset flow built on Clerk's `reset_password_email_code` strategy, with request → code+new-password → optional second-factor phases mirroring `SchoolSignIn`'s existing MFA handling.
- Extract `completeSchoolSignIn` (`src/features/school/components/auth/complete-school-signin.ts`) as the shared tail of session activation, org (re-)assignment, JWT refresh, and redirect — previously inlined only in `SchoolSignIn`, now reused by both sign-in and reset-password so they can't drift.
- Add the `/school/[slug]/reset-password` route/page, gated so an already-authenticated user is redirected straight through, and wire a "Forgot password?" link into `SchoolSignIn`'s password field.
- Detect Google-only accounts (`existingUser.hasPassword === false` with a Google OAuth provider) and steer them back to sign-in instead of letting them attempt a reset with no password to reset.
- `middleware.ts`: mark `/school/:slug/reset-password(.*)` as a public route and include `reset-password` in the auth-flow path regex so the membership/email-domain gate doesn't block it before a session exists.

### UT onboarding — priority areas step
- Register `UTInterestsForm` as a real step (`priorities`) in `stepRegistry.ts` and `registry.ts` (UT `totalSteps` 5 → 6, `OnboardingStepId` gains `"priorities"`), and renumber all "Step N of 5" headers to "Step N of 6" across the UT form components. Previously the priority-areas UI existed but wasn't wired into the step flow, so it was effectively uneditable.
- Fix `UTInterestsForm`'s reset/default-checked logic: `defaultValues.priorityAreas` crosses a JSON boundary (localStorage draft or API response) so its runtime shape isn't guaranteed — guard with `Array.isArray` before using it in both the `reset()` effect and each checkbox's `defaultChecked`.

### Student/alumni status correction
- Add `deriveUtStatus` / `hasGraduationYearPassed` (`src/features/school/onboarding/deriveUtStatus.ts`, with unit tests) — a self-reported "student" whose `gradYear` has already passed is corrected to "alumni"; an explicit "alumni" selection is trusted as-is since someone can return to school after graduating.
- Apply the correction in two places for defense in depth: client-side in `UTSchoolFields` via a `useEffect` that live-corrects `utStatus` as the user edits `gradYear`, and server-side in `onboardingProfile.ts`'s `saveOnboardingProfile` so the DB stays correct even against a stale client or a direct API call.
- Constrain the `gradYear` field's min/max based on the (possibly just-corrected) status: students are constrained to `[currentYear, currentYear + 10]`, alumni to `[1965, currentYear]`, replacing the previous static `[1900, 2035]` range that allowed students to pick past years or alumni to pick future ones.

### General onboarding — manual save
- Add an optional `onManualSave` prop to `AboutYouForm`, `StartupForm`, `BackgroundAndSocialsForm`, and `InterestsAndValuesForm`, rendered as a "Save progress" button next to Back/Next that calls `getValues()` without requiring the form to validate/submit.
- `CreateProfile.tsx` wires `handleManualSave` to merge the in-progress step data into `formData` and persist it via `useOnboardingDraft`'s `save`, toasting success/failure (`react-hot-toast`) based on the (now boolean-returning) result of `localStorage.setItem`.
- `useOnboardingDraft.save` now returns `true`/`false` instead of failing silently, so callers can surface a "storage full or disabled" error to the user.
- `InterestsAndValuesForm` factors the "merge other-priority text into `priorityAreas`" logic into a shared `withOtherPriority` helper so both the submit handler and the new manual-save handler apply it consistently.

### Sign-up/sign-in routing and post-auth landing
- `SchoolLanding` (`src/app/(school)/school/[slug]/page.tsx`) now links to `/school/${slug}/sign-up` and `/school/${slug}/sign-in` instead of the generic top-level `/sign-up` / `/sign-in`, keeping visitors inside the school portal.
- `sso-complete`: on org lookup failure, render the existing `AutoRetry` component instead of redirecting to `/`, consistent with this page's other failure branches — an org lookup miss immediately after signup is more likely transient replication lag than a real 404.
- `middleware.ts`: the bare `/school/:slug` landing page is public (so anonymous visitors and other-org users can view it), but a newly-signed-up member of *that* org would previously land there as a dead end. Add a check, run after org resolution, that redirects a same-org member who hasn't completed school onboarding to `/school/:slug/onboarding`.

## Migration / Config
- `supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql` — backfills `onboarded_at` on `profile_pool_memberships` from `profiles.updated_at` for rows the earlier expand migration left `NULL` (it had only set `onboarded_at` when `profiles.onboarding_complete = true`, a column the app never writes since onboarding-complete tracking moved to Clerk `publicMetadata`).
- `supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql` — fixes a production RLS bug: `profiles_select_org`'s self-join on `profile_pool_memberships` had the target side's rows hidden by `ppm_owner` RLS, making the "shares a pool" check always false and silently restricting every user to reading only their own profile (breaking the matching feed, likes, mutual matches, conversations, and `user_activity_summary`). Adds a `SECURITY DEFINER` helper `shares_pool_with()` (mirroring the existing `upsert_pool_membership` precedent) and rewrites both affected SELECT policies to use it.
- `supabase/migrations/20260713000000_ensure_mccombs_utexas_domain.sql` — idempotently ensures `mccombs.utexas.edu` is present in the `ut` org's `allowed_email_domains`; it was documented in `seed.sql` but seed data isn't applied to production.
- No new environment variables or third-party setup required.

## Testing
- Added unit tests for `deriveUtStatus` / `hasGraduationYearPassed` covering: student with a past grad year → corrected to alumni; student with current/future/unset grad year → unchanged; explicit alumni is trusted regardless of grad year; `undefined` status passes through (`src/features/school/onboarding/deriveUtStatus.test.ts`).

## Notes
- The two `20260623*` migrations fix bugs introduced by an earlier (already-merged) expand migration; the RLS self-join issue in particular was a live production bug affecting all users' ability to see each other's profiles.
