### PR TITLE
UT Onboarding Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5039,15 +5039,12 @@
         "node": ">= 0.4"
       }
     },
-<<<<<<< Updated upstream
-=======
     "node_modules/heic-to": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
       "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
       "license": "LGPL-3.0"
     },
->>>>>>> Stashed changes
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "country-state-city": "^3.2.1",
         "framer-motion": "^12.23.25",
         "gsap": "^3.14.2",
+        "heic-to": "^1.5.2",
         "lenis": "^1.3.4",
         "lucide-react": "^0.553.0",
         "motion": "^12.23.12",
@@ -5038,6 +5039,15 @@
         "node": ">= 0.4"
       }
     },
+<<<<<<< Updated upstream
+=======
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
+    },
+>>>>>>> Stashed changes
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,26 +1542,6 @@
         "cross-spawn": "^7.0.6"
       }
     },
-    "node_modules/@react-email/render": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.3.2.tgz",
-      "integrity": "sha512-oq8/BD/I/YspeuBjjdLJG6xaf9tsPYk+VWu8/mX9xWbRN0t0ExKSVm9sEBL6RsCpndQA2jbY2VgPEreIrzUgqw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "html-to-text": "^9.0.5",
-        "prettier": "^3.5.3",
-        "react-promise-suspense": "^0.3.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.4.tgz",
@@ -1855,21 +1835,6 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
-      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "selderee": "^0.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -3783,17 +3748,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3862,69 +3816,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -3969,20 +3860,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5161,45 +5038,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html-to-text": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
-      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.11.0",
-        "deepmerge": "^4.3.1",
-        "dom-serializer": "^2.0.0",
-        "htmlparser2": "^8.0.2",
-        "selderee": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5823,17 +5661,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/leac": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
-      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/lenis": {
@@ -6679,21 +6506,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parseley": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
-      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "leac": "^0.6.0",
-        "peberminta": "^0.9.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6735,17 +6547,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/peberminta": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
-      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -6870,7 +6671,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
       "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -7073,25 +6874,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-promise-suspense": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
-      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7334,20 +7116,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
-    },
-    "node_modules/selderee": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
-      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "parseley": "^0.12.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "country-state-city": "^3.2.1",
     "framer-motion": "^12.23.25",
     "gsap": "^3.14.2",
+    "heic-to": "^1.5.2",
     "lenis": "^1.3.4",
     "lucide-react": "^0.553.0",
     "motion": "^12.23.12",

