### PR TITLE
Add UT onboarding manual save, fix save-progress cursor and CAPTCHA overflow

### DIFF
--- a/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
+++ b/src/app/(general)/onboarding/form-components/AboutYouForm.tsx
@@ -416,7 +416,7 @@ function AboutYouForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
+++ b/src/app/(general)/onboarding/form-components/BackgroundAndSocialsForm.tsx
@@ -181,7 +181,7 @@ function BackgroundAndSocialsForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
+++ b/src/app/(general)/onboarding/form-components/InterestsAndValuesForm.tsx
@@ -212,7 +212,7 @@ function InterestsAndValuesForm({
             <button
               type="button"
               onClick={() => onManualSave(withOtherPriority(getValues()))}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(general)/onboarding/form-components/StartupForm.tsx
+++ b/src/app/(general)/onboarding/form-components/StartupForm.tsx
@@ -296,7 +296,7 @@ function StartupForm({
             <button
               type="button"
               onClick={() => onManualSave(getValues())}
-              className="text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
             >
               Save progress
             </button>

--- a/src/app/(school)/school/[slug]/onboarding/page.tsx
+++ b/src/app/(school)/school/[slug]/onboarding/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, use } from "react";
 import { useSession, useUser } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
+import toast from "react-hot-toast";
 
 import { completeOnboarding } from "@/app/(general)/onboarding/_actions";
 import { useUserProfile } from "@/features/profile/useProfile";
@@ -87,6 +88,17 @@ export default function SchoolOnboardingPage({
   };
 
   const handleBack = () => goToStep(stepNumber - 1, "back");
+
+  const handleManualSave = (stepData: Partial<OnboardingData>) => {
+    const merged = { ...formData, ...stepData };
+    setFormData(merged);
+    const ok = draft.save(stepNumber, merged);
+    if (ok) {
+      toast.success("Progress saved");
+    } else {
+      toast.error("Couldn't save — your browser storage may be full or disabled");
+    }
+  };
 
   const handleEditStep = (step: number) =>
     goToStep(step, step < stepNumber ? "back" : "forward");
@@ -223,6 +235,7 @@ export default function SchoolOnboardingPage({
               key={stepId}
               onNext={(newData) => advanceStep(newData, stepNum + 1)}
               onBack={stepNum > 1 ? handleBack : undefined}
+              onManualSave={handleManualSave}
               defaultValues={formData}
             />
           );

--- a/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(school)/school/[slug]/sign-up/[[...sign-up]]/page.tsx
@@ -23,7 +23,7 @@ export default async function SchoolSignUpPage({
 
   return (
     <div className="flex flex-1 items-center justify-center px-4 py-12">
-      <div id="clerk-captcha" />
+      <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
       <SchoolSignUp
         slug={org.slug}
         schoolName={org.name}

--- a/src/features/school/components/auth/SchoolResetPassword.tsx
+++ b/src/features/school/components/auth/SchoolResetPassword.tsx
@@ -383,7 +383,7 @@ export default function SchoolResetPassword({
               )}
             </div>
 
-            <div id="clerk-captcha" />
+            <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
 
             {!isGoogleOnly && (
               <button

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -304,7 +304,7 @@ export default function SchoolSignIn({
                 </div>
               )}
 
-              <div id="clerk-captcha" />
+              <div id="clerk-captcha" className="w-fit max-w-full overflow-x-auto" />
 
               {showPasswordField && (
                 <button

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -54,10 +54,12 @@ function CharCount({ value, max }: { value: string; max: number }) {
 function UTAboutYouForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTAboutYouData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTAboutYouData>) => void;
   defaultValues?: Partial<UTAboutYouData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -70,6 +72,7 @@ function UTAboutYouForm({
     reset,
     watch,
     setValue,
+    getValues,
   } = useForm<UTAboutYouData>({ defaultValues });
 
   const experienceValue = watch("experience") || "";
@@ -322,6 +325,15 @@ function UTAboutYouForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
+++ b/src/features/school/onboarding/components/UTBackgroundAndSocialsForm.tsx
@@ -17,10 +17,12 @@ const LABEL_CLS =
 function UTBackgroundAndSocialsForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTBackgroundAndSocialsData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTBackgroundAndSocialsData>) => void;
   defaultValues?: Partial<UTBackgroundAndSocialsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -29,6 +31,7 @@ function UTBackgroundAndSocialsForm({
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm<UTBackgroundAndSocialsData>({ defaultValues });
 
@@ -98,6 +101,15 @@ function UTBackgroundAndSocialsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTInterestsForm.tsx
+++ b/src/features/school/onboarding/components/UTInterestsForm.tsx
@@ -123,10 +123,12 @@ type UTInterestsData = {
 function UTInterestsForm({
   onBack,
   onNext,
+  onManualSave,
   defaultValues,
 }: {
   onBack: () => void;
   onNext: (data: UTInterestsData) => void;
+  onManualSave?: (data: Partial<UTInterestsData>) => void;
   defaultValues?: Partial<UTInterestsData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -137,6 +139,7 @@ function UTInterestsForm({
     handleSubmit,
     reset,
     watch,
+    getValues,
     formState: { errors },
   } = useForm<UTInterestsData>({ defaultValues });
 
@@ -237,6 +240,15 @@ function UTInterestsForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/components/UTStartupForm.tsx
+++ b/src/features/school/onboarding/components/UTStartupForm.tsx
@@ -31,10 +31,12 @@ const PILL_RADIO_CLS =
 function UTStartupForm({
   onNext,
   onBack,
+  onManualSave,
   defaultValues,
 }: {
   onNext: (data: UTStartupFormData) => void;
   onBack: () => void;
+  onManualSave?: (data: Partial<UTStartupFormData>) => void;
   defaultValues?: Partial<UTStartupFormData>;
 }) {
   const fieldsRef = useStepEntry();
@@ -46,6 +48,7 @@ function UTStartupForm({
     control,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<UTStartupFormData>({ defaultValues });
 
@@ -279,6 +282,15 @@ function UTStartupForm({
           >
             ← Back
           </button>
+          {onManualSave && (
+            <button
+              type="button"
+              onClick={() => onManualSave(getValues())}
+              className="cursor-pointer text-sm font-medium text-[var(--ui-text-muted)] underline-offset-2 hover:text-[var(--ui-text)] hover:underline"
+            >
+              Save progress
+            </button>
+          )}
           <button
             type="submit"
             className="inline-flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-8 py-3.5 text-sm font-semibold text-[var(--ui-btn-text)] shadow-lg shadow-black/5 transition-all duration-200 hover:bg-[var(--ui-btn-bg)]/90 active:scale-[0.98] sm:flex-none"

--- a/src/features/school/onboarding/stepRegistry.ts
+++ b/src/features/school/onboarding/stepRegistry.ts
@@ -9,6 +9,7 @@ import UTInterestsForm from "@/features/school/onboarding/components/UTInterests
 export type StepProps = {
   onNext: (data: Partial<OnboardingData>) => void;
   onBack?: () => void;
+  onManualSave?: (data: Partial<OnboardingData>) => void;
   defaultValues: OnboardingData;
 };
 


### PR DESCRIPTION
## Summary
Brings the University of Texas (UT) school onboarding flow up to parity with the general onboarding flow by adding a manual "Save progress" action, and fixes a couple of small UI issues: non-pointer cursors on save-progress links and a Clerk CAPTCHA widget that could overflow its container on narrow viewports.

## Changes

### UT Onboarding — Manual Save
- Add an optional `onManualSave` prop to the shared `StepProps` type (`src/features/school/onboarding/stepRegistry.ts`) so any onboarding step can opt into manual saving without changing the required contract for steps that don't need it.
- Wire `onManualSave` through all four UT onboarding step components (`UTAboutYouForm`, `UTBackgroundAndSocialsForm`, `UTInterestsForm`, `UTStartupForm`): each now pulls `getValues` from its `react-hook-form` instance and renders a "Save progress" button next to Back/Next that calls `onManualSave(getValues())`, matching the pattern already used in the general onboarding forms.
- Implement `handleManualSave` in the UT onboarding page (`src/app/(school)/school/[slug]/onboarding/page.tsx`): merges the current step's in-progress values into `formData`, then reuses the existing `draft.save()` (from `useOnboardingDraft`) to persist to local storage — the same draft mechanism already used for step-navigation autosave and initial draft restore. Surfaces success/failure via `react-hot-toast` ("Progress saved" vs. a storage-full/disabled error message).

### UI Fixes
- Add `cursor-pointer` to the "Save progress" buttons in the general onboarding forms (`AboutYouForm`, `BackgroundAndSocialsForm`, `InterestsAndValuesForm`, `StartupForm`) — they were previously missing a pointer cursor despite being interactive.
- Constrain the Clerk `#clerk-captcha` widget with `w-fit max-w-full overflow-x-auto` across all three school auth surfaces (`SchoolSignUpPage`, `SchoolResetPassword`, `SchoolSignIn`) so the CAPTCHA iframe scrolls instead of overflowing/breaking layout on small screens.

## Testing
- No automated tests included; changes are UI/UX only (button behavior, layout, local-storage draft persistence reused from existing code path).

## Notes
- The manual save button only appears when a step is given an `onManualSave` handler, so this is backward compatible with any onboarding flow that doesn't pass one.
