### PR TITLE
Replace cloudflare position and center it vertically

### DIFF
--- a/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
@@ -23,7 +23,7 @@ export default async function SchoolSignUpPage({
 
   return (
     <div className="flex flex-1 items-center justify-center px-4 py-12">
-      <div id="clerk-captcha" />
+      <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
       <SchoolSignUp
         slug={org.slug}
         schoolName={org.name}

--- a/src/features/school/components/auth/SchoolResetPassword.tsx
+++ b/src/features/school/components/auth/SchoolResetPassword.tsx
@@ -383,7 +383,7 @@ export default function SchoolResetPassword({
               )}
             </div>
 
-            <div id="clerk-captcha" />
+            <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
 
             {!isGoogleOnly && (
               <button

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -304,7 +304,7 @@ export default function SchoolSignIn({
                 </div>
               )}
 
-              <div id="clerk-captcha" />
+              <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
 
               {showPasswordField && (
                 <button


### PR DESCRIPTION
## Summary
Fixes the layout of Clerk's bot-protection CAPTCHA widget (Cloudflare Turnstile, rendered via `<div id="clerk-captcha">`) across the school sign-in, sign-up, and reset-password forms. Previously the container had no sizing/positioning styles, so it always occupied a full-width block row even when Clerk renders the widget invisibly (the common case), and had no defined behavior on narrow viewports. The div now shrink-wraps to its actual content and stays vertically stacked with the rest of the form.

## Changes

### Auth forms
- `src/features/school/components/auth/SchoolSignIn.tsx`, `SchoolResetPassword.tsx`, and `src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx`: change `<div id="clerk-captcha" />` to `<div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />` in all three usages.
  - `w-fit` makes the container shrink to its content instead of stretching full-width, so it claims zero horizontal space when Clerk's bot protection runs invisibly (no challenge rendered) and only as much width as Turnstile actually needs (compact ~150px or normal ~300px) when a challenge does show.
  - `max-w-full` caps the widget at the available column width so it can't push past the form card's padding on narrow screens (the card is `max-w-md` with `p-8` padding inside a `px-4` page wrapper, leaving as little as ~224px of usable width at a 320px viewport).
  - `overflow-x-auto` is a safety net: if Turnstile ever renders wider than the capped width on a very narrow screen, it scrolls locally inside its own box instead of forcing the whole page to scroll horizontally.
  - No Clerk configuration or logic changes — this is a pure CSS fix on the wrapper div, applied identically across all three call sites since they share the same markup pattern.

## Testing
- Verified via `curl` against the local dev server that the class renders correctly in the server-side HTML output for `/school/ut/sign-in`.
- Visual/responsive verification across viewport widths (320px–1280px) was not completed in a browser during this session; recommend a manual check by triggering Clerk's bot-protection challenge and resizing the viewport before merging.
