### PR TITLE
Add Global Admin Environment Variable

### DIFF
--- a/src/features/school/auth/org-admin.ts
+++ b/src/features/school/auth/org-admin.ts
@@ -25,6 +25,18 @@ export async function getVerifiedPrimaryEmail(
   }
 }
 
+/**
+ * Global platform-admin emails configured via env var, comma-separated.
+ * Lets us grant admin access without a DB migration/PR.
+ */
+export function getEnvAdminEmails(): string[] {
+  return (
+    process.env.ADMIN_EMAILS?.split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean) ?? []
+  );
+}
+
 export async function getOrgAdminEmails(orgId: string): Promise<string[]> {
   const supabase = supabaseAdmin();
   const { data } = await supabase
@@ -32,8 +44,9 @@ export async function getOrgAdminEmails(orgId: string): Promise<string[]> {
     .select("settings")
     .eq("id", orgId)
     .single();
-  const emails: string[] = data?.settings?.admin_emails ?? [];
-  return emails.map((e) => e.trim().toLowerCase());
+  const dbEmails: string[] = data?.settings?.admin_emails ?? [];
+  const emails = [...dbEmails.map((e) => e.trim().toLowerCase()), ...getEnvAdminEmails()];
+  return Array.from(new Set(emails));
 }
 
 export async function isOrgAdmin({

--- a/src/features/school/auth/school-auth.ts
+++ b/src/features/school/auth/school-auth.ts
@@ -4,6 +4,7 @@ import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
 import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
+import { getEnvAdminEmails } from "@/features/school/auth/org-admin";
 
 export type ExistingUserInfo = {
   exists: boolean;
@@ -58,7 +59,8 @@ export async function assignSchoolOrg(
   const email = primary?.emailAddress;
   if (!email) return { error: "No email on account." };
 
-  if (!isEmailDomainAllowed(email, org.allowed_email_domains)) {
+  const isGlobalAdmin = getEnvAdminEmails().includes(email.toLowerCase());
+  if (!isGlobalAdmin && !isEmailDomainAllowed(email, org.allowed_email_domains)) {
     return {
       error: `This account's email is not eligible for ${org.name}.`,
     };


### PR DESCRIPTION
## Summary
Introduces a global, environment-configured list of platform-admin emails so specific accounts can be granted org-admin access and bypass email-domain restrictions without a database migration. This is layered on top of the existing per-org `admin_emails` setting rather than replacing it.

## Changes

### Auth
- Add `getEnvAdminEmails()` in [org-admin.ts](src/features/school/auth/org-admin.ts) that reads the comma-separated `ADMIN_EMAILS` env var, trims/lowercases each entry, and filters out blanks — mirrors the existing normalization used for DB-stored admin emails.
- Update `getOrgAdminEmails(orgId)` to merge per-org DB admin emails with the global env-configured list, deduping via `Set` so an email listed in both sources doesn't appear twice.
- Update `assignSchoolOrg` in [school-auth.ts](src/features/school/auth/school-auth.ts) to check the joining user's email against `getEnvAdminEmails()` first; if it matches, the `isEmailDomainAllowed` check is skipped, letting global admins join an org even if their email domain isn't on that org's allowlist.

## Migration / Config
- New env var `ADMIN_EMAILS`: comma-separated list of emails to grant global admin/allowlist-bypass privileges. Needs to be set in each deployment environment (e.g. Vercel project settings) where this access is desired.

## Notes
- Emails in `ADMIN_EMAILS` are compared case-insensitively (lowercased on both sides) but no other validation (e.g. format) is performed.
