### PR TITLE
Add skeleton loader to cofoundr dashboard

### DIFF
--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { trackEvent } from "@/lib/posthog-events";
 import { useProfileViewTracking } from "@/features/profile/useProfileViewTracking";
 import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/features/school/data/utSchoolsAndMajors";
 import FilterSidebar, { getFilterChipLabels } from "@/features/school/components/dashboard/FilterSidebar";
+import { SwipeCardSkeleton, SearchResultCardSkeleton } from "@/features/school/components/dashboard/ProfileCardSkeletons";
 import ReportProfileButton from "@/features/report/ReportProfileButton";
 import {
   type DashboardFilters,
@@ -410,6 +411,7 @@ export default function SchoolDashboardPage() {
         onChange={updateFilters}
         isOpen={filterDrawerOpen}
         onClose={() => setFilterDrawerOpen(false)}
+        isLoading={isLoadingProfiles}
       />
 
       {/* Search bar — only shown when open */}
@@ -441,6 +443,7 @@ export default function SchoolDashboardPage() {
           variant="sidebar"
           filters={filters}
           onChange={updateFilters}
+          isLoading={isLoadingProfiles}
         />
 
         <div className="mx-auto flex w-full min-w-0 max-w-2xl flex-1 flex-col min-h-0">
@@ -448,9 +451,11 @@ export default function SchoolDashboardPage() {
       {isSearchActive ? (
         <div>
           {isSearching && (
-            <p className="mb-4 text-center text-sm text-[var(--ui-text-muted)]">
-              Searching…
-            </p>
+            <div className="flex flex-col gap-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <SearchResultCardSkeleton key={i} />
+              ))}
+            </div>
           )}
           {!isSearching && searchResults && searchResults.length === 0 && (
             <div className="flex flex-col items-center gap-3 py-16 text-center">
@@ -500,9 +505,7 @@ export default function SchoolDashboardPage() {
       ) : (
         /* Swipe card */
         isLoadingProfiles ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
-            <p className="text-sm text-[var(--ui-text-muted)]">Loading profiles…</p>
-          </div>
+          <SwipeCardSkeleton />
         ) : !curProfile ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
             {filtersActive ? (

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,3 @@
+export default function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-[var(--ui-surface-active)] ${className}`} />;
+}

--- a/src/features/school/components/dashboard/FilterSidebar.tsx
+++ b/src/features/school/components/dashboard/FilterSidebar.tsx
@@ -14,6 +14,7 @@ import {
   EMPTY_DASHBOARD_FILTERS,
   hasActiveFilters,
 } from "@/features/school/data/dashboardFilters";
+import Skeleton from "@/components/ui/Skeleton";
 
 type SelectOption = { value: string; label: string };
 
@@ -124,6 +125,8 @@ type FilterSidebarProps = {
   variant?: "sidebar" | "drawer";
   /** Desktop sidebar height — should match the profile card */
   panelHeightClass?: string;
+  /** Show a skeleton in place of the real filter controls while profile data is loading */
+  isLoading?: boolean;
 };
 
 const INTENT_OPTIONS = [
@@ -285,6 +288,53 @@ function FilterPanel({
   );
 }
 
+function FilterPanelSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
+        <Skeleton className="h-5 w-16" />
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+        {/* School department */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+
+        {/* Industry / interest */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-32" />
+          <div className="flex flex-wrap gap-1">
+            <Skeleton className="h-5 w-12" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-5 w-14" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-5 w-12" />
+          </div>
+        </div>
+
+        {/* Graduation year */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+
+        {/* Intent */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-16" />
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-9 w-full rounded-xl" />
+            <Skeleton className="h-9 w-full rounded-xl" />
+            <Skeleton className="h-9 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function FilterSidebar({
   filters,
   onChange,
@@ -292,6 +342,7 @@ export default function FilterSidebar({
   onClose,
   variant = "sidebar",
   panelHeightClass = "",
+  isLoading = false,
 }: FilterSidebarProps) {
   useEffect(() => {
     if (variant !== "drawer" || !isOpen) return;
@@ -307,7 +358,11 @@ export default function FilterSidebar({
       <aside
         className={`hidden w-64 shrink-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 lg:flex ${panelHeightClass}`}
       >
-        <FilterPanel filters={filters} onChange={onChange} scrollable={true} />
+        {isLoading ? (
+          <FilterPanelSkeleton />
+        ) : (
+          <FilterPanel filters={filters} onChange={onChange} scrollable={true} />
+        )}
       </aside>
     );
   }
@@ -332,13 +387,17 @@ export default function FilterSidebar({
             transition={{ type: "spring", damping: 28, stiffness: 320 }}
             className="fixed left-0 top-0 z-50 flex h-full w-[85vw] max-w-sm flex-col overflow-x-hidden border-r border-[var(--ui-border)] bg-[var(--ui-popover-bg,var(--org-bg,#ffffff))] p-4 shadow-xl"
           >
-            <FilterPanel
-              filters={filters}
-              onChange={onChange}
-              onClose={onClose}
-              showClose
-              scrollable
-            />
+            {isLoading ? (
+              <FilterPanelSkeleton />
+            ) : (
+              <FilterPanel
+                filters={filters}
+                onChange={onChange}
+                onClose={onClose}
+                showClose
+                scrollable
+              />
+            )}
           </motion.aside>
         </>
       )}

--- a/src/features/school/components/dashboard/ProfileCardSkeletons.tsx
+++ b/src/features/school/components/dashboard/ProfileCardSkeletons.tsx
@@ -1,0 +1,77 @@
+import Skeleton from "@/components/ui/Skeleton";
+
+export function SwipeCardSkeleton() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]">
+      <div className="flex-1 overflow-y-auto p-5">
+        {/* Avatar + Name row */}
+        <div className="mb-4 flex items-start gap-3">
+          <Skeleton className="h-16 w-16 flex-shrink-0 rounded-full" />
+          <div className="flex flex-1 min-w-0 flex-col gap-1">
+            <Skeleton className="h-7 w-40" />
+            <Skeleton className="h-5 w-24" />
+          </div>
+          <div className="flex flex-shrink-0 flex-col items-end gap-1.5">
+            <Skeleton className="h-6 w-16" />
+            <Skeleton className="h-6 w-16" />
+          </div>
+        </div>
+
+        {/* About box */}
+        <div className="mb-4 flex flex-col gap-2 rounded-lg border border-[var(--ui-border)] p-3">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-2/3" />
+        </div>
+
+        {/* Tag row */}
+        <div className="mb-1 flex flex-wrap gap-1.5">
+          <Skeleton className="h-6 w-16" />
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-14" />
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-border)] px-5 py-4">
+        <Skeleton className="h-11 w-11 flex-shrink-0 rounded-full" />
+        <Skeleton className="h-11 w-28 flex-shrink-0 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+export function SearchResultCardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]">
+      <div className="p-4">
+        {/* Avatar + name row */}
+        <div className="mb-3 flex items-center gap-3">
+          <Skeleton className="h-12 w-12 flex-shrink-0 rounded-full" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+
+        {/* Bio snippet */}
+        <div className="mb-3 flex flex-col gap-1">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+
+        {/* Sector tags */}
+        <div className="flex flex-wrap gap-1.5">
+          <Skeleton className="h-5 w-14" />
+          <Skeleton className="h-5 w-16" />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-3 border-t border-[var(--ui-border)] px-4 py-3">
+        <Skeleton className="h-10 w-24 flex-shrink-0 rounded-full" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds skeleton loading states to the UT co-foundr matching dashboard (`school/[slug]/dashboard`) so the profile card, search results, and filter sidebar/drawer show shaped placeholders instead of plain "Loading…" / "Searching…" text while data fetches. This removes the layout pop when content arrives and follows the existing `animate-pulse` + `bg-[var(--ui-surface-active)]` pattern already used in `ProfileViewModal`.

## Changes

### New skeleton components
- Add `src/components/ui/Skeleton.tsx` — a single-purpose `animate-pulse` block (`bg-[var(--ui-surface-active)]`, `rounded-md`) that all the skeletons below compose from, keeping sizing/shape control in the `className` passed by each caller.
- Add `src/features/school/components/dashboard/ProfileCardSkeletons.tsx` with `SwipeCardSkeleton` and `SearchResultCardSkeleton`, each mirroring the real card's exact container classes (`rounded-2xl border`, avatar size, footer button dimensions) so there's no dimension jump on swap. Bar heights are matched to each real element's actual rendered height (Tailwind line-height for its text class, plus padding for badges/pills) rather than approximated from font size alone — e.g. a `text-lg` name uses `h-7`, a `p-3` about-box line uses `h-6`.
- In `FilterSidebar.tsx`, add `FilterPanelSkeleton`, mirroring `FilterPanel`'s four filter groups (School Department, Industry/Interest, Graduation Year, Intent) with matching control heights (`h-10` for `FilterSelect`-style bars, `h-9` for intent rows, `h-5` chip pills).

### Wiring
- `FilterSidebar` now accepts an `isLoading?: boolean` prop; both the desktop `sidebar` variant and the mobile `drawer` variant render `FilterPanelSkeleton` in place of `FilterPanel` when true, leaving the real interactive controls untouched as a sibling render path.
- In `page.tsx`, both `<FilterSidebar>` usages (drawer at line ~412, sidebar at line ~444) now pass `isLoading={isLoadingProfiles}`.
- The swipe-card branch replaces the old `"Loading profiles…"` text with `<SwipeCardSkeleton />` when `isLoadingProfiles` is true.
- The search branch replaces `"Searching…"` text with three stacked `<SearchResultCardSkeleton />` while `isSearching` is true, matching the `flex flex-col gap-3` layout used for real results so there's no height jump.

No changes to data-fetching logic — `isLoadingProfiles` (`useGetProfiles`) and `isSearching` (`useSearchProfiles`) already existed and are the only flags driving these render branches.

## Testing
- `npx tsc --noEmit` and `npx eslint` on all four changed/added files — no errors.
- Manual review of class-by-class dimension matching against the real `SearchResultCard`, swipe card, and `FilterPanel` markup (avatar sizes, button/pill heights, container classes).
- Not yet visually verified in a running browser session — the dashboard route sits behind Clerk auth in `middleware.ts`, so this wasn't screenshotted end-to-end; recommend a manual pass on a throttled connection (light + dark org theme) before merging.

## Notes
- Skeleton dimensions were tuned in a follow-up pass after an initial review found several bars undersized relative to their real counterparts (name/subtitle lines, about-box text, intent rows) — heights were recomputed from Tailwind's actual line-height tables rather than eyeballed.
