### PR TITLE
Add manual onboarding save option to UT site

### DIFF
--- a/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
+++ b/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
@@ -416,7 +416,7 @@ function AboutYouForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
+++ b/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
@@ -181,7 +181,7 @@ function BackgroundAndSocialsForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
+++ b/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
@@ -212,7 +212,7 @@ function InterestsAndValuesForm({
             <button
               type="button"
               onClick={() => onManualSave(withOtherPriority(getValues()))}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -296,7 +296,7 @@ function StartupForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(school)/school/[slug]/onboarding/page.tsx
+++ b/src/app/(school)/school/[slug]/onboarding/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, use } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
+import toast from "react-hot-toast";
 
 import { completeOnboarding } from "@/app/(general)/onboarding/_actions";
 import { useUserProfile } from "@/features/profile/useProfile";
@@ -87,6 +88,17 @@ export default function SchoolOnboardingPage({
   };
 
   const handleBack = () => goToStep(stepNumber - 1, "back");
+
+  const handleManualSave = (stepData: Partial<OnboardingData>) => {
+    const merged = { ...formData, ...stepData };
+    setFormData(merged);
+    const ok = draft.save(stepNumber, merged);
+    if (ok) {
+      toast.success("Progress saved");
+    } else {
+      toast.error("Couldn't save — your browser storage may be full or disabled");
+    }
+  };
 
   const handleEditStep = (step: number) =>
     goToStep(step, step < stepNumber ? "back" : "forward");
@@ -223,6 +235,7 @@ export default function SchoolOnboardingPage({
               key={stepId}
               onNext={(newData) => advanceStep(newData, stepNum + 1)}
               onBack={stepNum > 1 ? handleBack : undefined}
+              onManualSave={handleManualSave}
               defaultValues={formData}
             />
           );

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -54,10 +54,12 @@ function CharCount({ value, max }: { value: string; max: number }) {
 function UTAboutYouForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTAboutYouData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTAboutYouData>) => void;
   defaultValues?: Partial<UTAboutYouData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -70,6 +72,7 @@ function UTAboutYouForm({
     reset,
     watch,
     setValue,
+    getValues,
   } = useForm<UTAboutYouData>({ defaultValues });
 
   const experienceValue = watch("experience") || "";
@@ -322,6 +325,15 @@ function UTAboutYouForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
+++ b/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
@@ -17,10 +17,12 @@ const LABEL_CLS =
 function UTBackgroundAndSocialsForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTBackgroundAndSocialsData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTBackgroundAndSocialsData>) => void;
   defaultValues?: Partial<UTBackgroundAndSocialsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -29,6 +31,7 @@ function UTBackgroundAndSocialsForm({
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm<UTBackgroundAndSocialsData>({ defaultValues });
 
@@ -98,6 +101,15 @@ function UTBackgroundAndSocialsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTInterestsForm.tsx
+++ b/src/features/school/onboarding/components/UTInterestsForm.tsx
@@ -123,10 +123,12 @@ type UTInterestsData = {
 function UTInterestsForm({
   onBack,
   onNext,
+  onManualSave,
   defaultValues,
 }: {
   onBack: () => void;
   onNext: (data: UTInterestsData) => void;
+  onManualSave?: (data: Partial<UTInterestsData>) => void;
   defaultValues?: Partial<UTInterestsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -137,6 +139,7 @@ function UTInterestsForm({
     handleSubmit,
     reset,
     watch,
+    getValues,
     formState: { errors },
   } = useForm<UTInterestsData>({ defaultValues });
 
@@ -237,6 +240,15 @@ function UTInterestsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -31,10 +31,12 @@ const PILL_RADIO_CLS =
 function UTStartupForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTStartupFormData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTStartupFormData>) => void;
   defaultValues?: Partial<UTStartupFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -46,6 +48,7 @@ function UTStartupForm({
     control,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<UTStartupFormData>({ defaultValues });
 
@@ -279,6 +282,15 @@ function UTStartupForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/stepRegistry.ts
+++ b/src/features/school/onboarding/stepRegistry.ts
@@ -9,6 +9,7 @@ import UTInterestsForm from "@/features/school/onboarding/components/UTInterests
 export type StepProps = {
   onNext: (data: Partial<OnboardingData>) => void;
   onBack?: () => void;
+  onManualSave?: (data: Partial<OnboardingData>) => void;
   defaultValues: OnboardingData;
 };
 


### PR DESCRIPTION
## Summary
Brings the school/university ("UT") onboarding flow up to parity with the general onboarding flow's manual "Save progress" feature (added in a prior commit but never wired into the school flow). Previously, `StepProps` for the school flow had no `onManualSave` hook, so none of its step forms could expose a save control — users relied entirely on autosave-on-navigate to persist localStorage draft data. Also fixes a missing `cursor-pointer` style on the "Save progress" button across both flows.

## Changes

### School onboarding flow
- `src/features/school/onboarding/stepRegistry.ts` — add `onManualSave?: (data: Partial<OnboardingData>) => void` to the shared `StepProps` type so step components can accept the callback.
- `src/app/(school)/school/[slug]/onboarding/page.tsx` — add `handleManualSave`, mirroring the general flow's `CreateProfile.tsx` implementation: merges the current step's form values into `formData`, writes them to the `onboarding_draft` localStorage key via `draft.save(stepNumber, merged)`, and shows a `react-hot-toast` success/error toast based on whether the write succeeded (e.g. storage full/disabled). Wired into the step-rendering loop via `onManualSave={handleManualSave}` alongside the existing `onNext`/`onBack`/`defaultValues` props.
- `UTAboutYouForm.tsx`, `UTStartupForm.tsx`, `UTBackgroundAndSocialsForm.tsx`, `UTInterestsForm.tsx` — each now accepts an optional `onManualSave` prop, pulls `getValues` from `useForm`, and renders a "Save progress" text button between "← Back" and the submit button (only when `onManualSave` is provided). Photo and Review steps are intentionally left unchanged, matching the general flow (photo is never cached in the draft; review is the final submit step, not a mid-flow save point).

### Styling
- Added `cursor-pointer` to the "Save progress" button's className in all four school-flow forms above, plus the four pre-existing general-flow forms (`AboutYouForm.tsx`, `StartupForm.tsx`, `BackgroundAndSocialsForm.tsx`, `InterestsAndValuesForm.tsx`) that shared the same gap — the button previously showed the browser's default (non-pointer) cursor on hover.

## Testing
- `npx tsc --noEmit` — passes with no errors.
- `npm run build` — production build compiles successfully; both `/onboarding` and `/school/[slug]/onboarding` routes build without errors (one pre-existing, unrelated webpack warning from `@vladmandic/face-api`).
- Verified via `curl` that both onboarding routes correctly 307-redirect to Clerk sign-in when unauthenticated (confirms middleware/routing intact).

## Notes
- No backend/draft-save mechanism was added — this only extends the existing client-side localStorage autosave pattern to the school flow. The `profiles` table schema still requires a complete payload (NOT NULL columns, required `pfp_url`), so true server-side partial-save remains out of scope.
- Full authenticated click-through in a browser (verifying hover/cursor styling live) was not performed — recommend a manual pass at `/school/<slug>/onboarding` once signed in.