--- a/src/app/(general)/edit-profile/page.tsx
+++ b/src/app/(general)/edit-profile/page.tsx
@@ -231,8 +231,7 @@ export default function EditProfile() {
                 Profile Picture
               </h2>
               <p className="text-sm text-gray-400">
-                Upload a clear photo of yourself. AI will verify it&apos;s a
-                real human face.
+                Upload a clear photo of yourself with your face visible.
               </p>
             </div>
           </div>

--- a/src/app/(general)/messages/[conversationId]/page.tsx
+++ b/src/app/(general)/messages/[conversationId]/page.tsx
@@ -29,6 +29,7 @@ function ConversationPage({ params }: ConversationPageProps) {
   const [sendError, setSendError] = React.useState<string | null>(null);
   const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     params.then((resolvedParams) => {
@@ -47,9 +48,15 @@ function ConversationPage({ params }: ConversationPageProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
+  // Grow the message box to fit its content, up to a max height
+  React.useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [messageInput]);
 
+  const sendCurrentMessage = async () => {
     if (!messageInput.trim() || isSending) return;
 
     setIsSending(true);
@@ -88,6 +95,11 @@ function ConversationPage({ params }: ConversationPageProps) {
     } finally {
       setIsSending(false);
     }
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await sendCurrentMessage();
   };
 
   return (
@@ -168,12 +180,12 @@ function ConversationPage({ params }: ConversationPageProps) {
         {/* Notifications - Always Visible */}
         <div className="space-y-3">
           {/* Privacy Notice */}
-          <div className="rounded-lg border border-white bg-(--charcoal-black) p-3">
-            <div className="mb-2 flex items-center gap-2 text-yellow-400">
+          <div className="rounded-lg border border-blue-500/30 bg-blue-500/20 p-3">
+            <div className="mb-2 flex items-center gap-2 text-blue-400">
               <div className="h-4 w-4 rounded-full bg-blue-500"></div>
               <span className="text-sm font-medium">Privacy Notice</span>
             </div>
-            <p className="text-xs text-white">
+            <p className="text-xs text-blue-300">
               This is a starting point to connect outside of Mamun. Messages are
               not encrypted, so please don&apos;t write any sensitive data in
               the chat.
@@ -290,11 +302,12 @@ function ConversationPage({ params }: ConversationPageProps) {
 
             <form
               onSubmit={handleSendMessage}
-              className="flex items-center gap-3"
+              className="flex items-end gap-3"
             >
               <div className="flex-1">
-                <input
-                  type="text"
+                <textarea
+                  ref={textareaRef}
+                  rows={1}
                   placeholder={
                     messages.length >= 20
                       ? "Message limit reached"
@@ -302,7 +315,13 @@ function ConversationPage({ params }: ConversationPageProps) {
                   }
                   value={messageInput}
                   onChange={(e) => setMessageInput(e.target.value)}
-                  className="w-full rounded-lg border border-white/30 bg-[var(--charcoal-black)] px-4 py-2 text-white placeholder-white/30 transition-colors focus:border-white focus:outline-none"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      sendCurrentMessage();
+                    }
+                  }}
+                  className="max-h-40 w-full resize-none overflow-y-auto rounded-lg border border-white/30 bg-[var(--charcoal-black)] px-4 py-2 text-white placeholder-white/30 transition-colors focus:border-white focus:outline-none"
                   disabled={isSending || messages.length >= 20}
                   maxLength={1000}
                 />
@@ -325,7 +344,7 @@ function ConversationPage({ params }: ConversationPageProps) {
               </button>
             </form>
             <p className="mt-2 text-center text-xs text-white/30">
-              Press Enter or click Send to send your message
+              Press Enter to send, Shift+Enter for a new line
             </p>
           </div>
         </motion.div>

--- a/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
+++ b/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
@@ -34,10 +34,12 @@ const PILL_RADIO_CLS =
 function AboutYouForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: AboutYouData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<AboutYouData>) => void;
   defaultValues?: Partial<AboutYouData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -50,6 +52,7 @@ function AboutYouForm({
     reset,
     watch,
     setValue,
+    getValues,
   } = useForm<AboutYouData>({ defaultValues });
 
   const titleValue = watch("title") || "";
@@ -409,6 +412,15 @@ function AboutYouForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
+++ b/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
@@ -25,10 +25,12 @@ const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-mut
 function BackgroundAndSocialsForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: BackgroundAndSocialsData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<BackgroundAndSocialsData>) => void;
   defaultValues?: Partial<BackgroundAndSocialsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -39,6 +41,7 @@ function BackgroundAndSocialsForm({
     handleSubmit,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<BackgroundAndSocialsData>({ defaultValues });
 
@@ -174,6 +177,15 @@ function BackgroundAndSocialsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
+++ b/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
@@ -14,10 +14,12 @@ const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-mut
 function InterestsAndValuesForm({
   onBack,
   onNext,
+  onManualSave,
   defaultValues,
 }: {
   onBack: () => void;
   onNext: (data: InterestsAndValuesFormData) => void;
+  onManualSave?: (data: Partial<InterestsAndValuesFormData>) => void;
   defaultValues?: Partial<InterestsAndValuesFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -46,6 +48,7 @@ function InterestsAndValuesForm({
     reset,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<InterestsAndValuesFormData>({ defaultValues });
 
@@ -74,12 +77,18 @@ function InterestsAndValuesForm({
     if (errCount > 0) triggerShake();
   }, [errCount, triggerShake]);
 
-  const onSubmit = (data: InterestsAndValuesFormData) => {
-    const mergedPriorityAreas = [
+  const withOtherPriority = (
+    data: InterestsAndValuesFormData,
+  ): InterestsAndValuesFormData => ({
+    ...data,
+    priorityAreas: [
       ...(data.priorityAreas || []),
       ...(showOtherInput && otherPriority ? [otherPriority] : []),
-    ];
-    onNext({ ...data, priorityAreas: mergedPriorityAreas });
+    ],
+  });
+
+  const onSubmit = (data: InterestsAndValuesFormData) => {
+    onNext(withOtherPriority(data));
   };
 
   return (
@@ -199,6 +208,15 @@ function InterestsAndValuesForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(withOtherPriority(getValues()))}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/ProfilePhotoForm.tsx
+++ b/src/app/(general)/onboarding/form-components/ProfilePhotoForm.tsx
@@ -139,7 +139,7 @@ function ProfilePhotoForm({ onNext, defaultValues }: ProfilePhotoFormProps) {
             Add your profile photo
           </h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
-            Our AI verifies it contains a real face to keep profiles authentic.
+            Make sure your face is clearly visible in the photo.
           </p>
         </div>
 

--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -40,10 +40,12 @@ const PILL_RADIO_CLS =
 function StartupForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: StartupFormData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<StartupFormData>) => void;
   defaultValues?: Partial<StartupFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -55,6 +57,7 @@ function StartupForm({
     control,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<StartupFormData>({ defaultValues });
 
@@ -289,6 +292,15 @@ function StartupForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -30,7 +30,7 @@ const TEXTAREA_CLS =
   "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 

--- a/src/app/(school)/school/[slug]/accept-policies/page.tsx
+++ b/src/app/(school)/school/[slug]/accept-policies/page.tsx
@@ -100,7 +100,7 @@ export default function AcceptPoliciesPage() {
               <Link
                 href={`/school/${slug}/privacy-policy`}
                 target="_blank"
-                className="font-semibold underline hover:opacity-70"
+                className="rounded font-semibold underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
                 style={{ color: primary }}
               >
                 Privacy Policy
@@ -109,7 +109,7 @@ export default function AcceptPoliciesPage() {
               <Link
                 href={`/school/${slug}/terms-and-conditions`}
                 target="_blank"
-                className="font-semibold underline hover:opacity-70"
+                className="rounded font-semibold underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
                 style={{ color: primary }}
               >
                 Terms of Use
@@ -171,7 +171,7 @@ export default function AcceptPoliciesPage() {
             type="button"
             onClick={handleContinue}
             disabled={!allChecked || submitting}
-            className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
             style={{ backgroundColor: primary }}
           >
             {submitting ? "Saving…" : "I Agree & Continue"}

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -183,6 +183,12 @@ function SearchResultCard({
 export default function SchoolDashboardPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const toggleSearch = () => {
+    setSearchOpen((prev) => {
+      if (prev) setSearchQuery("");
+      return !prev;
+    });
+  };
   const [filters, setFilters] = useState<DashboardFilters>(EMPTY_DASHBOARD_FILTERS);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [viewingUserId, setViewingUserId] = useState<string | null>(null);
@@ -312,11 +318,16 @@ export default function SchoolDashboardPage() {
           <IoFilterOutline className="h-4 w-4" />
         </button>
         <button
-          onClick={() => setSearchOpen(true)}
+          onClick={toggleSearch}
           className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] hover:bg-[#ffe8d6] transition cursor-pointer"
-          aria-label="Open search"
+          aria-expanded={searchOpen}
+          aria-label={searchOpen ? "Close search" : "Open search"}
         >
-          <IoSearchOutline className="h-4 w-4" />
+          {searchOpen ? (
+            <IoCloseOutline className="h-4 w-4" />
+          ) : (
+            <IoSearchOutline className="h-4 w-4" />
+          )}
         </button>
       </div>
     </div>
@@ -414,7 +425,7 @@ export default function SchoolDashboardPage() {
             className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#a34800] outline-none"
           />
           <button
-            onClick={() => { setSearchQuery(""); setSearchOpen(false); }}
+            onClick={toggleSearch}
             className="flex-shrink-0 text-[#BF5700] hover:text-[#8a3d00] cursor-pointer"
           >
             <IoCloseOutline className="h-4 w-4" />

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -109,7 +109,7 @@ function SearchResultCard({
                 </span>
               )}
               {profile.isTechnical && (
-                <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2 py-0.5 text-[10px] font-medium text-[#bf5700]">
+                <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2 py-0.5 text-[10px] font-medium text-[#a34800]">
                   {profile.isTechnical === "yes" ? "Technical" : "Non-technical"}
                 </span>
               )}
@@ -296,7 +296,7 @@ export default function SchoolDashboardPage() {
         <p className="text-xs font-semibold uppercase tracking-widest">
           <span className="text-[#84cc16]">Mamun</span>
           <span className="text-[var(--ui-text-muted)]"> &times; </span>
-          <span className="text-[#BF5700]">{schoolName}</span>
+          <span className="text-[#a34800]">{schoolName}</span>
         </p>
         <h1 className="mt-0.5 text-base font-semibold text-[var(--ui-text)]">
           UT co-foundr Matching
@@ -410,7 +410,7 @@ export default function SchoolDashboardPage() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by skill, major, industry…"
-            className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#bf5700]/60 outline-none"
+            className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#a34800] outline-none"
           />
           <button
             onClick={() => { setSearchQuery(""); setSearchOpen(false); }}
@@ -454,7 +454,7 @@ export default function SchoolDashboardPage() {
                         key={s.dimension}
                         type="button"
                         onClick={() => handleRelax(s)}
-                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#bf5700] transition hover:bg-[#ffe8d6] cursor-pointer"
+                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#a34800] transition hover:bg-[#ffe8d6] cursor-pointer"
                       >
                         <span className="font-medium">Drop &ldquo;{s.label}&rdquo;</span>
                         <span className="flex-shrink-0 rounded-full bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
@@ -471,7 +471,7 @@ export default function SchoolDashboardPage() {
               )}
               <button
                 onClick={() => setSearchQuery("")}
-                className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"
+                className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
               >
                 Clear search
               </button>
@@ -504,7 +504,7 @@ export default function SchoolDashboardPage() {
                 <button
                   type="button"
                   onClick={() => updateFilters(EMPTY_DASHBOARD_FILTERS)}
-                  className="mt-1 text-sm font-medium text-[#bf5700] hover:underline cursor-pointer"
+                  className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
                 >
                   Clear filters
                 </button>
@@ -586,7 +586,7 @@ export default function SchoolDashboardPage() {
                       </span>
                     )}
                     {curProfile.archetype && (
-                      <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                      <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
                         {curProfile.archetype === "the_scaler"
                           ? "The Scaler"
                           : curProfile.archetype === "the_steward"
@@ -602,7 +602,7 @@ export default function SchoolDashboardPage() {
                 </div>
 
                 {curProfile.isTechnical && (
-                  <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#bf5700]">
+                  <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
                     {curProfile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
                   </div>
                 )}
@@ -715,7 +715,7 @@ export default function SchoolDashboardPage() {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#bf5700]"
+                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#a34800]"
                           >
                             {icon}
                             {label}

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -100,10 +100,11 @@ function SearchResultCard({
               </span>
               {profile.utStatus && (
                 <span
-                  className="inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-medium text-white"
-                  style={{
-                    backgroundColor: profile.utStatus === "student" ? "#22c55e" : "#a855f7",
-                  }}
+                  className={`inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-medium ${
+                    profile.utStatus === "student"
+                      ? "bg-emerald-100 text-emerald-800"
+                      : "bg-purple-100 text-purple-800"
+                  }`}
                 >
                   {profile.utStatus === "student" ? "Student" : "Alumni"}
                 </span>
@@ -294,7 +295,7 @@ export default function SchoolDashboardPage() {
       <div className="w-8" />
       <div className="text-center">
         <p className="text-xs font-semibold uppercase tracking-widest">
-          <span className="text-[#84cc16]">Mamun</span>
+          <span className="text-[#4d7c0f]">Mamun</span>
           <span className="text-[var(--ui-text-muted)]"> &times; </span>
           <span className="text-[#a34800]">{schoolName}</span>
         </p>
@@ -577,10 +578,11 @@ export default function SchoolDashboardPage() {
                   <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
                     {curProfile.utStatus && (
                       <span
-                        className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium text-white"
-                        style={{
-                          backgroundColor: curProfile.utStatus === "student" ? "#22c55e" : "#a855f7",
-                        }}
+                        className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ${
+                          curProfile.utStatus === "student"
+                            ? "bg-emerald-100 text-emerald-800"
+                            : "bg-purple-100 text-purple-800"
+                        }`}
                       >
                         {curProfile.utStatus === "student" ? "Student" : "Alumni"}
                       </span>

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -356,7 +356,7 @@ export default function SchoolDashboardPage() {
               key={chip.key}
               type="button"
               onClick={() => updateFilters(chip.onRemove())}
-              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:opacity-90"
+              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:bg-[#a34800]"
             >
               {chip.label}
               <span aria-hidden>&times;</span>

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -98,7 +98,7 @@ export default function AcceptInviteClient({
             {inviterName} invited you to link as co-founders
           </h1>
           {inviterTitle && (
-            <p className="mt-1 text-sm" style={{ color: "#9cadb7" }}>
+            <p className="mt-1 text-sm" style={{ color: "#5f7280" }}>
               {inviterTitle}
             </p>
           )}
@@ -116,7 +116,7 @@ export default function AcceptInviteClient({
               </p>
             )}
             {note && (
-              <p className="text-sm italic" style={{ color: "#9cadb7" }}>
+              <p className="text-sm italic" style={{ color: "#5f7280" }}>
                 &ldquo;{note}&rdquo;
               </p>
             )}
@@ -136,7 +136,7 @@ export default function AcceptInviteClient({
           </button>
         ) : (
           <div className="mb-4 space-y-1.5">
-            <label className="block text-xs font-medium" style={{ color: "#9cadb7" }}>
+            <label className="block text-xs font-medium" style={{ color: "#5f7280" }}>
               Your role
             </label>
             <select
@@ -155,7 +155,7 @@ export default function AcceptInviteClient({
           </div>
         )}
 
-        <p className="mb-6 text-center text-sm" style={{ color: "#9cadb7" }}>
+        <p className="mb-6 text-center text-sm" style={{ color: "#5f7280" }}>
           Accepting will link your profiles as confirmed co-founders, visible on both your cards.
         </p>
 

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -128,8 +128,7 @@ export default function AcceptInviteClient({
           <button
             type="button"
             onClick={() => setEditingRole(true)}
-            className="mb-4 flex cursor-pointer items-center gap-1.5 text-xs font-medium transition hover:opacity-80"
-            style={{ color: "#bf5700" }}
+            className="mb-4 flex cursor-pointer items-center gap-1.5 text-xs font-medium text-[#bf5700] transition hover:text-[#a34800]"
           >
             <FaPencil className="h-3 w-3" />
             Edit my role
@@ -174,8 +173,7 @@ export default function AcceptInviteClient({
             type="button"
             onClick={handleAccept}
             disabled={accepting || declining}
-            className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-            style={{ backgroundColor: "#bf5700" }}
+            className="flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[#bf5700] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#a34800] disabled:cursor-not-allowed disabled:opacity-50"
           >
             <FaHandshake className="h-4 w-4" />
             {accepting ? "Accepting…" : "Accept"}

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -38,7 +38,7 @@ export default async function InviteAcceptPage({
           <p className="text-base font-semibold" style={{ color: "#333f48" }}>
             This invite is no longer valid
           </p>
-          <p className="mt-2 text-sm" style={{ color: "#9cadb7" }}>
+          <p className="mt-2 text-sm" style={{ color: "#5f7280" }}>
             It may have expired, been revoked, or already accepted.
           </p>
           <Link
@@ -94,11 +94,11 @@ export default async function InviteAcceptPage({
             {inviterName} wants to link as co-founders
           </h1>
           {inviterProfile?.title && (
-            <p className="mt-1 text-sm" style={{ color: "#9cadb7" }}>
+            <p className="mt-1 text-sm" style={{ color: "#5f7280" }}>
               {inviterProfile.title}
             </p>
           )}
-          <p className="mt-4 text-sm" style={{ color: "#9cadb7" }}>
+          <p className="mt-4 text-sm" style={{ color: "#5f7280" }}>
             Sign in or create an account to accept this invite.
           </p>
           <div className="mt-6 flex flex-col gap-3">

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -43,8 +43,7 @@ export default async function InviteAcceptPage({
           </p>
           <Link
             href={`/school/${slug}/dashboard`}
-            className="mt-6 inline-block cursor-pointer rounded-xl px-6 py-2.5 text-sm font-semibold text-white"
-            style={{ backgroundColor: "#bf5700" }}
+            className="mt-6 inline-block cursor-pointer rounded-xl bg-[#bf5700] px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-[#a34800]"
           >
             Go to dashboard
           </Link>
@@ -104,8 +103,7 @@ export default async function InviteAcceptPage({
           <div className="mt-6 flex flex-col gap-3">
             <Link
               href={signInUrl}
-              className="cursor-pointer rounded-xl px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90"
-              style={{ backgroundColor: "#bf5700" }}
+              className="cursor-pointer rounded-xl bg-[#bf5700] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#a34800]"
             >
               Sign in
             </Link>

--- a/src/app/(school)/school/[slug]/layout.tsx
+++ b/src/app/(school)/school/[slug]/layout.tsx
@@ -103,13 +103,16 @@ export default async function SchoolSlugLayout({
             "--org-accent": cfg.branding.accentColor,
             "--org-bg": cfg.branding.backgroundColor,
             "--org-text": cfg.branding.textColor,
-            // Semantic UI tokens — light-mode overrides for school orgs with white bg
+            // Semantic UI tokens — light-mode overrides for school orgs with white bg.
+            // Text/subtle values are chosen to clear WCAG AA (4.5:1) on white — see
+            // the plan doc for the full contrast audit.
             ...(cfg.branding.backgroundColor === "#FFFFFF" ||
             cfg.branding.backgroundColor === "#ffffff"
               ? {
+                  "--ui-bg": "#ffffff",
                   "--ui-text": cfg.branding.textColor,
-                  "--ui-text-muted": "#9cadb7",
-                  "--ui-text-subtle": "rgba(51,63,72,0.45)",
+                  "--ui-text-muted": "#5f7280",
+                  "--ui-text-subtle": "#64757e",
                   "--ui-border": "#e8e4dc",
                   "--ui-border-strong": "#c8c3b8",
                   "--ui-surface": "rgba(51,63,72,0.04)",

--- a/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
@@ -36,6 +36,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
   const [isLimitReached, setIsLimitReached] = React.useState<boolean>(false);
   const [showProfile, setShowProfile] = React.useState<boolean>(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     params.then((resolvedParams) => {
@@ -62,9 +63,15 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
+  // Grow the message box to fit its content, up to a max height
+  React.useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [messageInput]);
 
+  const sendCurrentMessage = async () => {
     if (!messageInput.trim() || isSending) return;
 
     setIsSending(true);
@@ -102,6 +109,11 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
     } finally {
       setIsSending(false);
     }
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await sendCurrentMessage();
   };
 
   return (
@@ -200,8 +212,8 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
 
       {/* Notices */}
       <div className="mb-4 space-y-2">
-        <div className="rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] p-3">
-          <p className="text-xs text-[var(--ui-text-muted)]">
+        <div className="rounded-lg border border-blue-300 bg-blue-50 p-3">
+          <p className="text-xs font-medium text-blue-700">
             This is a starting point to connect outside of Mamun. Messages are
             not encrypted, so please don&apos;t share sensitive data here.
           </p>
@@ -286,9 +298,10 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
             />
           </div>
 
-          <form onSubmit={handleSendMessage} className="flex items-center gap-2">
-            <input
-              type="text"
+          <form onSubmit={handleSendMessage} className="flex items-end gap-2">
+            <textarea
+              ref={textareaRef}
+              rows={1}
               placeholder={
                 messages.length >= 20
                   ? "Message limit reached"
@@ -296,7 +309,13 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
               }
               value={messageInput}
               onChange={(e) => setMessageInput(e.target.value)}
-              className="flex-1 rounded-lg border border-[var(--ui-border)] bg-white px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--org-primary)] focus:outline-none"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  sendCurrentMessage();
+                }
+              }}
+              className="max-h-40 flex-1 resize-none overflow-y-auto rounded-lg border border-[var(--ui-border)] bg-white px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--org-primary)] focus:outline-none"
               disabled={isSending || messages.length >= 20}
               maxLength={1000}
             />

--- a/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/[conversationId]/page.tsx
@@ -249,7 +249,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
               <p className="text-xs text-[var(--ui-text-muted)]">{error.message}</p>
               <button
                 onClick={() => window.location.reload()}
-                className="mt-2 rounded-lg bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white hover:opacity-90 cursor-pointer"
+                className="mt-2 rounded-lg bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white cursor-pointer hover:bg-[#a34800]"
               >
                 Try Again
               </button>
@@ -302,7 +302,7 @@ export default function SchoolConversationPage({ params }: ConversationPageProps
             />
             <button
               type="submit"
-              className="rounded-lg bg-[var(--org-primary)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-40 cursor-pointer"
+              className="rounded-lg bg-[var(--org-primary)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-40 cursor-pointer"
               disabled={!messageInput.trim() || isSending || messages.length >= 20}
             >
               {isSending ? "Sending..." : "Send"}

--- a/src/app/(school)/school/[slug]/matches/page.tsx
+++ b/src/app/(school)/school/[slug]/matches/page.tsx
@@ -297,7 +297,7 @@ export default function SchoolMatchesPage({
                           <button
                             onClick={() => profile.user_id && handleMessage(profile.user_id)}
                             disabled={createConversationMutation.isPending}
-                            className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                            className="flex items-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-semibold text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                           >
                             <FaHandshake className="h-3.5 w-3.5" />
                             It&apos;s a Match!
@@ -332,7 +332,7 @@ export default function SchoolMatchesPage({
                             profile.user_id && handleMessage(profile.user_id)
                           }
                           disabled={createConversationMutation.isPending}
-                          className="rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                          className="rounded-full bg-[var(--org-primary)] px-4 py-2 text-xs font-medium text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                         >
                           Message
                         </button>

--- a/src/app/(school)/school/[slug]/not-authorized/page.tsx
+++ b/src/app/(school)/school/[slug]/not-authorized/page.tsx
@@ -42,7 +42,7 @@ export default async function NotAuthorizedPage({
       <div className="flex flex-col items-center gap-3">
         <Link
           href={`/school/${slug}/sign-up`}
-          className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-lg px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: "var(--org-primary)" }}
         >
           Sign up with your school email

--- a/src/app/(school)/school/[slug]/page.tsx
+++ b/src/app/(school)/school/[slug]/page.tsx
@@ -89,14 +89,14 @@ export default async function SchoolLanding({
       <div className="flex flex-col items-center gap-3 sm:flex-row">
         <Link
           href="/sign-up"
-          className="rounded-lg px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-lg px-6 py-3 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: branding.primaryColor }}
         >
           {landing.ctaPrimaryLabel}
         </Link>
         <Link
           href="/sign-in"
-          className="rounded-lg border px-6 py-3 text-sm font-semibold transition-opacity hover:opacity-70"
+          className="rounded-lg border px-6 py-3 text-sm font-semibold transition-colors hover:bg-black/5"
           style={{
             borderColor: branding.accentColor,
             color: branding.accentColor,

--- a/src/app/(school)/school/[slug]/page.tsx
+++ b/src/app/(school)/school/[slug]/page.tsx
@@ -88,14 +88,14 @@ export default async function SchoolLanding({
 
       <div className="flex flex-col items-center gap-3 sm:flex-row">
         <Link
-          href="/sign-up"
+          href={`/school/${slug}/sign-up`}
           className="rounded-lg px-6 py-3 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md"
           style={{ backgroundColor: branding.primaryColor }}
         >
           {landing.ctaPrimaryLabel}
         </Link>
         <Link
-          href="/sign-in"
+          href={`/school/${slug}/sign-in`}
           className="rounded-lg border px-6 py-3 text-sm font-semibold transition-colors hover:bg-black/5"
           style={{
             borderColor: branding.accentColor,

--- a/src/app/(school)/school/[slug]/privacy-policy/page.tsx
+++ b/src/app/(school)/school/[slug]/privacy-policy/page.tsx
@@ -81,7 +81,7 @@ export default async function SchoolPrivacyPolicyPage({
                 <a
                   href={downloadUrl}
                   download
-                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
                   style={{ backgroundColor: primaryColor }}
                 >
                   <svg

--- a/src/app/(school)/school/[slug]/profile/page.tsx
+++ b/src/app/(school)/school/[slug]/profile/page.tsx
@@ -50,7 +50,7 @@ const PILL_RADIO_CLS =
 
 function CharCount({ value, max }: { value: string; max: number }) {
   return (
-    <p className={`text-right text-xs ${(value?.length ?? 0) > max - 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"}`}>
+    <p className={`text-right text-xs ${(value?.length ?? 0) > max - 50 ? "text-amber-700" : "text-[var(--ui-text-subtle)]"}`}>
       {value?.length ?? 0} / {max}
     </p>
   );

--- a/src/app/(school)/school/[slug]/reset-password/[[...reset-password]]/page.tsx
+++ b/src/app/(school)/school/[slug]/reset-password/[[...reset-password]]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
+import SchoolResetPassword from "@/features/school/components/auth/SchoolResetPassword";
+
+export default async function SchoolResetPasswordPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ email?: string; redirect?: string }>;
+}) {
+  const { slug } = await params;
+  const { email, redirect: redirectParam } = await searchParams;
+
+  const { userId } = await auth();
+  if (userId) {
+    redirect(redirectParam || `/school/${slug}/dashboard`);
+  }
+
+  const org = await getOrganizationBySlug(slug);
+  if (!org) notFound();
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-12">
+      <SchoolResetPassword
+        slug={org.slug}
+        schoolName={org.name}
+        allowedDomains={org.allowed_email_domains ?? []}
+        initialEmail={email ?? ""}
+        afterAuthRedirect={redirectParam ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/(school)/school/[slug]/sso-callback/page.tsx
+++ b/src/app/(school)/school/[slug]/sso-callback/page.tsx
@@ -8,7 +8,7 @@ export default function SSOCallbackPage() {
   const complete = `/school/${slug}/sso-complete`;
   return (
     <div className="flex flex-1 items-center justify-center">
-      <div className="text-sm" style={{ color: "#9cadb7" }}>
+      <div className="text-sm" style={{ color: "#5f7280" }}>
         Completing sign-in…
       </div>
       <AuthenticateWithRedirectCallback

--- a/src/app/(school)/school/[slug]/sso-complete/page.tsx
+++ b/src/app/(school)/school/[slug]/sso-complete/page.tsx
@@ -21,7 +21,8 @@ export default async function SSOCompletePage({
 
   const org = await getOrganizationBySlug(slug);
   if (!org) {
-    redirect("/");
+    console.error("sso-complete: org lookup failed for slug", slug);
+    return <AutoRetry />;
   }
 
   const clerk = await clerkClient();

--- a/src/app/(school)/school/[slug]/terms-and-conditions/page.tsx
+++ b/src/app/(school)/school/[slug]/terms-and-conditions/page.tsx
@@ -81,7 +81,7 @@ export default async function SchoolTermsPage({
                 <a
                   href={downloadUrl}
                   download
-                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  className="inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2"
                   style={{ backgroundColor: primaryColor }}
                 >
                   <svg

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
   --charcoal-black: #1c1c1c;
 
   /* - semantic UI tokens (dark-mode defaults — overridden by school layout for light orgs) - */
+  --ui-bg: #0d0d0d;
   --ui-text: #ffffff;
   --ui-text-muted: rgba(255, 255, 255, 0.5);
   --ui-text-subtle: rgba(255, 255, 255, 0.3);

--- a/src/components/FaceDetectionUploader.tsx
+++ b/src/components/FaceDetectionUploader.tsx
@@ -72,22 +72,52 @@ export default function FaceDetectionUploader({
       return;
     }
 
-    if (!file.type.startsWith("image/")) {
+    const { isHeic } = await import("heic-to");
+    // File.type for HEIC/HEIF is unreliable across browsers/OSes (often
+    // empty), so ask heic-to to sniff the actual file bytes instead.
+    const fileIsHeic = await isHeic(file).catch(() => false);
+
+    if (!fileIsHeic && !file.type.startsWith("image/")) {
       const msg = "Please select a valid image file.";
       setStatus({ type: "error", message: msg });
       onValidationFail?.(msg);
       return;
     }
 
+    let workingFile = file;
+
+    if (fileIsHeic) {
+      setStatus({ type: "loading", message: "Converting HEIC photo..." });
+      try {
+        const { heicTo } = await import("heic-to");
+        const convertedBlob = await heicTo({
+          blob: file,
+          type: "image/jpeg",
+          quality: 0.9,
+        });
+        const newName = file.name.replace(/\.hei[cf]$/i, "") + ".jpg";
+        workingFile = new File([convertedBlob], newName, {
+          type: "image/jpeg",
+        });
+      } catch (error) {
+        console.error("HEIC conversion error:", error);
+        const msg =
+          "Couldn't process this photo. Please try a different photo.";
+        setStatus({ type: "error", message: msg });
+        onValidationFail?.(msg);
+        return;
+      }
+    }
+
     setStatus({
       type: "loading",
       message: "Scanning photo with high accuracy...",
     });
-    const objectUrl = URL.createObjectURL(file);
+    const objectUrl = URL.createObjectURL(workingFile);
     setPreviewUrl(objectUrl);
 
     // Create an HTML image element for face-api to use
-const img = new window.Image();
+    const img = new window.Image();
     img.src = objectUrl;
 
     // Wait for image to load before detection
@@ -109,7 +139,7 @@ const img = new window.Image();
           if (bestScore > 0.75) {
             // Extra strict check against good cartoons
             setStatus({ type: "success", message: "✅ Valid face detected!" });
-            onValidationSuccess(file);
+            onValidationSuccess(workingFile);
           } else {
             const msg =
               "⚠️ Cannot clearly verify a real human face. Please try a clearer photo.";
@@ -145,7 +175,7 @@ const img = new window.Image();
       </label>
       <input
         type="file"
-        accept="image/png, image/jpeg, image/webp"
+        accept="image/png, image/jpeg, image/webp, image/heic, image/heif, .heic, .heif"
         onChange={handleFileChange}
         disabled={status.type === "loading" && !isModelReady}
         className="block w-full cursor-pointer rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:placeholder-gray-400"

--- a/src/components/forms/CreateProfile.tsx
+++ b/src/components/forms/CreateProfile.tsx
@@ -10,6 +10,7 @@ import OnboardingProgressBar from "@/components/ui/OnboardingProgressBar";
 import { useOnboardingDraft } from "@/hooks/useOnboardingDraft";
 import { useStepTransition } from "@/hooks/useOnboardingAnimation";
 import React, { useState, useEffect } from "react";
+import toast from "react-hot-toast";
 
 type CreateProfileProps = {
   onSubmit: (
@@ -127,6 +128,17 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
     goToStep(stepNumber - 1, "back");
   };
 
+  const handleManualSave = (stepData: Partial<OnboardingData>) => {
+    const merged = { ...formData, ...stepData };
+    setFormData(merged);
+    const ok = draft.save(stepNumber, merged);
+    if (ok) {
+      toast.success("Progress saved");
+    } else {
+      toast.error("Couldn't save — your browser storage may be full or disabled");
+    }
+  };
+
   const handleEditStep = (step: number) => {
     goToStep(step, step < stepNumber ? "back" : "forward");
   };
@@ -178,6 +190,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <AboutYouForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 3)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -185,6 +198,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <StartupForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 4)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -192,6 +206,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <BackgroundAndSocialsForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 5)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}
@@ -199,6 +214,7 @@ function CreateProfile({ onSubmit, initialData, onSuccess, onError }: CreateProf
           <InterestsAndValuesForm
             onBack={handleBack}
             onNext={(newData) => advanceStep(newData, 6)}
+            onManualSave={handleManualSave}
             defaultValues={formData}
           />
         )}

--- a/src/components/ui/AIWriter.tsx
+++ b/src/components/ui/AIWriter.tsx
@@ -127,11 +127,11 @@ export default function AIWriter({ text, onAccept, fieldType }: AIWriterProps) {
 
           {suggestionMessage && (
             <div className="flex items-center justify-between">
-              <p className="text-sm text-gray-400">{suggestionMessage}</p>
+              <p className="text-sm text-gray-600">{suggestionMessage}</p>
               <button
                 type="button"
                 onClick={rejectSuggestion}
-                className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+                className="rounded-md p-1.5 text-gray-600 transition-colors hover:bg-gray-700 hover:text-white"
               >
                 <FaXmark className="h-4 w-4" />
               </button>

--- a/src/components/ui/LocationSelector.tsx
+++ b/src/components/ui/LocationSelector.tsx
@@ -226,7 +226,7 @@ export default function LocationSelector({
     <div className="space-y-4">
       {/* Country */}
       <div className="flex flex-col gap-y-2">
-        <label className="text-sm font-medium text-gray-300">Country *</label>
+        <label className="text-sm font-medium text-[var(--ui-text)]">Country *</label>
         <select
           className={selectClass}
           value={selectedCountryIso}
@@ -256,7 +256,7 @@ export default function LocationSelector({
       {/* State — US only */}
       {isUS && (
         <div className="flex flex-col gap-y-2">
-          <label className="text-sm font-medium text-gray-300">State *</label>
+          <label className="text-sm font-medium text-[var(--ui-text)]">State *</label>
           <select
             className={selectClass}
             value={selectedStateIso}
@@ -287,7 +287,7 @@ export default function LocationSelector({
 
       {/* City — constrained combobox */}
       <div className="flex flex-col gap-y-2">
-        <label className="text-sm font-medium text-gray-300">City *</label>
+        <label className="text-sm font-medium text-[var(--ui-text)]">City *</label>
         <div ref={comboboxRef} className="relative">
           <input
             ref={inputRef}

--- a/src/features/cofounder/CoFounderLinks.tsx
+++ b/src/features/cofounder/CoFounderLinks.tsx
@@ -41,7 +41,7 @@ export default function CoFounderLinks({ userId, onClickCofounder }: Props) {
                   className="h-9 w-9 flex-shrink-0 rounded-full object-cover"
                 />
               ) : (
-                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#bf5700]/20 text-sm font-bold text-[#bf5700]">
+                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#bf5700]/20 text-sm font-bold text-[#a34800]">
                   {initials}
                 </span>
               )}

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -178,7 +178,7 @@ export default function CoFounderPanel({
           <button
             type="submit"
             disabled={sendInvite.isPending || !email.trim()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:opacity-90 disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:bg-[#a34800] disabled:opacity-50"
           >
             <FaUserPlus className="h-3.5 w-3.5" />
             {sendInvite.isPending ? "Sending…" : "Send invite"}

--- a/src/features/matches/ProfileDetailModal.tsx
+++ b/src/features/matches/ProfileDetailModal.tsx
@@ -348,7 +348,7 @@ export default function ProfileDetailModal({
                   <button
                     onClick={() => onMessage(userId)}
                     disabled={isMessagePending}
-                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                   >
                     <FaHandshake className="h-4 w-4" />
                     It&apos;s a Match!
@@ -376,7 +376,7 @@ export default function ProfileDetailModal({
                 <button
                   onClick={() => onMessage(userId)}
                   disabled={isMessagePending}
-                  className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-full bg-[var(--org-primary)] px-4 py-2.5 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-50 cursor-pointer"
                 >
                   <FaEnvelope className="h-4 w-4" />
                   Message

--- a/src/features/profile/ProfileViewModal.tsx
+++ b/src/features/profile/ProfileViewModal.tsx
@@ -335,7 +335,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                   className={`flex w-full items-center justify-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 cursor-pointer ${
                     likeStatus?.isLiked
                       ? "bg-pink-500 text-white hover:bg-pink-600"
-                      : "bg-[var(--org-primary)] text-white hover:opacity-90"
+                      : "bg-[var(--org-primary)] text-white hover:bg-[#a34800]"
                   }`}
                 >
                   <FaPaperPlane className="h-4 w-4" />

--- a/src/features/profile/services/onboardingProfile.ts
+++ b/src/features/profile/services/onboardingProfile.ts
@@ -5,6 +5,7 @@ import {
   mapSchoolProfileToUTData,
   mapUTDataToSchoolProfileRow,
 } from "@/lib/mapProfileToFromDBFormat";
+import { deriveUtStatus } from "@/features/school/onboarding/deriveUtStatus";
 
 // Shared onboarding-profile service used by the unified /api/profile endpoint
 // (and its deprecated /api/ut-profile alias). A user's school membership is
@@ -84,6 +85,13 @@ export async function saveOnboardingProfile({
       status: 400,
       error: "utStatus is required for school profiles",
     };
+  }
+
+  // A self-reported "student" whose graduation year has already passed is
+  // actually alumni — correct it here so the DB stays right even if a client
+  // bug (or a direct API call) submits a stale/inconsistent utStatus.
+  if (isSchool) {
+    formData = { ...formData, utStatus: deriveUtStatus(formData.utStatus, formData.gradYear) };
   }
 
   const supabase = serviceRoleClient();

--- a/src/features/school/components/SchoolHeader.tsx
+++ b/src/features/school/components/SchoolHeader.tsx
@@ -127,7 +127,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
     >
       <Link
         href={`/school/${slug}`}
-        className="text-base font-semibold tracking-tight text-white/70 transition-colors hover:text-white"
+        className="text-base font-semibold tracking-tight text-white transition-[font-weight] duration-300 hover:font-bold"
       >
         {headerText}
       </Link>
@@ -139,12 +139,12 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             key={href}
             href={href}
             className={featured
-              ? "rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
+              ? "rounded-lg border border-white/30 px-3 py-1.5 text-sm font-medium text-white transition-[border-color,font-weight] duration-300 hover:font-semibold hover:border-white/60"
               : clsx(
-                  "text-sm font-medium transition-colors border-b-2",
+                  "text-sm font-medium transition-[border-color,font-weight] duration-300 border-b-2",
                   pathname.startsWith(href)
                     ? "text-white border-white"
-                    : "text-white/70 hover:text-white border-transparent",
+                    : "text-white hover:font-semibold border-transparent",
                 )
             }
           >
@@ -157,7 +157,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
         <Link
           href={cofounderHref}
           onClick={handleCofounderClick}
-          className="hidden items-center gap-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white md:flex"
+          className="hidden items-center gap-1.5 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold md:flex"
         >
           <FaUserPlus className="h-3.5 w-3.5" />
           Invite a co-foundr
@@ -165,7 +165,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
 
         <Link
           href={`/school/${slug}/matches`}
-          className="relative flex items-center justify-center text-white/70 transition-colors hover:text-white"
+          className="relative flex items-center justify-center text-white transition-transform duration-300 hover:scale-110"
         >
           <FaHeart className="h-5 w-5 text-white" />
           {savedMatchesCount > 0 && (
@@ -204,7 +204,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
         {/* Mobile hamburger */}
         <button
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          className="cursor-pointer rounded-lg p-1.5 text-white/70 transition-colors hover:text-white md:hidden"
+          className="cursor-pointer rounded-lg p-1.5 text-white transition-transform duration-300 hover:scale-110 md:hidden"
           aria-label="Toggle menu"
         >
           {isMobileMenuOpen ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
@@ -224,8 +224,8 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
                 <Link
                   href={href}
                   className={featured
-                    ? "block rounded-lg border border-white/30 px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white hover:border-white/60"
-                    : "block rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                    ? "block rounded-lg border border-white/30 px-3 py-2 text-sm font-medium text-white transition-[border-color,font-weight] duration-300 hover:font-semibold hover:border-white/60"
+                    : "block rounded-lg px-3 py-2 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold"
                   }
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
@@ -236,7 +236,7 @@ export default function SchoolHeader({ slug, schoolName, config, isAdmin }: Scho
             <li>
               <Link
                 href={cofounderHref}
-                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/70 transition-colors hover:text-white"
+                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold"
                 onClick={() => {
                   handleCofounderClick();
                   setIsMobileMenuOpen(false);

--- a/src/features/school/components/auth/AutoRetry.tsx
+++ b/src/features/school/components/auth/AutoRetry.tsx
@@ -13,7 +13,7 @@ export default function AutoRetry() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm" style={{ color: "#9cadb7" }}>
+      <p className="text-sm" style={{ color: "#5f7280" }}>
         Setting up your account…
       </p>
     </div>

--- a/src/features/school/components/auth/SchoolResetPassword.tsx
+++ b/src/features/school/components/auth/SchoolResetPassword.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth, useSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  isEmailDomainAllowed,
+  formatAllowedDomainsForCopy,
+} from "@/features/school/auth/email-domain";
+import {
+  checkExistingUser,
+  type ExistingUserInfo,
+} from "@/features/school/auth/school-auth";
+import { completeSchoolSignIn } from "./complete-school-signin";
+
+type Props = {
+  slug: string;
+  schoolName: string;
+  allowedDomains: string[];
+  initialEmail?: string;
+  afterAuthRedirect?: string | null;
+};
+
+/** Pull Clerk's first error message off a thrown error, with a fallback. */
+function clerkErrorMessage(err: unknown, fallback: string): string {
+  if (
+    err &&
+    typeof err === "object" &&
+    "errors" in err &&
+    Array.isArray((err as { errors: { message: string }[] }).errors)
+  ) {
+    return (
+      (err as { errors: { message: string }[] }).errors[0]?.message ?? fallback
+    );
+  }
+  return fallback;
+}
+
+export default function SchoolResetPassword({
+  slug,
+  schoolName,
+  allowedDomains,
+  initialEmail = "",
+  afterAuthRedirect = null,
+}: Props) {
+  const { isLoaded, signIn, setActive } = useSignIn();
+  const { getToken } = useAuth();
+  const router = useRouter();
+
+  const [email, setEmail] = useState(initialEmail);
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [secondFactorCode, setSecondFactorCode] = useState("");
+  // Flow phases: "request" → "reset" → (optional) "secondFactor".
+  const [pendingReset, setPendingReset] = useState(false);
+  const [pendingSecondFactor, setPendingSecondFactor] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [existingUser, setExistingUser] = useState<ExistingUserInfo>({
+    exists: false,
+    hasPassword: false,
+    oauthProviders: [],
+  });
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const allowedCopy = formatAllowedDomainsForCopy(allowedDomains);
+  const existingHasGoogle = existingUser.oauthProviders.includes("oauth_google");
+  // A Google-only account has no password to reset — steer them back to Google.
+  const isGoogleOnly =
+    existingUser.exists && existingHasGoogle && !existingUser.hasPassword;
+
+  useEffect(() => {
+    if (pendingReset) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setExistingUser({ exists: false, hasPassword: false, oauthProviders: [] });
+    const trimmed = email.trim();
+    if (!trimmed || !isEmailDomainAllowed(trimmed, allowedDomains)) return;
+    debounceRef.current = setTimeout(async () => {
+      const info = await checkExistingUser(trimmed);
+      setExistingUser(info);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [email, allowedDomains, pendingReset]);
+
+  async function finish(sessionId: string | null) {
+    // setActive is guaranteed defined here: reached only after `isLoaded`.
+    const { error: assignError } = await completeSchoolSignIn({
+      setActive: setActive!,
+      getToken,
+      router,
+      slug,
+      sessionId,
+      afterAuthRedirect,
+    });
+    if (assignError) setError(assignError);
+  }
+
+  async function handleRequest(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (!isEmailDomainAllowed(email, allowedDomains)) {
+      setError(
+        `This portal is for ${schoolName}. Sign in at mamuncofoundr.com instead, or use a ${allowedCopy} email.`,
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await signIn.create({
+        strategy: "reset_password_email_code",
+        identifier: email,
+      });
+      setPendingReset(true);
+    } catch (err: unknown) {
+      setError(
+        clerkErrorMessage(
+          err,
+          "We couldn't send a reset code. Please try again.",
+        ),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleReset(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords don't match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await signIn.attemptFirstFactor({
+        strategy: "reset_password_email_code",
+        code,
+        password,
+      });
+
+      if (result.status === "complete") {
+        await finish(result.createdSessionId);
+        return;
+      }
+
+      // Account-level MFA can require a second factor after the reset. Mirror
+      // SchoolSignIn's email_code handling. The installed @clerk/types predates
+      // email_code as a typed second factor, hence the casts.
+      if (result.status === "needs_second_factor") {
+        const factors = (result.supportedSecondFactors ??
+          []) as unknown as Array<{
+          strategy: string;
+          emailAddressId?: string;
+        }>;
+        const emailFactor = factors.find((f) => f.strategy === "email_code");
+        if (emailFactor) {
+          await signIn.prepareSecondFactor({
+            strategy: "email_code",
+            emailAddressId: emailFactor.emailAddressId,
+          } as never);
+          setPendingSecondFactor(true);
+        } else {
+          setError(
+            "Additional verification is required. Please contact support.",
+          );
+        }
+        return;
+      }
+
+      setError("We couldn't reset your password. Please try again.");
+    } catch (err: unknown) {
+      setError(clerkErrorMessage(err, "Invalid or expired code. Try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleVerifySecondFactor(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isLoaded) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const attempt = await signIn.attemptSecondFactor({
+        strategy: "email_code",
+        code: secondFactorCode,
+      } as never);
+      if (attempt.status === "complete") {
+        await finish(attempt.createdSessionId);
+      } else {
+        setError("Verification could not be completed. Please try again.");
+      }
+    } catch (err: unknown) {
+      setError(clerkErrorMessage(err, "Invalid code. Please try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const heading = pendingSecondFactor
+    ? "Verify it's you"
+    : pendingReset
+      ? "Check your email"
+      : "Reset your password";
+  const subtitle = pendingSecondFactor
+    ? `We sent a verification code to ${email}.`
+    : pendingReset
+      ? `We sent a 6-digit code to ${email}. Enter it with a new password.`
+      : `Enter your ${allowedCopy} email and we'll send a reset code.`;
+
+  const inputClass =
+    "w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-sm outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20";
+  const codeInputClass =
+    "w-full rounded-lg border border-[#e8e4dc] px-3 py-2 text-base tracking-[0.5em] outline-none transition focus:border-[#bf5700] focus:ring-2 focus:ring-[#bf5700]/20";
+  const labelClass = "mb-1 block text-xs font-medium";
+  const buttonClass =
+    "w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50";
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-2xl border border-[#e8e4dc] bg-white p-8 shadow-sm">
+        <div className="mb-6">
+          <h1
+            className="mb-1 text-xl font-semibold tracking-tight md:text-2xl"
+            style={{ color: "#333f48" }}
+          >
+            {heading}
+          </h1>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
+            {subtitle}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {pendingSecondFactor ? (
+          <form onSubmit={handleVerifySecondFactor} className="space-y-4">
+            <div>
+              <label
+                htmlFor="sf-code"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Verification code
+              </label>
+              <input
+                id="sf-code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                value={secondFactorCode}
+                onChange={(e) => setSecondFactorCode(e.target.value)}
+                className={codeInputClass}
+                maxLength={6}
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className={buttonClass}
+            >
+              {submitting ? "Verifying…" : "Verify and continue"}
+            </button>
+          </form>
+        ) : pendingReset ? (
+          <form onSubmit={handleReset} className="space-y-4">
+            <div>
+              <label
+                htmlFor="code"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Reset code
+              </label>
+              <input
+                id="code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className={codeInputClass}
+                maxLength={6}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="new-password"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                New password
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={inputClass}
+                minLength={8}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="confirm-password"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                Confirm new password
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={inputClass}
+                minLength={8}
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !isLoaded}
+              className={buttonClass}
+            >
+              {submitting ? "Resetting…" : "Reset password"}
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handleRequest} className="space-y-4">
+            <div>
+              <label
+                htmlFor="email"
+                className={labelClass}
+                style={{ color: "#333f48" }}
+              >
+                School email
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@utexas.edu"
+                className={inputClass}
+                required
+              />
+              {isGoogleOnly && (
+                <p className="mt-1.5 text-xs" style={{ color: "#7a3a00" }}>
+                  This account uses Google sign-in, so there&apos;s no password
+                  to reset.{" "}
+                  <Link
+                    href={`/school/${slug}/sign-in`}
+                    className="font-semibold hover:underline"
+                    style={{ color: "#bf5700" }}
+                  >
+                    Go to sign in
+                  </Link>
+                  .
+                </p>
+              )}
+            </div>
+
+            <div id="clerk-captcha" />
+
+            {!isGoogleOnly && (
+              <button
+                type="submit"
+                disabled={submitting || !isLoaded}
+                className={buttonClass}
+              >
+                {submitting ? "Sending code…" : "Send reset code"}
+              </button>
+            )}
+          </form>
+        )}
+
+        <div
+          className="mt-6 border-t pt-4 text-center text-xs"
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
+        >
+          Remember your password?{" "}
+          <Link
+            href={`/school/${slug}/sign-in`}
+            className="font-semibold hover:underline"
+            style={{ color: "#bf5700" }}
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -9,10 +9,10 @@ import {
   formatAllowedDomainsForCopy,
 } from "@/features/school/auth/email-domain";
 import {
-  assignSchoolOrg,
   checkExistingUser,
   type ExistingUserInfo,
 } from "@/features/school/auth/school-auth";
+import { completeSchoolSignIn } from "./complete-school-signin";
 import GoogleOAuthButton from "./GoogleOAuthButton";
 
 type Props = {
@@ -73,14 +73,15 @@ export default function SchoolSignIn({
   async function completeSignIn(sessionId: string | null) {
     // setActive is guaranteed defined here: every caller only reaches this
     // after `isLoaded` was already checked truthy in the calling handler.
-    await setActive!({ session: sessionId });
-    const assigned = await assignSchoolOrg(slug);
-    if ("error" in assigned) {
-      setError(assigned.error);
-      return;
-    }
-    await getToken({ skipCache: true });
-    router.push(afterAuthRedirect ?? `/school/${slug}`);
+    const { error: assignError } = await completeSchoolSignIn({
+      setActive: setActive!,
+      getToken,
+      router,
+      slug,
+      sessionId,
+      afterAuthRedirect,
+    });
+    if (assignError) setError(assignError);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -269,13 +270,28 @@ export default function SchoolSignIn({
 
               {showPasswordField && (
                 <div>
-                  <label
-                    htmlFor="password"
-                    className="mb-1 block text-xs font-medium"
-                    style={{ color: "#333f48" }}
-                  >
-                    Password
-                  </label>
+                  <div className="mb-1 flex items-center justify-between">
+                    <label
+                      htmlFor="password"
+                      className="block text-xs font-medium"
+                      style={{ color: "#333f48" }}
+                    >
+                      Password
+                    </label>
+                    <Link
+                      href={`/school/${slug}/reset-password?email=${encodeURIComponent(
+                        email,
+                      )}${
+                        afterAuthRedirect
+                          ? `&redirect=${encodeURIComponent(afterAuthRedirect)}`
+                          : ""
+                      }`}
+                      className="text-xs font-medium hover:underline"
+                      style={{ color: "#bf5700" }}
+                    >
+                      Forgot password?
+                    </Link>
+                  </div>
                   <input
                     id="password"
                     type="password"

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -215,7 +215,7 @@ export default function SchoolSignIn({
               </>
             )}
           </h1>
-          <p className="text-sm" style={{ color: "#9cadb7" }}>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
             {pendingSecondFactor
               ? `We sent a 6-digit code to ${email}.`
               : `Use your ${allowedCopy} account.`}
@@ -235,7 +235,7 @@ export default function SchoolSignIn({
             </div>
             <div className="mb-4 flex items-center gap-3">
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
-              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#5f7280" }}>
                 or
               </span>
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
@@ -339,7 +339,7 @@ export default function SchoolSignIn({
 
         <div
           className="mt-6 border-t pt-4 text-center text-xs"
-          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
         >
           Don&apos;t have an account?{" "}
           <Link

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -294,8 +294,7 @@ export default function SchoolSignIn({
                 <button
                   type="submit"
                   disabled={submitting || !isLoaded}
-                  className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-                  style={{ backgroundColor: "#bf5700" }}
+                  className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
                 >
                   {submitting ? "Signing in…" : "Sign in"}
                 </button>
@@ -329,8 +328,7 @@ export default function SchoolSignIn({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Verifying…" : "Verify and continue"}
             </button>

--- a/src/features/school/components/auth/SchoolSignUp.tsx
+++ b/src/features/school/components/auth/SchoolSignUp.tsx
@@ -160,7 +160,7 @@ export default function SchoolSignUp({
               </>
             )}
           </h1>
-          <p className="text-sm" style={{ color: "#9cadb7" }}>
+          <p className="text-sm" style={{ color: "#5f7280" }}>
             {pendingVerification
               ? `We sent a 6-digit code to ${email}.`
               : `Sign up with your ${allowedCopy} email.`}
@@ -180,7 +180,7 @@ export default function SchoolSignUp({
             </div>
             <div className="mb-4 flex items-center gap-3">
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
-              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#9cadb7" }}>
+              <span className="text-[10px] uppercase tracking-[0.1em]" style={{ color: "#5f7280" }}>
                 or
               </span>
               <div className="h-px flex-1" style={{ backgroundColor: "#e8e4dc" }} />
@@ -300,12 +300,12 @@ export default function SchoolSignUp({
               {submitting ? "Creating account…" : "Create account"}
             </button>
 
-            <p className="text-center text-[11px]" style={{ color: "#9cadb7" }}>
+            <p className="text-center text-[11px]" style={{ color: "#5f7280" }}>
               By creating an account, you agree to our{" "}
               <Link
                 href={`/school/${slug}/privacy-policy`}
                 className="font-medium underline hover:opacity-70"
-                style={{ color: "#9cadb7" }}
+                style={{ color: "#5f7280" }}
               >
                 Privacy Policy
               </Link>
@@ -350,7 +350,7 @@ export default function SchoolSignUp({
 
         <div
           className="mt-6 border-t pt-4 text-center text-xs"
-          style={{ borderColor: "#e8e4dc", color: "#9cadb7" }}
+          style={{ borderColor: "#e8e4dc", color: "#5f7280" }}
         >
           Already have an account?{" "}
           <Link

--- a/src/features/school/components/auth/SchoolSignUp.tsx
+++ b/src/features/school/components/auth/SchoolSignUp.tsx
@@ -260,8 +260,7 @@ export default function SchoolSignUp({
                     {existingHasPassword && (
                       <Link
                         href={`/school/${slug}/sign-in`}
-                        className="block rounded-lg px-4 py-2 text-center text-xs font-semibold text-white transition-opacity hover:opacity-90"
-                        style={{ backgroundColor: "#bf5700" }}
+                        className="block rounded-lg bg-[#bf5700] px-4 py-2 text-center text-xs font-semibold text-white transition-colors hover:bg-[#a34800]"
                       >
                         Sign in with password
                       </Link>
@@ -294,8 +293,7 @@ export default function SchoolSignUp({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Creating account…" : "Create account"}
             </button>
@@ -304,8 +302,7 @@ export default function SchoolSignUp({
               By creating an account, you agree to our{" "}
               <Link
                 href={`/school/${slug}/privacy-policy`}
-                className="font-medium underline hover:opacity-70"
-                style={{ color: "#5f7280" }}
+                className="font-medium text-[#5f7280] underline transition-colors hover:text-[#a34800]"
               >
                 Privacy Policy
               </Link>
@@ -340,8 +337,7 @@ export default function SchoolSignUp({
             <button
               type="submit"
               disabled={submitting || !isLoaded}
-              className="w-full rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ backgroundColor: "#bf5700" }}
+              className="w-full rounded-lg bg-[#bf5700] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#a34800] disabled:opacity-50"
             >
               {submitting ? "Verifying…" : "Verify and continue"}
             </button>

--- a/src/features/school/components/auth/SessionRefreshRedirect.tsx
+++ b/src/features/school/components/auth/SessionRefreshRedirect.tsx
@@ -17,7 +17,7 @@ export default function SessionRefreshRedirect({ to }: { to: string }) {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm" style={{ color: "#9cadb7" }}>
+      <p className="text-sm" style={{ color: "#5f7280" }}>
         Setting up your account…
       </p>
     </div>

--- a/src/features/school/components/auth/complete-school-signin.ts
+++ b/src/features/school/components/auth/complete-school-signin.ts
@@ -1,0 +1,35 @@
+import type { useSignIn, useAuth } from "@clerk/nextjs";
+import type { useRouter } from "next/navigation";
+import { assignSchoolOrg } from "@/features/school/auth/school-auth";
+
+type SetActive = NonNullable<ReturnType<typeof useSignIn>["setActive"]>;
+type GetToken = ReturnType<typeof useAuth>["getToken"];
+type Router = ReturnType<typeof useRouter>;
+
+/**
+ * Shared tail of every successful school auth flow (sign-in and password
+ * reset): activate the Clerk session, (re-)assign the user to the school org,
+ * refresh the JWT so the new org metadata is on the token, then redirect into
+ * the portal. Returns `{ error }` when org assignment fails so the caller can
+ * surface it in its error banner.
+ */
+export async function completeSchoolSignIn(opts: {
+  setActive: SetActive;
+  getToken: GetToken;
+  router: Router;
+  slug: string;
+  sessionId: string | null;
+  afterAuthRedirect?: string | null;
+}): Promise<{ error?: string }> {
+  const { setActive, getToken, router, slug, sessionId, afterAuthRedirect } =
+    opts;
+
+  await setActive({ session: sessionId });
+  const assigned = await assignSchoolOrg(slug);
+  if ("error" in assigned) {
+    return { error: assigned.error };
+  }
+  await getToken({ skipCache: true });
+  router.push(afterAuthRedirect ?? `/school/${slug}`);
+  return {};
+}

--- a/src/features/school/components/contact/UtAboutPanel.tsx
+++ b/src/features/school/components/contact/UtAboutPanel.tsx
@@ -13,15 +13,14 @@ export default function UtAboutPanel() {
     >
       <div className="px-6 py-10 sm:px-12 sm:py-14">
         <p
-          className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
-          style={{ color: "rgba(255,255,255,0.55)" }}
+          className="mb-2 text-[10px] font-medium text-white uppercase tracking-[0.1em]"
         >
           University of Texas at Austin
         </p>
         <h2 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
           Have a school question?
         </h2>
-        <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed text-white/80">
+        <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed text-white">
           For questions about UT programs, events, or anything school-related
           that isn&apos;t about the co-foundr platform, reach out to McCombs
           directly.

--- a/src/features/school/components/contact/UtSupportPanel.tsx
+++ b/src/features/school/components/contact/UtSupportPanel.tsx
@@ -15,7 +15,7 @@ export default function UtSupportPanel() {
       <h2 className="mb-3 text-2xl font-semibold sm:text-3xl" style={{ color: "#333f48" }}>
         Need help with the platform?
       </h2>
-      <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed sm:text-base" style={{ color: "#9cadb7" }}>
+      <p className="mx-auto mb-8 max-w-md text-sm leading-relaxed sm:text-base" style={{ color: "#5f7280" }}>
         Book time with the Mamun team for help with your account, matches, or
         anything else technical on the co-foundr platform.
       </p>
@@ -32,7 +32,7 @@ export default function UtSupportPanel() {
       </Link>
 
       <div className="border-t pt-6" style={{ borderColor: "rgba(0,0,0,0.06)" }}>
-        <p className="mb-1 text-sm" style={{ color: "#9cadb7" }}>
+        <p className="mb-1 text-sm" style={{ color: "#5f7280" }}>
           Or email us at{" "}
           <a
             href="mailto:mamun@mamuncofoundr.com"
@@ -42,7 +42,7 @@ export default function UtSupportPanel() {
             mamun@mamuncofoundr.com
           </a>
         </p>
-        <p className="text-sm" style={{ color: "#9cadb7" }}>
+        <p className="text-sm" style={{ color: "#5f7280" }}>
           Leave your full name and we will get back to you within 1–2 business
           days.
         </p>

--- a/src/features/school/components/dashboard/FilterSidebar.tsx
+++ b/src/features/school/components/dashboard/FilterSidebar.tsx
@@ -91,7 +91,7 @@ function FilterSelect({
                 role="option"
                 aria-selected={!selected}
                 onClick={() => { onChange(""); setOpen(false); }}
-                className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${!selected ? "font-medium text-[#BF5700]" : "text-[#3d1a00]/50"}`}
+                className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${!selected ? "font-medium text-[#a34800]" : "text-[#3d1a00]/70"}`}
               >
                 {placeholder}
               </li>
@@ -101,7 +101,7 @@ function FilterSelect({
                   role="option"
                   aria-selected={opt.value === String(value)}
                   onClick={() => { onChange(opt.value); setOpen(false); }}
-                  className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${opt.value === String(value) ? "font-medium text-[#BF5700]" : "text-[#3d1a00]"}`}
+                  className={`cursor-pointer px-4 py-2.5 text-sm transition hover:bg-[#BF5700]/10 ${opt.value === String(value) ? "font-medium text-[#a34800]" : "text-[#3d1a00]"}`}
                 >
                   {opt.value === String(value) && <span className="mr-1.5">✓</span>}
                   {opt.label}
@@ -172,7 +172,7 @@ function FilterPanel({
             <button
               type="button"
               onClick={clearAll}
-              className="text-xs font-medium text-[#bf5700] hover:underline cursor-pointer"
+              className="text-xs font-medium text-[#a34800] hover:underline cursor-pointer"
             >
               Clear all
             </button>

--- a/src/features/school/components/landing/CtaBand.tsx
+++ b/src/features/school/components/landing/CtaBand.tsx
@@ -33,7 +33,7 @@ export default function CtaBand() {
         <motion.div
           variants={item}
           className="mb-2 text-[10px] font-medium uppercase tracking-[0.1em]"
-          style={{ color: "rgba(255,255,255,0.5)" }}
+          style={{ color: "#ffffff" }}
         >
           University of Texas
         </motion.div>
@@ -45,7 +45,7 @@ export default function CtaBand() {
         </motion.h2>
         <motion.p
           variants={item}
-          className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white/70"
+          className="mx-auto mb-7 max-w-md text-sm leading-relaxed text-white"
         >
           Join the University of Texas co-foundr community — verified, value-aligned, and
           ready to build something that changes the world.
@@ -59,7 +59,7 @@ export default function CtaBand() {
             Create your profile
           </Link>
         </motion.div>
-        <motion.div variants={item} className="text-xs text-white/40">
+        <motion.div variants={item} className="text-xs text-white">
           Exclusively for University of Texas students, alumni, and faculty
         </motion.div>
       </motion.div>

--- a/src/features/school/components/landing/DepartmentMosaic.tsx
+++ b/src/features/school/components/landing/DepartmentMosaic.tsx
@@ -103,6 +103,78 @@ const TIER_2: Dept[] = [
       { label: "BioTech", bg: "#fdecea", fg: "#922b21" },
     ],
   },
+  {
+    name: "Jackson Geosciences",
+    programs: "Geo Sciences · Env Sci · Energy & Earth Resources",
+    accent: "#ca8a04",
+    chips: [
+      { label: "CleanTech", bg: "#fdf6e3", fg: "#a16207" },
+      { label: "DeepTech", bg: "#fdf6e3", fg: "#a16207" },
+    ],
+  },
+  {
+    name: "Civic Leadership",
+    programs: "BS Civic Leadership",
+    accent: "#4b3f8f",
+    chips: [
+      { label: "Policy", bg: "#eeecf9", fg: "#4b3f8f" },
+      { label: "GovTech", bg: "#eeecf9", fg: "#4b3f8f" },
+    ],
+  },
+  {
+    name: "Education",
+    programs: "Applied Learning · STEM Ed · Youth & Community Studies",
+    accent: "#0f766e",
+    chips: [
+      { label: "EdTech", bg: "#e6f4f3", fg: "#0f766e" },
+      { label: "Impact", bg: "#e6f4f3", fg: "#0f766e" },
+    ],
+  },
+  {
+    name: "Nursing",
+    programs: "BSN · MSN · DNP",
+    accent: "#059669",
+    chips: [
+      { label: "HealthTech", bg: "#e5f5ef", fg: "#059669" },
+      { label: "BioTech", bg: "#e5f5ef", fg: "#059669" },
+    ],
+  },
+  {
+    name: "Pharmacy",
+    programs: "PharmD · Pharmaceutical Sciences",
+    accent: "#7c3aed",
+    chips: [
+      { label: "HealthTech", bg: "#f1eafd", fg: "#7c3aed" },
+      { label: "BioTech", bg: "#f1eafd", fg: "#7c3aed" },
+    ],
+  },
+  {
+    name: "Social Work",
+    programs: "BSW · MSSW",
+    accent: "#65a30d",
+    chips: [
+      { label: "Impact", bg: "#f0f6e3", fg: "#65a30d" },
+      { label: "Policy", bg: "#f0f6e3", fg: "#65a30d" },
+    ],
+  },
+  {
+    name: "Law",
+    programs: "JD · LLM",
+    accent: "#57534e",
+    chips: [
+      { label: "Policy", bg: "#eeece9", fg: "#57534e" },
+      { label: "GovTech", bg: "#eeece9", fg: "#57534e" },
+    ],
+  },
+  {
+    name: "Pre-Med, Pre-Law & Teaching",
+    programs: "Pre-Med · Pre-Law · Pre-Teaching",
+    accent: "#0284c7",
+    chips: [
+      { label: "HealthTech", bg: "#e5f3fb", fg: "#0284c7" },
+      { label: "EdTech", bg: "#e5f3fb", fg: "#0284c7" },
+    ],
+  },
 ];
 
 function Card({ dept }: { dept: Dept }) {
@@ -173,7 +245,7 @@ export default function DepartmentMosaic() {
           className="mb-10 text-center text-sm"
           style={{ color: "#5f7280" }}
         >
-          Founders from across every corner of the University of Texas — 10 schools, one
+          Founders from across every corner of the University of Texas — 18 schools, one
           platform, one mission.
         </p>
 

--- a/src/features/school/components/landing/DepartmentMosaic.tsx
+++ b/src/features/school/components/landing/DepartmentMosaic.tsx
@@ -136,7 +136,7 @@ function Card({ dept }: { dept: Dept }) {
       </div>
       <div
         className="mb-2 pl-1 text-[11px]"
-        style={{ color: "#9cadb7" }}
+        style={{ color: "#5f7280" }}
       >
         {dept.programs}
       </div>
@@ -171,7 +171,7 @@ export default function DepartmentMosaic() {
         </h2>
         <p
           className="mb-10 text-center text-sm"
-          style={{ color: "#9cadb7" }}
+          style={{ color: "#5f7280" }}
         >
           Founders from across every corner of the University of Texas — 10 schools, one
           platform, one mission.

--- a/src/features/school/components/landing/Hero.tsx
+++ b/src/features/school/components/landing/Hero.tsx
@@ -36,11 +36,11 @@ export default function Hero() {
         >
           Make it here.
           <br />
-          <span className="text-white/60">Find your founding team.</span>
+          <span className="text-white">Find your founding team.</span>
         </motion.h1>
         <motion.p
           variants={item}
-          className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white/70 sm:text-base"
+          className="mx-auto mb-8 max-w-xl text-sm leading-relaxed text-white sm:text-base"
         >
           The University of Texas co-foundr matching platform connects value-aligned students,
           alumni, and faculty ready to build something that changes the world.

--- a/src/features/school/components/landing/HowItWorks.tsx
+++ b/src/features/school/components/landing/HowItWorks.tsx
@@ -85,7 +85,7 @@ export default function HowItWorks() {
               </div>
               <div
                 className="text-sm leading-relaxed"
-                style={{ color: "#9cadb7" }}
+                style={{ color: "#5f7280" }}
               >
                 {s.desc}
               </div>

--- a/src/features/school/components/landing/PublicFooter.tsx
+++ b/src/features/school/components/landing/PublicFooter.tsx
@@ -28,69 +28,47 @@ export default function PublicFooter({ slug }: { slug: string }) {
 
           <div className="flex gap-12">
             <div>
-              <div
-                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <div className="mb-3 text-[10px] font-semibold text-white/70 uppercase tracking-[0.08em]">
                 Resources
               </div>
-              <motion.a
+              <a
                 href="https://www.cakeequity.com/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block text-xs hover:text-white transition-colors"
-                style={{ color: "#9cadb7" }}
-                whileHover={{ color: "#ffffff" }}
+                className="block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
               >
                 Create a Cap Table
-              </motion.a>
+              </a>
             </div>
             <div>
-              <div
-                className="mb-3 text-[10px] font-semibold uppercase tracking-[0.08em]"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <div className="mb-3 text-[10px] font-semibold text-white/70 uppercase tracking-[0.08em]">
                 Company
               </div>
-              <motion.div
-                whileHover={{ color: "#ffffff" }}
+              <Link
+                href={`/school/${slug}/privacy-policy`}
+                className="mb-1.5 block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
               >
-                <Link
-                  href={`/school/${slug}/privacy-policy`}
-                  className="mb-1.5 block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Privacy Policy
-                </Link>
-              </motion.div>
-              <motion.div whileHover={{ color: "#ffffff" }}>
-                <Link
-                  href={`/school/${slug}/terms-and-conditions`}
-                  className="mb-1.5 block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Terms &amp; Conditions
-                </Link>
-              </motion.div>
-              <motion.div whileHover={{ color: "#ffffff" }}>
-                <Link
-                  href={`/school/${slug}/contact-us`}
-                  className="block text-xs hover:text-white transition-colors"
-                  style={{ color: "#9cadb7" }}
-                >
-                  Contact Us
-                </Link>
-              </motion.div>
+                Privacy Policy
+              </Link>
+              <Link
+                href={`/school/${slug}/terms-and-conditions`}
+                className="mb-1.5 block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
+              >
+                Terms &amp; Conditions
+              </Link>
+              <Link
+                href={`/school/${slug}/contact-us`}
+                className="block text-xs text-[#9cadb7] transition-colors duration-300 hover:text-white"
+              >
+                Contact Us
+              </Link>
             </div>
           </div>
         </motion.div>
 
         <div
-          className="border-t pt-5 text-xs"
-          style={{
-            borderColor: "rgba(255,255,255,0.08)",
-            color: "rgba(255,255,255,0.25)",
-          }}
+          className="border-t pt-5 text-xs text-white/60"
+          style={{ borderColor: "rgba(255,255,255,0.08)" }}
         >
           © 2026 University of Texas Co-Foundr. Powered by Mamun. All rights
           reserved.

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -19,13 +19,13 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
         </a>
         <Link
           href={`/school/${slug}/contact-us`}
-          className="text-xs sm:text-sm font-medium text-white/75 hover:text-white whitespace-nowrap"
+          className="text-xs sm:text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold whitespace-nowrap"
         >
           Contact us
         </Link>
         <Link
           href={`/school/${slug}/privacy-policy`}
-          className="text-xs sm:text-sm font-medium text-white/75 hover:text-white whitespace-nowrap"
+          className="text-xs sm:text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold whitespace-nowrap"
         >
           Privacy Policy
         </Link>

--- a/src/features/school/components/landing/WhyItWorks.tsx
+++ b/src/features/school/components/landing/WhyItWorks.tsx
@@ -92,7 +92,7 @@ export default function WhyItWorks() {
         >
           <p
             className="text-[9px] font-bold tracking-widest uppercase text-center mb-3"
-            style={{ color: "#9cadb7" }}
+            style={{ color: "#5f7280" }}
           >
             10 UT Schools · One pool
           </p>
@@ -116,7 +116,7 @@ export default function WhyItWorks() {
                   </span>
                   <span
                     className="block text-[9px] leading-snug whitespace-nowrap mt-0.5"
-                    style={{ color: "#9cadb7" }}
+                    style={{ color: "#5f7280" }}
                   >
                     {s.role}
                   </span>
@@ -244,7 +244,7 @@ export default function WhyItWorks() {
         viewport={{ once: true }}
         transition={{ duration: 0.5, delay: 0.2 }}
         className="mt-8 text-center text-xs leading-relaxed"
-        style={{ color: "#9cadb7" }}
+        style={{ color: "#5f7280" }}
       >
         You bring what you&apos;re great at.{" "}
         <strong style={{ color: "#5a6a75", fontWeight: 600 }}>

--- a/src/features/school/components/landing/WhyItWorks.tsx
+++ b/src/features/school/components/landing/WhyItWorks.tsx
@@ -13,6 +13,14 @@ const SCHOOLS = [
   { name: "Architecture", role: "Space · Systems", color: "#333f48" },
   { name: "LBJ", role: "Public Affairs", color: "#9cadb7" },
   { name: "Dell Medical", role: "Health · Clinical", color: "#c0392b" },
+  { name: "Jackson Geosciences", role: "Geosciences · Energy", color: "#ca8a04" },
+  { name: "Civic Leadership", role: "Leadership · Policy", color: "#4b3f8f" },
+  { name: "Education", role: "Education · Impact", color: "#0f766e" },
+  { name: "Nursing", role: "Health · Care", color: "#059669" },
+  { name: "Pharmacy", role: "Pharma · Health", color: "#7c3aed" },
+  { name: "Social Work", role: "Social Work · Impact", color: "#65a30d" },
+  { name: "Law", role: "Law · Policy", color: "#57534e" },
+  { name: "Pre-Professional", role: "Pre-Med · Pre-Law · Teaching", color: "#0284c7" },
 ];
 
 const container = {
@@ -74,7 +82,7 @@ export default function WhyItWorks() {
         >
           An engineer who can&apos;t sell. A business student with no one to
           build. A designer working alone. The matching engine reaches across all
-          10 schools and assembles the team none of them could find on their own.
+          18 schools and assembles the team none of them could find on their own.
         </motion.p>
       </div>
 
@@ -94,7 +102,7 @@ export default function WhyItWorks() {
             className="text-[9px] font-bold tracking-widest uppercase text-center mb-3"
             style={{ color: "#5f7280" }}
           >
-            10 UT Schools · One pool
+            18 UT Schools · One pool
           </p>
           <div className="grid grid-cols-2 gap-x-5 gap-y-3">
             {SCHOOLS.map((s) => (

--- a/src/features/school/data/utSchoolsAndMajors.ts
+++ b/src/features/school/data/utSchoolsAndMajors.ts
@@ -19,7 +19,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Finance', abbreviation: 'MFinance' },
       { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
     ] as const,
-    sectorInterests: ['b2b_saas', 'fintech'] as const,
   },
   cockrell_engineering: {
     label: 'Cockrell Engineering',
@@ -33,7 +32,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Biomedical Engineering', abbreviation: 'Biomedical' },
       { degreeType: 'bachelors', name: 'Chemical Engineering', abbreviation: 'ChE' },
     ] as const,
-    sectorInterests: ['ai_ml', 'deeptech'] as const,
   },
   school_of_information: {
     label: 'School of Information',
@@ -46,7 +44,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Human-Computer Interaction', abbreviation: 'HCI' },
       { degreeType: 'masters', name: 'Information Systems', abbreviation: 'MIS' },
     ] as const,
-    sectorInterests: ['data', 'ux'] as const,
   },
   natural_sciences: {
     label: 'Natural Sciences',
@@ -58,7 +55,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Chemistry', abbreviation: 'Chemistry' },
       { degreeType: 'bachelors', name: 'Neuroscience', abbreviation: 'Neuroscience' },
     ] as const,
-    sectorInterests: ['healthtech', 'biotech'] as const,
   },
   liberal_arts: {
     label: 'Liberal Arts',
@@ -70,7 +66,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Government', abbreviation: 'Government' },
       { degreeType: 'bachelors', name: 'Plan II Honors', abbreviation: 'Plan II' },
     ] as const,
-    sectorInterests: ['policy', 'impact'] as const,
   },
   moody_communication: {
     label: 'Moody Communication',
@@ -83,7 +78,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Public Relations', abbreviation: 'PR' },
       { degreeType: 'bachelors', name: 'Radio-Television-Film', abbreviation: 'RTF' },
     ] as const,
-    sectorInterests: ['media', 'consumer'] as const,
   },
   college_of_fine_arts: {
     label: 'College of Fine Arts',
@@ -96,7 +90,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'bachelors', name: 'Music', abbreviation: 'Music' },
       { degreeType: 'bachelors', name: 'Theatre', abbreviation: 'Theatre' },
     ] as const,
-    sectorInterests: ['edtech', 'consumer'] as const,
   },
   school_of_architecture: {
     label: 'School of Architecture',
@@ -108,7 +101,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Architecture', abbreviation: 'MArch' },
       { degreeType: 'masters', name: 'Urban Design', abbreviation: 'Urban Design' },
     ] as const,
-    sectorInterests: ['proptech', 'cleantech'] as const,
   },
   lbj_public_affairs: {
     label: 'LBJ Public Affairs',
@@ -120,7 +112,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Global Policy', abbreviation: 'Global Policy' },
       { degreeType: 'professional', name: 'Juris Doctor / Public Affairs', abbreviation: 'JD/MPAff' },
     ] as const,
-    sectorInterests: ['govtech', 'impact'] as const,
   },
   dell_medical_school: {
     label: 'Dell Medical School',
@@ -132,7 +123,6 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'professional', name: 'Doctor of Medicine / Doctor of Philosophy', abbreviation: 'MD/PhD' },
       { degreeType: 'masters', name: 'Health Innovation', abbreviation: 'Health Innovation' },
     ] as const,
-    sectorInterests: ['healthtech', 'biotech'] as const,
   },
 } as const;
 
@@ -183,12 +173,6 @@ export const getProgramsForSchoolAndDegreeType = (
   return getProgramsForSchool(school).filter(
     p => p.degreeType === degreeType,
   );
-};
-
-export const getSectorInterestsForSchool = (
-  school: UTCollege,
-): readonly UTSectorInterest[] => {
-  return UT_SCHOOLS_AND_PROGRAMS[school].sectorInterests;
 };
 
 export const getSchoolLabel = (school: UTCollege): string => {

--- a/src/features/school/data/utSchoolsAndMajors.ts
+++ b/src/features/school/data/utSchoolsAndMajors.ts
@@ -124,6 +124,90 @@ export const UT_SCHOOLS_AND_PROGRAMS = {
       { degreeType: 'masters', name: 'Health Innovation', abbreviation: 'Health Innovation' },
     ] as const,
   },
+  jackson_geosciences: {
+    label: 'Jackson Geosciences',
+    fullName: 'Jackson School of Geosciences',
+    tier: 'partner',
+    color: 'from-yellow-600 to-yellow-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Geological Sciences', abbreviation: 'Geo Sciences' },
+      { degreeType: 'bachelors', name: 'Environmental Science', abbreviation: 'Env Sci' },
+      { degreeType: 'masters', name: 'Energy and Earth Resources', abbreviation: 'Energy & Earth Resources' },
+    ] as const,
+  },
+  school_of_civic_leadership: {
+    label: 'Civic Leadership',
+    fullName: 'School of Civic Leadership',
+    tier: 'partner',
+    color: 'from-indigo-600 to-indigo-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Civic Leadership', abbreviation: 'BS Civic Leadership' },
+    ] as const,
+  },
+  college_of_education: {
+    label: 'Education',
+    fullName: 'College of Education',
+    tier: 'partner',
+    color: 'from-teal-600 to-teal-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Applied Learning & Development', abbreviation: 'ALD' },
+      { degreeType: 'bachelors', name: 'STEM Education', abbreviation: 'STEM Ed' },
+      { degreeType: 'bachelors', name: 'Youth & Community Studies', abbreviation: 'YCS' },
+      { degreeType: 'masters', name: 'Curriculum & Instruction', abbreviation: 'M.Ed.' },
+    ] as const,
+  },
+  school_of_nursing: {
+    label: 'Nursing',
+    fullName: 'School of Nursing',
+    tier: 'partner',
+    color: 'from-emerald-600 to-emerald-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Nursing', abbreviation: 'BSN' },
+      { degreeType: 'masters', name: 'Nursing', abbreviation: 'MSN' },
+      { degreeType: 'professional', name: 'Doctor of Nursing Practice', abbreviation: 'DNP' },
+    ] as const,
+  },
+  college_of_pharmacy: {
+    label: 'Pharmacy',
+    fullName: 'College of Pharmacy',
+    tier: 'partner',
+    color: 'from-violet-600 to-violet-700',
+    programs: [
+      { degreeType: 'professional', name: 'Doctor of Pharmacy', abbreviation: 'PharmD' },
+      { degreeType: 'masters', name: 'Pharmaceutical Sciences', abbreviation: 'Pharm Sci' },
+    ] as const,
+  },
+  school_of_social_work: {
+    label: 'Social Work',
+    fullName: 'School of Social Work',
+    tier: 'partner',
+    color: 'from-lime-600 to-lime-700',
+    programs: [
+      { degreeType: 'bachelors', name: 'Social Work', abbreviation: 'BSW' },
+      { degreeType: 'masters', name: 'Social Work', abbreviation: 'MSSW' },
+    ] as const,
+  },
+  school_of_law: {
+    label: 'Law',
+    fullName: 'School of Law',
+    tier: 'partner',
+    color: 'from-stone-600 to-stone-700',
+    programs: [
+      { degreeType: 'professional', name: 'Juris Doctor', abbreviation: 'JD' },
+      { degreeType: 'masters', name: 'Law', abbreviation: 'LLM' },
+    ] as const,
+  },
+  pre_med_pre_law_teaching: {
+    label: 'Pre-Med, Pre-Law & Teaching',
+    fullName: 'Pre-Med, Pre-Law & Teaching',
+    tier: 'partner',
+    color: 'from-sky-600 to-sky-700',
+    programs: [
+      { degreeType: 'other', name: 'Pre-Med', abbreviation: 'Pre-Med' },
+      { degreeType: 'other', name: 'Pre-Law', abbreviation: 'Pre-Law' },
+      { degreeType: 'other', name: 'Pre-Teaching', abbreviation: 'Pre-Teaching' },
+    ] as const,
+  },
 } as const;
 
 export const DEGREE_TYPE_LABELS: Record<DegreeType, string> = {

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -95,7 +95,7 @@ function UTAboutYouForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 2 of 5
+            Step 2 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">About you</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -43,7 +43,7 @@ function CharCount({ value, max }: { value: string; max: number }) {
   return (
     <p
       className={`text-right text-xs ${
-        remaining < 50 ? "text-amber-400" : "text-[var(--ui-text-subtle)]"
+        remaining < 50 ? "text-amber-700" : "text-[var(--ui-text-subtle)]"
       }`}
     >
       {value.length} / {max}

--- a/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
+++ b/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
@@ -46,7 +46,7 @@ function UTBackgroundAndSocialsForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 4 of 5
+            Step 4 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">Additional details</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTInterestsForm.tsx
+++ b/src/features/school/onboarding/components/UTInterestsForm.tsx
@@ -142,10 +142,17 @@ function UTInterestsForm({
 
   const selectedAreas = watch("priorityAreas") || [];
 
+  // defaultValues crosses a JSON boundary (localStorage draft / API response),
+  // so its shape isn't guaranteed to match the string[] type at runtime.
+  const defaultPriorityAreas = Array.isArray(defaultValues?.priorityAreas)
+    ? defaultValues.priorityAreas
+    : [];
+
   useEffect(() => {
-    if (defaultValues?.priorityAreas) {
-      reset(defaultValues);
+    if (defaultPriorityAreas.length > 0) {
+      reset({ priorityAreas: defaultPriorityAreas });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValues, reset]);
 
   const errCount = Object.keys(errors).length;
@@ -209,9 +216,7 @@ function UTInterestsForm({
                         value={tag}
                         {...register("priorityAreas")}
                         disabled={isDisabled}
-                        defaultChecked={defaultValues?.priorityAreas?.includes(
-                          tag,
-                        )}
+                        defaultChecked={defaultPriorityAreas.includes(tag)}
                         className="sr-only"
                       />
                       {tag}

--- a/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
+++ b/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
@@ -112,7 +112,7 @@ function UTProfilePhotoForm({ onNext, defaultValues }: UTProfilePhotoFormProps) 
         {/* Header */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 1 of 5
+            Step 1 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">
             Add your profile photo

--- a/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
+++ b/src/features/school/onboarding/components/UTProfilePhotoForm.tsx
@@ -118,7 +118,7 @@ function UTProfilePhotoForm({ onNext, defaultValues }: UTProfilePhotoFormProps) 
             Add your profile photo
           </h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">
-            Our AI verifies it contains a real face to keep profiles authentic.
+            Make sure your face is clearly visible in the photo.
           </p>
         </div>
 

--- a/src/features/school/onboarding/components/UTReviewForm.tsx
+++ b/src/features/school/onboarding/components/UTReviewForm.tsx
@@ -30,7 +30,7 @@ export default function UTReviewForm({
       {/* Header */}
       <div className="pb-4">
         <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-          Step 5 of 5
+          Step 6 of 6
         </p>
         <h2 className="text-2xl font-bold text-[var(--ui-text)]">Review your info</h2>
         <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -60,6 +60,11 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
     if (corrected && corrected !== utStatusValue) sv("utStatus", corrected);
   }, [utStatusValue, gradYearValue, sv]);
 
+  const currentYear = new Date().getFullYear();
+  const isAlumni = utStatusValue === "alumni";
+  const gradYearMin = isAlumni ? 1965 : currentYear;
+  const gradYearMax = isAlumni ? currentYear : currentYear + 10;
+
   const availableDegreeTypes = utCollegeValue ? getDegreeTypesForSchool(utCollegeValue) : [];
   const availablePrograms =
     utCollegeValue && utDegreeTypeValue
@@ -202,8 +207,14 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
           placeholder="e.g. 2026"
           {...reg("gradYear", {
             valueAsNumber: true,
-            min: { value: 1900, message: "Invalid year" },
-            max: { value: 2035, message: "Invalid year" },
+            min: {
+              value: gradYearMin,
+              message: isAlumni ? "Invalid year" : "Graduation year can't be in the past for students",
+            },
+            max: {
+              value: gradYearMax,
+              message: isAlumni ? "Graduation year can't be in the future for alumni" : "Invalid year",
+            },
           })}
         />
         {errs.gradYear && (

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -156,7 +156,7 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
             Select relevant sectors aligned with your program
           </p>
           <div className="flex flex-wrap gap-2">
-            {UT_SCHOOLS_AND_PROGRAMS[utCollegeValue].sectorInterests.map((sector) => (
+            {(Object.keys(SECTOR_INTEREST_LABELS) as UTSectorInterest[]).map((sector) => (
               <label
                 key={sector}
                 className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-all duration-150 ${

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -20,7 +20,7 @@ const LABEL_CLS =
   "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)]";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 type UTSchoolFieldsData = {
   utStatus: "student" | "alumni";

--- a/src/features/school/onboarding/components/UTSchoolFields.tsx
+++ b/src/features/school/onboarding/components/UTSchoolFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import {
   UseFormRegister,
   UseFormWatch,
@@ -15,6 +16,7 @@ import {
   DEGREE_TYPE_LABELS,
   SECTOR_INTEREST_LABELS,
 } from "@/features/school/data/utSchoolsAndMajors";
+import { deriveUtStatus } from "@/features/school/onboarding/deriveUtStatus";
 
 const LABEL_CLS =
   "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
@@ -49,6 +51,14 @@ export default function UTSchoolFields<T extends FieldValues>({ register, watch,
   const utCollegeValue = w("utCollege");
   const utDegreeTypeValue = w("utDegreeType");
   const utSectorInterestsValue = w("utSectorInterests") || [];
+  const gradYearValue = w("gradYear");
+
+  // A graduation year that's already passed means the person is alumni,
+  // even if they'd previously selected (or defaulted to) "student".
+  useEffect(() => {
+    const corrected = deriveUtStatus(utStatusValue, gradYearValue);
+    if (corrected && corrected !== utStatusValue) sv("utStatus", corrected);
+  }, [utStatusValue, gradYearValue, sv]);
 
   const availableDegreeTypes = utCollegeValue ? getDegreeTypesForSchool(utCollegeValue) : [];
   const availablePrograms =

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -66,7 +66,7 @@ function UTStartupForm({
         {/* ── Header ── */}
         <div className="pb-4">
           <p className="mb-1 text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase">
-            Step 3 of 5
+            Step 3 of 6
           </p>
           <h2 className="text-2xl font-bold text-[var(--ui-text)]">Startup or idea</h2>
           <p className="mt-1.5 text-sm text-[var(--ui-text-muted)]">

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -21,7 +21,7 @@ const TEXTAREA_CLS =
   "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] resize-none";
 
 const SELECT_CLS =
-  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-neutral-900";
+  "w-full rounded-xl border border-[var(--ui-border)] bg-[var(--ui-surface)] px-4 py-3.5 text-[var(--ui-text)] transition-all duration-200 focus:border-[var(--ui-border-strong)] focus:bg-[var(--ui-surface)] focus:ring-2 focus:ring-[var(--ui-border)] focus:outline-none hover:border-[var(--ui-border-strong)] [&>option]:bg-[var(--ui-popover-bg)] [&>option]:text-[var(--ui-text)]";
 
 const LABEL_CLS = "text-xs font-semibold tracking-widest text-[var(--ui-text-muted)] uppercase";
 

--- a/src/features/school/onboarding/deriveUtStatus.test.ts
+++ b/src/features/school/onboarding/deriveUtStatus.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { deriveUtStatus, hasGraduationYearPassed } from "./deriveUtStatus";
+
+describe("hasGraduationYearPassed", () => {
+  it("is false when gradYear is undefined", () => {
+    expect(hasGraduationYearPassed(undefined)).toBe(false);
+  });
+
+  it("is false when gradYear is the current year or later", () => {
+    const currentYear = new Date().getFullYear();
+    expect(hasGraduationYearPassed(currentYear)).toBe(false);
+    expect(hasGraduationYearPassed(currentYear + 1)).toBe(false);
+  });
+
+  it("is true when gradYear is before the current year", () => {
+    const currentYear = new Date().getFullYear();
+    expect(hasGraduationYearPassed(currentYear - 1)).toBe(true);
+  });
+});
+
+describe("deriveUtStatus", () => {
+  const currentYear = new Date().getFullYear();
+
+  it("corrects student to alumni when gradYear has already passed", () => {
+    expect(deriveUtStatus("student", currentYear - 1)).toBe("alumni");
+  });
+
+  it("leaves student as-is when gradYear is current or future", () => {
+    expect(deriveUtStatus("student", currentYear)).toBe("student");
+    expect(deriveUtStatus("student", currentYear + 1)).toBe("student");
+  });
+
+  it("leaves student as-is when gradYear is unset", () => {
+    expect(deriveUtStatus("student", undefined)).toBe("student");
+  });
+
+  it("trusts an explicit alumni selection regardless of gradYear", () => {
+    expect(deriveUtStatus("alumni", currentYear + 2)).toBe("alumni");
+  });
+
+  it("passes through an undefined utStatus", () => {
+    expect(deriveUtStatus(undefined, currentYear - 1)).toBeUndefined();
+  });
+});

--- a/src/features/school/onboarding/deriveUtStatus.ts
+++ b/src/features/school/onboarding/deriveUtStatus.ts
@@ -1,0 +1,15 @@
+export function hasGraduationYearPassed(gradYear: number | undefined): boolean {
+  if (gradYear === undefined) return false;
+  return gradYear < new Date().getFullYear();
+}
+
+// A self-reported "student" whose graduation year has already passed is
+// actually alumni; "alumni" is trusted as-is regardless of gradYear since
+// someone can return to school after graduating.
+export function deriveUtStatus(
+  utStatus: "student" | "alumni" | undefined,
+  gradYear: number | undefined,
+): "student" | "alumni" | undefined {
+  if (utStatus === "student" && hasGraduationYearPassed(gradYear)) return "alumni";
+  return utStatus;
+}

--- a/src/features/school/onboarding/stepRegistry.ts
+++ b/src/features/school/onboarding/stepRegistry.ts
@@ -4,6 +4,7 @@ import UTProfilePhotoForm from "@/features/school/onboarding/components/UTProfil
 import UTAboutYouForm from "@/features/school/onboarding/components/UTAboutYouForm";
 import UTStartupForm from "@/features/school/onboarding/components/UTStartupForm";
 import UTBackgroundAndSocialsForm from "@/features/school/onboarding/components/UTBackgroundAndSocialsForm";
+import UTInterestsForm from "@/features/school/onboarding/components/UTInterestsForm";
 
 export type StepProps = {
   onNext: (data: Partial<OnboardingData>) => void;
@@ -19,4 +20,5 @@ export const STEP_COMPONENTS: Record<StepStepId, ComponentType<StepProps>> = {
   about: UTAboutYouForm as ComponentType<StepProps>,
   startup: UTStartupForm as ComponentType<StepProps>,
   background: UTBackgroundAndSocialsForm as ComponentType<StepProps>,
+  priorities: UTInterestsForm as ComponentType<StepProps>,
 };

--- a/src/features/school/policies/PrivacyPolicyTOC.tsx
+++ b/src/features/school/policies/PrivacyPolicyTOC.tsx
@@ -87,7 +87,7 @@ export function PolicyDesktopTOC({
 
   return (
     <nav aria-label="Policy table of contents">
-      <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-400">
+      <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-gray-600">
         Contents
       </p>
       <ul className="space-y-0.5">

--- a/src/features/school/policies/ut-terms.tsx
+++ b/src/features/school/policies/ut-terms.tsx
@@ -381,7 +381,7 @@ export default function UTTermsAndConditions({ primaryColor }: Props) {
           For any question about these Terms, you can get in touch with us by emailing us at{" "}
           <a
             href="mailto:mamun@mamuncofoundr.com"
-            className="underline hover:opacity-70"
+            className="rounded underline decoration-2 underline-offset-2 transition-colors hover:bg-black/5"
             style={{ color: primaryColor }}
           >
             mamun@mamuncofoundr.com

--- a/src/features/school/registry/registry.ts
+++ b/src/features/school/registry/registry.ts
@@ -59,9 +59,9 @@ export const ORG_REGISTRY: Record<string, OrgConfig> = {
       unlimitedMessages: true,
     },
     onboarding: {
-      totalSteps: 5,
+      totalSteps: 6,
       apiEndpoint: "/api/profile",
-      steps: ["photo", "about", "startup", "background", "review"],
+      steps: ["photo", "about", "startup", "background", "priorities", "review"],
       step2RequiredFields: [
         "firstName",
         "lastName",

--- a/src/features/school/registry/types.ts
+++ b/src/features/school/registry/types.ts
@@ -21,7 +21,13 @@ export type OrgLimits = {
   unlimitedMessages: boolean;
 };
 
-export type OnboardingStepId = "photo" | "about" | "startup" | "background" | "review";
+export type OnboardingStepId =
+  | "photo"
+  | "about"
+  | "startup"
+  | "background"
+  | "priorities"
+  | "review";
 
 export type OrgOnboarding = {
   totalSteps: number;

--- a/src/features/school/types.d.ts
+++ b/src/features/school/types.d.ts
@@ -44,7 +44,15 @@ declare global {
     | "college_of_fine_arts"
     | "school_of_architecture"
     | "lbj_public_affairs"
-    | "dell_medical_school";
+    | "dell_medical_school"
+    | "school_of_civic_leadership"
+    | "college_of_education"
+    | "school_of_nursing"
+    | "college_of_pharmacy"
+    | "school_of_social_work"
+    | "school_of_law"
+    | "pre_med_pre_law_teaching"
+    | "jackson_geosciences";
 
   type UTDegreeType = "bachelors" | "masters" | "professional" | "other";
 

--- a/src/hooks/useOnboardingDraft.ts
+++ b/src/hooks/useOnboardingDraft.ts
@@ -37,14 +37,16 @@ export function useOnboardingDraft() {
     }
   };
 
-  const save = (step: number, data: OnboardingData) => {
+  const save = (step: number, data: OnboardingData): boolean => {
     try {
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({ step, data: stripPhoto(data) }),
       );
+      return true;
     } catch {
-      // Storage full or unavailable — fail silently
+      // Storage full or unavailable
+      return false;
     }
   };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,6 +31,7 @@ const isPublicRoute = createRouteMatcher([
   "/school/:slug/not-authorized",
   "/school/:slug/sign-up(.*)",
   "/school/:slug/sign-in(.*)",
+  "/school/:slug/reset-password(.*)",
   "/school/:slug/sso-callback(.*)",
   "/school/:slug/sso-complete(.*)",
 ]);
@@ -260,7 +261,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
 
     // MEMBERSHIP / EMAIL-DOMAIN GATE
     // Skip on auth-flow paths (sign-in/up/sso-*): sso-complete assigns org.
-    const isAuthFlowPath = /\/(sign-in|sign-up|sso-callback|sso-complete)(\/|$)/.test(pathname);
+    const isAuthFlowPath = /\/(sign-in|sign-up|reset-password|sso-callback|sso-complete)(\/|$)/.test(pathname);
     if (!isAuthFlowPath) {
       const claimOrgId = sessionClaims?.metadata?.organization_id;
       // Fast path: already assigned to this org via Clerk metadata → skip Clerk API call.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -225,13 +225,36 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   // regardless of the user's global organization_id.
   // ----------------------------------------------------------------
   if (isSchoolContext) {
-    if (isApiRoute || isPublicRoute(req)) {
+    // The bare school landing page ("/school/:slug") is public so anonymous
+    // visitors and users of other orgs can view the marketing page, but it
+    // must not become a dead end for a just-signed-up member of *this* org —
+    // see the dedicated check below, run after org resolution.
+    const isBareSchoolLanding = pathname === `/school/${pathSlug}`;
+
+    if (isApiRoute || (isPublicRoute(req) && !isBareSchoolLanding)) {
       return NextResponse.next();
     }
 
     const org = await resolveOrgBySlug(pathSlug!);
     if (!org) {
       // Unknown slug — let the [slug] layout handle notFound()
+      return NextResponse.next();
+    }
+
+    if (isBareSchoolLanding) {
+      const claimOrgId = sessionClaims?.metadata?.organization_id;
+      if (claimOrgId === org.id) {
+        const schoolOnboarding = sessionClaims?.metadata?.schoolOnboarding;
+        const schoolDone =
+          schoolOnboarding?.[org.id] === true ||
+          (sessionClaims?.metadata?.onboardingComplete === true &&
+            sessionClaims?.metadata?.organization_id === org.id);
+        if (!schoolDone) {
+          return NextResponse.redirect(
+            new URL(`/school/${org.slug}/onboarding`, req.url),
+          );
+        }
+      }
       return NextResponse.next();
     }
 

--- a/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
+++ b/supabase/migrations/20260623000003_fix_pool_membership_onboarded_at.sql
@@ -1,0 +1,21 @@
+-- Migration: Fix onboarded_at for backfilled membership rows
+--
+-- The expand migration (20260623000001) set onboarded_at only when
+-- profiles.onboarding_complete = true. That column is never written by the
+-- app (Phase 1 moved onboarding-complete tracking to Clerk publicMetadata),
+-- so every backfilled row landed with onboarded_at = NULL.
+--
+-- A profiles row exists iff the user completed onboarding (the onboarding
+-- flow writes the row on submit). Treat profiles.updated_at as a conservative
+-- completion timestamp for all pre-existing members.
+
+UPDATE profile_pool_memberships m
+SET onboarded_at = p.updated_at
+FROM profiles p
+WHERE p.user_id = m.user_id
+  AND m.onboarded_at IS NULL;
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: onboarded_at backfilled from profiles.updated_at for all NULL membership rows.';
+END $$;

--- a/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
+++ b/supabase/migrations/20260623000004_fix_pool_membership_rls_selfjoin.sql
@@ -1,0 +1,64 @@
+-- Migration: Fix pool-membership RLS self-join
+--
+-- Problem: the profiles_select_org policy in 20260623000002 proves "viewer and
+-- target share a pool" by self-joining profile_pool_memberships. The ppm_owner
+-- RLS on that table is enforced inside the subquery, so the target_m side
+-- (another user's rows) is invisible — making EXISTS always false for everyone
+-- except the viewer themselves. Net result: every user can only read their own
+-- profile, breaking the matching feed, likes, mutual matches, conversations,
+-- and user_activity_summary. Same bug exists in user_activity_summary_org_isolation.
+--
+-- Fix: a SECURITY DEFINER helper function that runs as its owner (bypassing
+-- ppm_owner), allowing the join to see both sides. Precedent: upsert_pool_membership
+-- in 20260623000001 is also SECURITY DEFINER for the same reason.
+--
+-- Scope: replaces only the two affected SELECT policies. No other policies,
+-- tables, or write guards are changed.
+
+-- ============================================================
+-- Helper: shared-pool membership check
+-- Runs as function owner → bypasses ppm_owner RLS → can see
+-- both the viewer's and the target's membership rows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.shares_pool_with(target text)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE
+SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM profile_pool_memberships viewer_m
+    JOIN profile_pool_memberships target_m
+      ON target_m.user_id = target
+     AND target_m.organization_id IS NOT DISTINCT FROM viewer_m.organization_id
+    WHERE viewer_m.user_id = auth.jwt() ->> 'sub'
+  );
+$$;
+
+-- ============================================================
+-- profiles — fix shared-membership SELECT
+-- ============================================================
+DROP POLICY IF EXISTS "profiles_select_org" ON profiles;
+
+CREATE POLICY "profiles_select_org" ON profiles
+  FOR SELECT
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+-- ============================================================
+-- user_activity_summary — same fix (mirrors profiles policy)
+-- ============================================================
+DROP POLICY IF EXISTS "user_activity_summary_org_isolation" ON user_activity_summary;
+
+CREATE POLICY "user_activity_summary_org_isolation" ON user_activity_summary
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_id = auth.jwt() ->> 'sub'
+    OR public.shares_pool_with(user_id)
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Fix: shares_pool_with() SECURITY DEFINER helper created; profiles_select_org and user_activity_summary_org_isolation policies rewritten to use it.';
+END $$;

--- a/supabase/migrations/20260713000000_ensure_mccombs_utexas_domain.sql
+++ b/supabase/migrations/20260713000000_ensure_mccombs_utexas_domain.sql
@@ -1,0 +1,19 @@
+-- Migration: Ensure mccombs.utexas.edu is in UT Austin's allowed email domains
+--
+-- mccombs.utexas.edu has been documented in seed.sql as an allowed UT
+-- domain, but seed.sql is not applied to production — only migrations are.
+-- Ensure the live org row actually has it (idempotent — no-op if already present).
+
+UPDATE organizations
+SET allowed_email_domains = (
+  SELECT ARRAY(
+    SELECT DISTINCT unnest(allowed_email_domains || ARRAY['mccombs.utexas.edu'])
+  )
+)
+WHERE slug = 'ut'
+  AND NOT ('mccombs.utexas.edu' = ANY (allowed_email_domains));
+
+DO $$
+BEGIN
+  RAISE NOTICE '✅ Ensured mccombs.utexas.edu is in UT org allowed_email_domains.';
+END $$;


### PR DESCRIPTION
## Summary
This PR merges a batch of UT co-foundr fixes spanning onboarding, authentication, database security, messaging, and accessibility. The most significant change is a critical RLS bug fix that was silently restricting every user to only seeing their own profile, breaking matching, likes, and conversations. It also adds a new onboarding step (priority areas/interests), a self-service password reset flow, HEIC photo upload support, 8 additional UT schools, and a sweep of WCAG contrast fixes across auth/landing/dashboard surfaces.

## Changes

### Database / RLS
- **Fix critical RLS self-join bug** (`20260623000004_fix_pool_membership_rls_selfjoin.sql`): `profiles_select_org` and `user_activity_summary_org_isolation` proved "viewer and target share a pool" by self-joining `profile_pool_memberships`, but the `ppm_owner` RLS on that table made the target's rows invisible inside the subquery — so the `EXISTS` was always false for everyone except the viewer. This silently broke the matching feed, likes, mutual matches, conversations, and activity summaries. Fixed with a `SECURITY DEFINER` helper function `shares_pool_with()` that bypasses `ppm_owner` to see both sides of the join (same pattern already used by `upsert_pool_membership`).
- **Backfill `onboarded_at`** (`20260623000003_fix_pool_membership_onboarded_at.sql`): the prior expand migration only set `onboarded_at` when `profiles.onboarding_complete = true`, a column the app never writes (onboarding-complete tracking moved to Clerk `publicMetadata`). Backfills using `profiles.updated_at` as a conservative completion timestamp for all pre-existing members.
- **Ensure `mccombs.utexas.edu`** is present in the UT org's `allowed_email_domains` in production (`20260713000000_ensure_mccombs_utexas_domain.sql`) — it was documented in `seed.sql` but seed data isn't applied to prod, only migrations.

### Authentication
- **New self-service password reset flow**: `SchoolResetPassword.tsx` (new, 416 lines) implements request → reset-code+new-password → optional second-factor, mirroring `SchoolSignIn`'s MFA handling. Served at `/school/[slug]/reset-password`, wired into `SchoolSignIn` via a "Forgot password?" link, and detects Google-only accounts to steer them back to OAuth sign-in instead of a dead-end reset.
- **Extract `completeSchoolSignIn`** (`complete-school-signin.ts`, new): the shared tail of every successful auth flow (activate Clerk session → assign school org → refresh JWT → redirect) was duplicated inline in `SchoolSignIn`; now shared between sign-in and the new reset-password flow.
- **`middleware.ts`**: registers `/school/:slug/reset-password(.*)` as a public route and as an auth-flow path (skips the membership/email-domain gate, same as sign-in/sign-up/sso-*).
- **Fix onboarding dead-end on bare school landing**: previously `/school/:slug` was unconditionally treated as public and skipped further checks, so a freshly-signed-up member of that org could land there and never get redirected into onboarding. Middleware now runs a dedicated check after org resolution — if the session's org claim matches and onboarding isn't complete, it redirects to `/school/:slug/onboarding`.
- **`sso-complete`**: on org lookup failure, no longer hard-redirects to `/` (killing the flow); now logs the error and renders `<AutoRetry />` to handle eventual-consistency races.

### Onboarding
- **New "priorities" step**: `UTInterestsForm` is wired into `stepRegistry.ts` and `registry.ts` as a 6th onboarding step (`totalSteps: 5 → 6`), with all "Step X of 5" labels bumped to "of 6" across the UT form components.
- **Fix uneditable priority areas**: `UTInterestsForm` previously called `reset(defaultValues)` whenever `defaultValues` changed at all, and used `defaultChecked` sourced directly from a possibly-non-array `defaultValues.priorityAreas` — together these caused checkboxes to silently fail to reflect user edits. Now derives a guaranteed-array `defaultPriorityAreas` (defensive against the JSON boundary from localStorage/API) and only resets when it's non-empty.
- **Manual "Save progress"**: `AboutYouForm`, `BackgroundAndSocialsForm`, `InterestsAndValuesForm`, and `StartupForm` gain an optional `onManualSave` button that calls `getValues()` and persists via `useOnboardingDraft`. `CreateProfile.tsx` wires this to `draft.save()` and shows a toast (success or storage-failure) via `react-hot-toast`. `useOnboardingDraft.save` now returns a boolean so the caller can react to failure instead of failing silently.
- **Auto-correct student/alumni status from grad year**: new `deriveUtStatus.ts` (with unit tests) — a self-reported "student" whose `gradYear` has already passed is corrected to "alumni"; explicit "alumni" is trusted regardless of `gradYear` (someone can return to school). Applied client-side in `UTSchoolFields` (live, as the user edits the field) and server-side in `onboardingProfile.ts` (defense against stale client state or direct API calls). `gradYear` min/max validation now also depends on the current status (alumni: 1965–current year; student: current year–+10).
- **Sector interests decoupled from school**: removed the per-school `sectorInterests` field and `getSectorInterestsForSchool` from `utSchoolsAndMajors.ts`; `UTSchoolFields` now offers the full `SECTOR_INTEREST_LABELS` set regardless of selected school.
- **Copy changes**: profile-photo and edit-profile copy no longer claims "AI verifies a real human face" (overstated — it's a face-detection check, not identity verification); now reads "Make sure your face is clearly visible in the photo."

### Profile Photo / HEIC Support
- `FaceDetectionUploader.tsx`: adds `heic-to` (new dependency) to detect HEIC/HEIF files by sniffing bytes (since `File.type` is unreliable for HEIC across browsers/OSes) and transcodes to JPEG client-side before face detection and upload. File input `accept` now includes `image/heic`, `image/heif`, `.heic`, `.heif`.

### Messaging
- Both conversation pages (`(general)/messages/[conversationId]` and `(school)/school/[slug]/matches/[conversationId]`) replace the single-line message `<input>` with an auto-growing `<textarea>` (max height 160px), Enter-to-send / Shift+Enter-for-newline, and update the helper text accordingly.
- Privacy notice restyled from a stark yellow-icon/white-border box to a blue-tinted informational style for better visual hierarchy.

### UT School Data / Landing Page
- Adds 8 new schools to `utSchoolsAndMajors.ts` and `types.d.ts` (`jackson_geosciences`, `school_of_civic_leadership`, `college_of_education`, `school_of_nursing`, `college_of_pharmacy`, `school_of_social_work`, `school_of_law`, `pre_med_pre_law_teaching`), bringing the total from 10 to 18 — reflected in `DepartmentMosaic.tsx`, `WhyItWorks.tsx` copy and school lists.
- Dashboard search bar (`SchoolDashboardPage`) now toggles open/closed from the same button (clearing the query on close) instead of only opening, with `aria-expanded` and an icon swap.

### Accessibility (WCAG) / Visual Polish
- Broad contrast fix: replaced `#9cadb7` (2.3:1 on white) with `#5f7280` (5.0:1) across UT auth (`SchoolSignIn`, `SchoolSignUp`, `AcceptInviteClient`, `sso-callback`, `AutoRetry`, `SessionRefreshRedirect`), landing (`DepartmentMosaic`, `HowItWorks`, `UtSupportPanel`, `WhyItWorks`), and invite pages.
- Replaced opacity-based hover states (`hover:opacity-90`, `text-white/70 hover:text-white`) with solid color, font-weight, or shadow transitions for WCAG-compliant contrast at all interaction states — spans `SchoolHeader`, `PublicFooter`, `PublicSchoolHeader`, dashboard buttons/badges, invite/policy pages, and CTA buttons (brand orange hover state standardized to `#a34800`).
- Status badges (student/alumni, technical/non-technical) converted from solid saturated backgrounds to a tint-chip pattern (e.g. `bg-emerald-100 text-emerald-800`) to fix insufficient contrast; fixed low-contrast `amber-400`/`gray-400`/`gray-300` text on light backgrounds in `CharCount`, `AIWriter`, `PrivacyPolicyTOC`, and `LocationSelector` (the latter also switched to the `--ui-text` CSS variable so it works correctly on light-mode school orgs).
- Standardized `<select>` option colors across browsers/devices in onboarding forms (`StartupForm`, `UTStartupForm`, `UTSchoolFields`) using `--ui-popover-bg`/`--ui-text` instead of a hardcoded `bg-neutral-900`; added a `--ui-bg` semantic token.

## Migration / Config
- Three new Supabase migrations must be applied: `20260623000003_fix_pool_membership_onboarded_at.sql`, `20260623000004_fix_pool_membership_rls_selfjoin.sql` (critical — restores cross-user profile visibility), and `20260713000000_ensure_mccombs_utexas_domain.sql`. All are written to be idempotent/safe to re-run.
- New dependency: `heic-to` (^1.5.2) for client-side HEIC/HEIF-to-JPEG conversion.

## Notes
- The RLS self-join fix is the highest-priority item in this PR — until it's deployed, matching/likes/conversations are effectively broken for all users on affected environments.
- `deriveUtStatus` unit tests are included (`deriveUtStatus.test.ts`) but no other new automated test coverage is added in this batch.
