### PR TITLE
Add startup column and year filter to admin matches table +  fix school sign-in redirect

### DIFF
--- a/src/app/(school)/school/[slug]/admin/page.tsx
+++ b/src/app/(school)/school/[slug]/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSession } from "@clerk/nextjs";
 import {
   FaUserGraduate,
@@ -91,6 +91,7 @@ export default function SchoolAdminPage() {
   );
   const [matchesLoading, setMatchesLoading] = useState(false);
   const [matchesFetched, setMatchesFetched] = useState(false);
+  const [matchYearFilter, setMatchYearFilter] = useState<string>("");
 
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [analyticsLoading, setAnalyticsLoading] = useState(false);
@@ -193,6 +194,28 @@ export default function SchoolAdminPage() {
     fetchAnalytics,
   ]);
 
+  const matchYears = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          matchConnections.map((c) => new Date(c.matched_at).getFullYear()),
+        ),
+      ).sort((a, b) => b - a),
+    [matchConnections],
+  );
+
+  const filteredMatchConnections = useMemo(
+    () =>
+      matchYearFilter
+        ? matchConnections.filter(
+            (c) =>
+              new Date(c.matched_at).getFullYear().toString() ===
+              matchYearFilter,
+          )
+        : matchConnections,
+    [matchConnections, matchYearFilter],
+  );
+
   const handleDelete = async (userId: string, name: string) => {
     if (
       !confirm(
@@ -268,10 +291,8 @@ export default function SchoolAdminPage() {
       const a = document.createElement("a");
       a.href = url;
       a.download =
-        res
-          .headers
-          .get("Content-Disposition")
-          ?.match(/filename="(.+)"/)?.[1] ?? "report.csv";
+        res.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ??
+        "report.csv";
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -475,7 +496,7 @@ export default function SchoolAdminPage() {
                     ].map((h) => (
                       <th
                         key={h}
-                        className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
+                        className="px-4 py-3 text-left text-xs font-semibold tracking-wider uppercase"
                         style={{ color: "var(--ui-text-muted)" }}
                       >
                         {h}
@@ -524,7 +545,7 @@ export default function SchoolAdminPage() {
                       </td>
                       <td className="px-4 py-3">
                         <span
-                          className={`inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${
+                          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap ${
                             student.is_technical
                               ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
                               : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
@@ -548,7 +569,7 @@ export default function SchoolAdminPage() {
                             )
                           }
                           disabled={deletingId === student.user_id}
-                          className="cursor-pointer rounded p-1.5 transition hover:bg-red-500/15 hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed"
+                          className="cursor-pointer rounded p-1.5 transition hover:bg-red-500/15 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-30"
                           style={{ color: "var(--ui-text-subtle)" }}
                           title="Delete account"
                         >
@@ -569,7 +590,7 @@ export default function SchoolAdminPage() {
         <>
           {/* Sub-toggle */}
           <div
-            className="mb-4 flex gap-1 rounded-lg border p-1 w-fit"
+            className="mb-4 flex w-fit gap-1 rounded-lg border p-1"
             style={{
               borderColor: "var(--ui-border)",
               backgroundColor: "var(--ui-surface)",
@@ -642,129 +663,168 @@ export default function SchoolAdminPage() {
                   </p>
                 </div>
               ) : (
-                <div
-                  className="overflow-hidden rounded-xl border"
-                  style={{ borderColor: "var(--ui-border)" }}
-                >
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr
-                        className="border-b"
-                        style={{
-                          borderColor: "var(--ui-border)",
-                          backgroundColor: "var(--ui-surface)",
-                        }}
-                      >
-                        {["Match", "Type Fit", "Date", "Status"].map((h) => (
-                          <th
-                            key={h}
-                            className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
-                            style={{ color: "var(--ui-text-muted)" }}
-                          >
-                            {h}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {matchConnections.map((conn, i) => {
-                        const nameOf = (
-                          p: MatchConnection["person1"],
-                        ): string => {
-                          if (p.first_name || p.last_name)
-                            return `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim();
-                          return p.email ?? "Unknown";
-                        };
+                <>
+                  <div className="mb-3 flex justify-end">
+                    <select
+                      value={matchYearFilter}
+                      onChange={(e) => setMatchYearFilter(e.target.value)}
+                      className="rounded-lg border px-3 py-1.5 text-xs font-medium"
+                      style={{
+                        borderColor: "var(--ui-border)",
+                        backgroundColor: "var(--ui-surface)",
+                        color: "var(--ui-text)",
+                      }}
+                    >
+                      <option value="">All years</option>
+                      {matchYears.map((year) => (
+                        <option key={year} value={year}>
+                          {year}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div
+                    className="overflow-hidden rounded-xl border"
+                    style={{ borderColor: "var(--ui-border)" }}
+                  >
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr
+                          className="border-b"
+                          style={{
+                            borderColor: "var(--ui-border)",
+                            backgroundColor: "var(--ui-surface)",
+                          }}
+                        >
+                          {[
+                            "Match",
+                            "Type Fit",
+                            "Startup",
+                            "Date",
+                            "Status",
+                          ].map((h) => (
+                            <th
+                              key={h}
+                              className="px-4 py-3 text-left text-xs font-semibold tracking-wider uppercase"
+                              style={{ color: "var(--ui-text-muted)" }}
+                            >
+                              {h}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {filteredMatchConnections.map((conn, i) => {
+                          const nameOf = (
+                            p: MatchConnection["person1"],
+                          ): string => {
+                            if (p.first_name || p.last_name)
+                              return `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim();
+                            return p.email ?? "Unknown";
+                          };
 
-                        const StatusBadge = () => {
-                          if (conn.kind === "linked")
+                          const StatusBadge = () => {
+                            if (conn.kind === "linked")
+                              return (
+                                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                                  <FaLink className="h-2.5 w-2.5" />
+                                  Linked
+                                </span>
+                              );
+                            if (conn.kind === "mutual")
+                              return (
+                                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+                                  <FaHandshake className="h-2.5 w-2.5" />
+                                  Mutual
+                                </span>
+                              );
                             return (
-                              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                                <FaLink className="h-2.5 w-2.5" />
-                                Linked
+                              <span className="inline-flex items-center gap-1 rounded-full bg-gray-500/15 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                                <FaClock className="h-2.5 w-2.5" />
+                                Pending
                               </span>
                             );
-                          if (conn.kind === "mutual")
+                          };
+
+                          const TypeBadge = ({
+                            p,
+                          }: {
+                            p: MatchConnection["person1"];
+                          }) => {
+                            if (p.is_technical === null) return null;
                             return (
-                              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
-                                <FaHandshake className="h-2.5 w-2.5" />
-                                Mutual
+                              <span
+                                className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap ${
+                                  p.is_technical
+                                    ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
+                                    : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
+                                }`}
+                              >
+                                {p.is_technical ? "Tech" : "Non-tech"}
                               </span>
                             );
-                          return (
-                            <span className="inline-flex items-center gap-1 rounded-full bg-gray-500/15 px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">
-                              <FaClock className="h-2.5 w-2.5" />
-                              Pending
-                            </span>
-                          );
-                        };
+                          };
 
-                        const TypeBadge = ({
-                          p,
-                        }: {
-                          p: MatchConnection["person1"];
-                        }) => {
-                          if (p.is_technical === null) return null;
                           return (
-                            <span
-                              className={`inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${
-                                p.is_technical
-                                  ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
-                                  : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
-                              }`}
+                            <tr
+                              key={conn.id}
+                              className="border-b transition"
+                              style={{
+                                borderColor: "var(--ui-border)",
+                                backgroundColor:
+                                  i % 2 !== 0 ? "var(--ui-surface)" : undefined,
+                              }}
                             >
-                              {p.is_technical ? "Tech" : "Non-tech"}
-                            </span>
+                              <td className="px-4 py-3">
+                                <div
+                                  className="font-medium"
+                                  style={{ color: "var(--ui-text)" }}
+                                >
+                                  {nameOf(conn.person1)}
+                                </div>
+                                <div
+                                  className="text-xs"
+                                  style={{ color: "var(--ui-text-muted)" }}
+                                >
+                                  × {nameOf(conn.person2)}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3">
+                                <div className="flex flex-wrap gap-1">
+                                  <TypeBadge p={conn.person1} />
+                                  <TypeBadge p={conn.person2} />
+                                </div>
+                              </td>
+                              <td className="px-4 py-3">
+                                <div
+                                  className="font-medium"
+                                  style={{ color: "var(--ui-text)" }}
+                                >
+                                  {conn.person1.startup_name ?? "—"}
+                                </div>
+                                <div
+                                  className="text-xs"
+                                  style={{ color: "var(--ui-text-muted)" }}
+                                >
+                                  {conn.person2.startup_name ?? "—"}
+                                </div>
+                              </td>
+                              <td
+                                className="px-4 py-3 text-xs"
+                                style={{ color: "var(--ui-text-subtle)" }}
+                              >
+                                {new Date(conn.matched_at).toLocaleDateString()}
+                              </td>
+                              <td className="px-4 py-3">
+                                <StatusBadge />
+                              </td>
+                            </tr>
                           );
-                        };
-
-                        return (
-                          <tr
-                            key={conn.id}
-                            className="border-b transition"
-                            style={{
-                              borderColor: "var(--ui-border)",
-                              backgroundColor:
-                                i % 2 !== 0
-                                  ? "var(--ui-surface)"
-                                  : undefined,
-                            }}
-                          >
-                            <td className="px-4 py-3">
-                              <div
-                                className="font-medium"
-                                style={{ color: "var(--ui-text)" }}
-                              >
-                                {nameOf(conn.person1)}
-                              </div>
-                              <div
-                                className="text-xs"
-                                style={{ color: "var(--ui-text-muted)" }}
-                              >
-                                × {nameOf(conn.person2)}
-                              </div>
-                            </td>
-                            <td className="px-4 py-3">
-                              <div className="flex flex-wrap gap-1">
-                                <TypeBadge p={conn.person1} />
-                                <TypeBadge p={conn.person2} />
-                              </div>
-                            </td>
-                            <td
-                              className="px-4 py-3 text-xs"
-                              style={{ color: "var(--ui-text-subtle)" }}
-                            >
-                              {new Date(conn.matched_at).toLocaleDateString()}
-                            </td>
-                            <td className="px-4 py-3">
-                              <StatusBadge />
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
               )}
             </>
           )}
@@ -812,7 +872,7 @@ export default function SchoolAdminPage() {
                         ].map((h) => (
                           <th
                             key={h}
-                            className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider"
+                            className="px-4 py-3 text-left text-xs font-semibold tracking-wider uppercase"
                             style={{ color: "var(--ui-text-muted)" }}
                           >
                             {h}
@@ -1011,8 +1071,9 @@ export default function SchoolAdminPage() {
       {activeTab === "reports" && (
         <div className="space-y-5">
           <p className="text-sm" style={{ color: "var(--ui-text-muted)" }}>
-            Generate CSV snapshots of the current cohort and matching outcomes on
-            demand. Each export reflects live data at the moment you download it.
+            Generate CSV snapshots of the current cohort and matching outcomes
+            on demand. Each export reflects live data at the moment you download
+            it.
           </p>
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/features/school/components/auth/complete-school-signin.ts
+++ b/src/features/school/components/auth/complete-school-signin.ts
@@ -30,6 +30,6 @@ export async function completeSchoolSignIn(opts: {
     return { error: assigned.error };
   }
   await getToken({ skipCache: true });
-  router.push(afterAuthRedirect ?? `/school/${slug}`);
+  router.push(afterAuthRedirect ?? `/school/${slug}/dashboard`);
   return {};
 }

--- a/src/features/school/services/matchConnections.ts
+++ b/src/features/school/services/matchConnections.ts
@@ -8,6 +8,7 @@ export type MatchPerson = {
   last_name: string | null;
   title: string | null;
   is_technical: boolean | null;
+  startup_name: string | null;
   email?: string | null;
 };
 
@@ -39,7 +40,7 @@ export async function getMatchConnections(
   // 1. Fetch all active org profiles
   const { data: profiles, error: profilesError } = await supabase
     .from("profiles")
-    .select("user_id, first_name, last_name, title, is_technical")
+    .select("user_id, first_name, last_name, title, is_technical, startup_name")
     .eq("organization_id", orgId)
     .is("deleted_at", null);
 
@@ -66,9 +67,7 @@ export async function getMatchConnections(
   // 4. Fetch pending cofounder_invites for org
   const { data: invites } = await supabase
     .from("cofounder_invites")
-    .select(
-      "id, inviter_user_id, invitee_email, invitee_user_id, created_at",
-    )
+    .select("id, inviter_user_id, invitee_email, invitee_user_id, created_at")
     .eq("organization_id", orgId)
     .eq("status", "pending")
     .order("created_at", { ascending: false });
@@ -86,6 +85,7 @@ export async function getMatchConnections(
       last_name: p.last_name,
       title: p.title,
       is_technical: p.is_technical,
+      startup_name: p.startup_name,
     };
   };
 
@@ -188,6 +188,7 @@ export async function getMatchConnections(
         last_name: null,
         title: null,
         is_technical: null,
+        startup_name: null,
         email: invite.invitee_email as string,
       };
     }


### PR DESCRIPTION
## Summary
This PR brings two staging changes into `main`: an enhancement to the school admin dashboard's Matches tab (startup name column plus a year filter), and a fix to the post-sign-in redirect for school users so they land on the dashboard instead of the generic school landing page. Also includes incidental Tailwind class-order cleanup in the admin page (from auto-formatting) with no behavioral effect.

## Changes

### Admin Dashboard — Matches Table
- Add a `startup_name` column to the Matches table (`src/app/(school)/school/[slug]/admin/page.tsx`), showing each matched person's startup underneath their name so admins can see startup affiliation at a glance without cross-referencing the cohort tab.
- Add a year filter dropdown (`matchYearFilter`) above the Matches table, derived via `useMemo` from the distinct years present in `matchConnections` (`matchYears`) and applied through a new `filteredMatchConnections` memo — lets admins scope the table to a specific cohort year as match history grows.
- Wrap the matches table in a fragment to accommodate the new filter control above it, and convert the table body to iterate `filteredMatchConnections` instead of the raw `matchConnections` array.

### Data Layer
- Extend `MatchPerson` and the `getMatchConnections` query (`src/features/school/services/matchConnections.ts`) to select and map `startup_name` from `profiles`, and default it to `null` for pending-invite placeholder records — required to surface the new Startup column.

### Auth
- Change the post-sign-in redirect in `completeSchoolSignIn` (`src/features/school/components/auth/complete-school-signin.ts`) from `/school/${slug}` to `/school/${slug}/dashboard`, so users land directly on their dashboard instead of the school root/landing route after completing sign-in.

### Formatting
- Minor Tailwind class-order and line-wrap adjustments across `page.tsx` (e.g. `uppercase tracking-wider` → `tracking-wider uppercase`, `disabled:opacity-30 disabled:cursor-not-allowed` reordering) — no functional change, appears to be auto-formatter output picked up alongside the feature work.

## Testing
- Not explicitly verified in this diff; recommend manually confirming the Matches tab filter and Startup column render correctly, and that school sign-in redirects to `/school/[slug]/dashboard`.
