### PR TITLE
Add cofoundr startup name + startup link to linking mechanism

### DIFF
--- a/src/app/(school)/school/[slug]/admin/page.tsx
+++ b/src/app/(school)/school/[slug]/admin/page.tsx
@@ -699,7 +699,7 @@ export default function SchoolAdminPage() {
                           {[
                             "Match",
                             "Type Fit",
-                            "Startup",
+                            "Team",
                             "Date",
                             "Status",
                           ].map((h) => (
@@ -796,18 +796,44 @@ export default function SchoolAdminPage() {
                                 </div>
                               </td>
                               <td className="px-4 py-3">
-                                <div
-                                  className="font-medium"
-                                  style={{ color: "var(--ui-text)" }}
-                                >
-                                  {conn.person1.startup_name ?? "—"}
-                                </div>
-                                <div
-                                  className="text-xs"
-                                  style={{ color: "var(--ui-text-muted)" }}
-                                >
-                                  {conn.person2.startup_name ?? "—"}
-                                </div>
+                                {(() => {
+                                  const teamName =
+                                    conn.person1.startup_name ??
+                                    conn.person2.startup_name;
+                                  const teamWebsite =
+                                    conn.person1.startup_website ??
+                                    conn.person2.startup_website;
+                                  if (!teamName) {
+                                    return (
+                                      <span
+                                        style={{ color: "var(--ui-text-muted)" }}
+                                      >
+                                        —
+                                      </span>
+                                    );
+                                  }
+                                  if (teamWebsite) {
+                                    return (
+                                      <a
+                                        href={teamWebsite}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="font-medium hover:underline"
+                                        style={{ color: "var(--ui-text)" }}
+                                      >
+                                        {teamName}
+                                      </a>
+                                    );
+                                  }
+                                  return (
+                                    <div
+                                      className="font-medium"
+                                      style={{ color: "var(--ui-text)" }}
+                                    >
+                                      {teamName}
+                                    </div>
+                                  );
+                                })()}
                               </td>
                               <td
                                 className="px-4 py-3 text-xs"

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -19,6 +19,8 @@ type Props = {
   inviterPfpUrl: string | null;
   inviteeRole: string | null;
   note: string | null;
+  startupName: string | null;
+  startupWebsite: string | null;
 };
 
 export default function AcceptInviteClient({
@@ -29,6 +31,8 @@ export default function AcceptInviteClient({
   inviterPfpUrl,
   inviteeRole,
   note,
+  startupName,
+  startupWebsite,
 }: Props) {
   const router = useRouter();
   const [accepting, setAccepting] = useState(false);
@@ -104,6 +108,30 @@ export default function AcceptInviteClient({
           )}
         </div>
 
+        {/* Proposed startup name/site — read-only, approved by accepting */}
+        {startupName && (
+          <div
+            className="mb-4 rounded-xl border border-[#e8e4dc] bg-[#faf8f4] px-4 py-3 space-y-1 text-center"
+          >
+            <p className="text-xs" style={{ color: "#5f7280" }}>
+              Your team will be named
+            </p>
+            <p className="text-base font-semibold" style={{ color: "#333f48" }}>
+              {startupName}
+            </p>
+            {startupWebsite && (
+              <a
+                href={startupWebsite}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-[#bf5700] hover:underline"
+              >
+                {startupWebsite}
+              </a>
+            )}
+          </div>
+        )}
+
         {/* Role assigned by inviter */}
         {(inviteeRole || note) && (
           <div
@@ -155,7 +183,10 @@ export default function AcceptInviteClient({
         )}
 
         <p className="mb-6 text-center text-sm" style={{ color: "#5f7280" }}>
-          Accepting will link your profiles as confirmed co-founders, visible on both your cards.
+          Accepting will link your profiles as confirmed co-founders, visible on both your cards
+          {startupName
+            ? `, and set your startup name to "${startupName}" on both profiles.`
+            : "."}
         </p>
 
         <div className="flex gap-3">

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -24,7 +24,9 @@ export default async function InviteAcceptPage({
 
   const { data: invite } = await supabase
     .from("cofounder_invites")
-    .select("id, inviter_user_id, organization_id, status, expires_at, invitee_role, note")
+    .select(
+      "id, inviter_user_id, organization_id, status, expires_at, invitee_role, note, startup_name, startup_website",
+    )
     .eq("token", token)
     .single();
 
@@ -134,6 +136,8 @@ export default async function InviteAcceptPage({
       inviterPfpUrl={inviterProfile?.pfp_url ?? null}
       inviteeRole={invite.invitee_role ?? null}
       note={invite.note ?? null}
+      startupName={invite.startup_name ?? null}
+      startupWebsite={invite.startup_website ?? null}
     />
   );
 }

--- a/src/app/api/cofounder-invite/[token]/accept/route.ts
+++ b/src/app/api/cofounder-invite/[token]/accept/route.ts
@@ -27,7 +27,9 @@ export async function POST(
 
     const { data: invite, error: inviteErr } = await supabase
       .from("cofounder_invites")
-      .select("id, inviter_user_id, organization_id, invitee_email, status, expires_at")
+      .select(
+        "id, inviter_user_id, organization_id, invitee_email, status, expires_at, startup_name, startup_website",
+      )
       .eq("token", token)
       .single();
 
@@ -110,6 +112,20 @@ export async function POST(
     if (linkErr) {
       console.error("[cofounder-invite accept] link insert error:", linkErr);
       return NextResponse.json({ error: "Failed to create co-founder link" }, { status: 500 });
+    }
+
+    // Overwrite both profiles' startup identity with the agreed-on name/site
+    if (invite.startup_name) {
+      const { error: profileSyncErr } = await supabase
+        .from("profiles")
+        .update({
+          startup_name: invite.startup_name,
+          startup_website: invite.startup_website,
+        })
+        .in("user_id", [invite.inviter_user_id, userId]);
+      if (profileSyncErr) {
+        console.error("[cofounder-invite accept] profile sync error:", profileSyncErr);
+      }
     }
 
     await supabase

--- a/src/app/api/cofounder-invite/route.ts
+++ b/src/app/api/cofounder-invite/route.ts
@@ -12,13 +12,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { inviteeEmail, inviteeRole, note } = await request.json();
+    const { inviteeEmail, startupName, startupWebsite, inviteeRole, note } =
+      await request.json();
     const normalizedEmail = (inviteeEmail ?? "").trim().toLowerCase();
+    const normalizedStartupName = (startupName ?? "").trim() || null;
+    const normalizedStartupWebsite = (startupWebsite ?? "").trim() || null;
     const normalizedRole = (inviteeRole ?? "").trim() || null;
     const normalizedNote = (note ?? "").trim() || null;
     if (!normalizedEmail) {
       return NextResponse.json(
         { error: "Missing inviteeEmail" },
+        { status: 400 },
+      );
+    }
+    if (!normalizedStartupName) {
+      return NextResponse.json(
+        { error: "Missing startupName" },
         { status: 400 },
       );
     }
@@ -147,6 +156,8 @@ export async function POST(request: NextRequest) {
         inviter_user_id: userId,
         organization_id: inviterProfile.organization_id,
         invitee_email: normalizedEmail,
+        startup_name: normalizedStartupName,
+        startup_website: normalizedStartupWebsite,
         invitee_role: normalizedRole,
         note: normalizedNote,
         invitee_user_id: inviteeUserId,
@@ -197,7 +208,7 @@ export async function GET() {
     const { data: invites, error: inviteErr } = await supabase
       .from("cofounder_invites")
       .select(
-        "id, token, invitee_email, invitee_role, note, status, created_at, expires_at",
+        "id, token, invitee_email, invitee_role, note, startup_name, startup_website, status, created_at, expires_at",
       )
       .eq("inviter_user_id", userId)
       .order("created_at", { ascending: false });

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -32,6 +32,8 @@ export default function CoFounderPanel({
   allowedDomains?: string[];
 }) {
   const [email, setEmail] = useState("");
+  const [startupName, setStartupName] = useState("");
+  const [startupWebsite, setStartupWebsite] = useState("");
   const [role, setRole] = useState("");
   const [note, setNote] = useState("");
   const { data, isLoading } = useCofounderManagement();
@@ -49,15 +51,20 @@ export default function CoFounderPanel({
   async function handleSend(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = email.trim().toLowerCase();
-    if (!trimmed) return;
+    const trimmedStartupName = startupName.trim();
+    if (!trimmed || !trimmedStartupName) return;
     try {
       await sendInvite.mutateAsync({
         inviteeEmail: trimmed,
+        startupName: trimmedStartupName,
+        startupWebsite: startupWebsite.trim() || undefined,
         inviteeRole: role || undefined,
         note: note.trim() || undefined,
       });
       toast.success(`Invite sent to ${trimmed}`);
       setEmail("");
+      setStartupName("");
+      setStartupWebsite("");
       setRole("");
       setNote("");
     } catch (err) {
@@ -156,6 +163,21 @@ export default function CoFounderPanel({
             className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
             required
           />
+          <input
+            type="text"
+            value={startupName}
+            onChange={(e) => setStartupName(e.target.value)}
+            placeholder="Startup or project name"
+            className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
+            required
+          />
+          <input
+            type="url"
+            value={startupWebsite}
+            onChange={(e) => setStartupWebsite(e.target.value)}
+            placeholder="https://yourstartup.com (optional)"
+            className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
+          />
           <select
             value={role}
             onChange={(e) => setRole(e.target.value)}
@@ -177,7 +199,7 @@ export default function CoFounderPanel({
           />
           <button
             type="submit"
-            disabled={sendInvite.isPending || !email.trim()}
+            disabled={sendInvite.isPending || !email.trim() || !startupName.trim()}
             className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:bg-[#a34800] disabled:opacity-50"
           >
             <FaUserPlus className="h-3.5 w-3.5" />

--- a/src/features/cofounder/hooks.ts
+++ b/src/features/cofounder/hooks.ts
@@ -9,6 +9,8 @@ export type CofounderInvite = {
   invitee_email: string;
   invitee_role: string | null;
   note: string | null;
+  startup_name: string | null;
+  startup_website: string | null;
   status: "pending" | "accepted" | "declined" | "revoked" | "expired";
   created_at: string;
   expires_at: string;
@@ -35,17 +37,27 @@ export function useSendCofounderInvite() {
   return useMutation({
     mutationFn: async ({
       inviteeEmail,
+      startupName,
+      startupWebsite,
       inviteeRole,
       note,
     }: {
       inviteeEmail: string;
+      startupName: string;
+      startupWebsite?: string;
       inviteeRole?: string;
       note?: string;
     }) => {
       const res = await fetch("/api/cofounder-invite", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ inviteeEmail, inviteeRole, note }),
+        body: JSON.stringify({
+          inviteeEmail,
+          startupName,
+          startupWebsite,
+          inviteeRole,
+          note,
+        }),
       });
       if (!res.ok) {
         const data = await res.json();

--- a/src/features/school/services/matchConnections.ts
+++ b/src/features/school/services/matchConnections.ts
@@ -9,6 +9,7 @@ export type MatchPerson = {
   title: string | null;
   is_technical: boolean | null;
   startup_name: string | null;
+  startup_website: string | null;
   email?: string | null;
 };
 
@@ -40,7 +41,9 @@ export async function getMatchConnections(
   // 1. Fetch all active org profiles
   const { data: profiles, error: profilesError } = await supabase
     .from("profiles")
-    .select("user_id, first_name, last_name, title, is_technical, startup_name")
+    .select(
+      "user_id, first_name, last_name, title, is_technical, startup_name, startup_website",
+    )
     .eq("organization_id", orgId)
     .is("deleted_at", null);
 
@@ -86,6 +89,7 @@ export async function getMatchConnections(
       title: p.title,
       is_technical: p.is_technical,
       startup_name: p.startup_name,
+      startup_website: p.startup_website,
     };
   };
 
@@ -189,6 +193,7 @@ export async function getMatchConnections(
         title: null,
         is_technical: null,
         startup_name: null,
+        startup_website: null,
         email: invite.invitee_email as string,
       };
     }

--- a/supabase/migrations/20260716000000_add_startup_fields_to_cofounder_invites.sql
+++ b/supabase/migrations/20260716000000_add_startup_fields_to_cofounder_invites.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_name TEXT NULL;
+ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;


### PR DESCRIPTION
## Summary
Adds a shared "startup name" and "startup site" to the co-founder invite flow so that a matched pair no longer ends up with two independently-set company names. The inviter proposes a startup name (required) and site (optional) when sending an invite; the invitee sees it read-only and approves it simply by accepting. On acceptance, both users' `profiles.startup_name`/`startup_website` are overwritten to match, and the school-org admin dashboard's Matches table now shows one clickable "Team" name instead of two stacked, possibly-conflicting names.

## Changes

### Database
- New migration `20260716000000_add_startup_fields_to_cofounder_invites.sql` adds `startup_name` and `startup_website` (both nullable `TEXT`) to `cofounder_invites`, and `startup_website` to `profiles` (mirrors the existing `personal_website`/`scheduling_url` column style — no `startups` table introduced, startup identity stays on `profiles`, just now synced via the invite).

### API
- `POST /api/cofounder-invite`: accepts `startupName`/`startupWebsite` in the request body, requires `startupName` (400 `"Missing startupName"` if blank, same pattern as the existing email check), and persists both fields on the new `cofounder_invites` row.
- `GET /api/cofounder-invite`: selects `startup_name, startup_website` so the inviter's own invite list carries them.
- `POST /api/cofounder-invite/[token]/accept`: selects the invite's `startup_name`/`startup_website` and, once the `cofounder_links` row is created, updates **both** the inviter's and acceptor's `profiles` rows (`.in("user_id", [inviter, acceptor])`) with the agreed name/site. Guarded by `if (invite.startup_name)` so legacy pending invites created before this migration (no proposed name) don't null out existing profile data on accept.

### Client — Invite & Accept flow
- `CoFounderPanel.tsx`: adds a required "Startup or project name" text input and an optional "startup site" `type="url"` input to the send-invite form (placed between email and role), resets both on successful send, and disables submit until both email and startup name are non-empty.
- `hooks.ts`: extends `useSendCofounderInvite`'s mutation args and the `CofounderInvite` type with `startupName`/`startupWebsite`.
- `.../invite/[token]/page.tsx`: selects the invite's `startup_name`/`startup_website` and passes them through to the client component.
- `AcceptInviteClient.tsx`: renders the proposed startup name/site in a **read-only** card (no edit affordance, unlike the existing editable "role" field) — approval happens implicitly by clicking Accept. Updates the pre-accept confirmation copy to state that accepting will also set this as the startup name on both profiles.

### Admin dashboard
- `matchConnections.ts`: adds `startup_website` to `MatchPerson`, the profiles `select()`, `toPerson()`, and the email-only pending-invite fallback object.
- `admin/page.tsx`: renames the "Startup" column header to "Team" and replaces the stacked `person1.startup_name` / `person2.startup_name` cell with a single value (`person1.startup_name ?? person2.startup_name`), rendered as a clickable `target="_blank"` link when either person has a `startup_website`, plain text otherwise, `"—"` when neither has a name.

## Migration / Config
- Run the new Supabase migration (`20260716000000_add_startup_fields_to_cofounder_invites.sql`) before deploying — adds two nullable columns, no backfill required.
- No env vars or third-party config changes.

## Testing
- `npx tsc --noEmit` passes with no errors.
- Not yet manually exercised end-to-end in the browser (send invite → accept → verify both profiles synced → verify admin table) — recommended before merge.

## Notes
- Co-founder pairs linked **before** this change ships are not retroactively reconciled; the admin table falls back to whichever single `startup_name` is non-null for those legacy pairs rather than merging two differing names.
- Onboarding forms (`StartupForm.tsx`/`UTStartupForm.tsx`) and the invite email template are unchanged — `startup_website` is populated only via the invite-accept flow for now.
- Unlinking a co-founder pair does not revert the overwritten `startup_name`/`startup_website` on either profile.
