### PR TITLE
Add end of cycle copywriting to show the student has exhausted all new profiles

### DIFF
--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -12,7 +12,7 @@ import toast from "react-hot-toast";
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
 import ProfileViewModal from "@/features/profile/ProfileViewModal";
-import { useGetProfiles, useSearchProfiles } from "@/features/profile/useProfile";
+import { useGetProfiles, useSearchProfiles, useResetMatchingRound } from "@/features/profile/useProfile";
 import { useSchool } from "@/features/school/components/SchoolContext";
 import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/useLikes";
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
@@ -211,7 +211,12 @@ export default function SchoolDashboardPage() {
   const cardRef = useRef<HTMLDivElement>(null);
 
   const { schoolName, slug } = useSchool();
-  const { data: profiles, isLoading: isLoadingProfiles } = useGetProfiles(filters, slug);
+  const {
+    data: profiles,
+    isLoading: isLoadingProfiles,
+    isFetching: isFetchingProfiles,
+  } = useGetProfiles(filters, slug);
+  const resetRoundMutation = useResetMatchingRound();
 
   useEffect(() => {
     setFilters(loadDashboardFilters());
@@ -294,6 +299,14 @@ export default function SchoolDashboardPage() {
       queryClient.invalidateQueries({ queryKey: ["profiles"] });
     } catch {
       toast.error("Failed to skip profile");
+    }
+  };
+
+  const handleStartOver = async () => {
+    try {
+      await resetRoundMutation.mutateAsync();
+    } catch {
+      toast.error("Failed to refresh profiles");
     }
   };
 
@@ -530,8 +543,16 @@ export default function SchoolDashboardPage() {
                   No more co-founders to show right now
                 </p>
                 <p className="text-sm text-[var(--ui-text-muted)]">
-                  Check back later — more students from your program will be joining.
+                  Check back later. More students from your program will be joining.
                 </p>
+                <button
+                  type="button"
+                  onClick={handleStartOver}
+                  disabled={resetRoundMutation.isPending || isFetchingProfiles}
+                  className="mt-1 inline-flex items-center gap-2 rounded-full bg-[#BF5700] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-60 cursor-pointer"
+                >
+                  {resetRoundMutation.isPending || isFetchingProfiles ? "Checking…" : "Start over"}
+                </button>
               </>
             )}
           </div>

--- a/src/app/api/profiles/reset-round/route.ts
+++ b/src/app/api/profiles/reset-round/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
+
+export async function POST() {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = await createServerSupabaseClient();
+
+    const { error } = await supabase
+      .from("matching_queue")
+      .update({ cycle: 0, updated_at: new Date().toISOString() })
+      .eq("viewer_user_id", userId);
+
+    if (error) {
+      console.error("Error resetting matching queue:", error);
+      return NextResponse.json(
+        { error: "Failed to reset matching queue" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in reset-round API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -240,6 +240,17 @@ export async function GET(req: NextRequest) {
       );
     }
 
+    // If every eligible candidate has already been skipped at least once since the
+    // last reset, the viewer has completed a full pass through the deck. Show the
+    // empty state instead of looping the same candidates in score order forever.
+    const roundComplete = enrichedFiltered.every(
+      (profile) => (queueMap.get(profile.user_id!)?.cycle ?? 0) >= 1,
+    );
+
+    if (roundComplete) {
+      return NextResponse.json({ profiles: [], currentUser, roundComplete: true });
+    }
+
     // Sort by: cycle asc (skipped profiles go to back) → score desc (best match first within same cycle)
     const sorted = enrichedFiltered
       .map((profile) => {

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -16,6 +16,7 @@ export function useGetProfiles(filters?: DashboardFilters, orgSlug?: string) {
   const {
     data: profiles,
     isLoading,
+    isFetching,
     error,
   } = useQuery({
     queryKey: ["profiles", filters, orgSlug],
@@ -60,7 +61,38 @@ export function useGetProfiles(filters?: DashboardFilters, orgSlug?: string) {
     retry: 1,
   });
 
-  return { data: profiles, isLoading, error };
+  return { data: profiles, isLoading, isFetching, error };
+}
+
+// Resets the viewer's matching_queue cycle counters to 0, so candidates
+// they've already cycled through this round reappear from the top.
+export function useResetMatchingRound() {
+  const { session } = useSession();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const token = await session?.getToken();
+      if (!token) throw new Error("No authentication token");
+
+      const response = await fetch("/api/profiles/reset-round", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to reset matching round");
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
 }
 
 export function useUserProfile() {


### PR DESCRIPTION
## Summary
Adds a real end-of-deck state to the UT co-foundr Matching dashboard. Previously, skipping a profile only bumped a `cycle` counter and sent it to the back of the queue — candidates were never actually removed from the pool, so `/api/profiles` kept re-serving the same people in score order indefinitely and the "no more profiles" empty state was effectively unreachable. This PR adds server-side detection for when a viewer has skipped every eligible candidate at least once, surfaces a clear empty-state message, and gives the student a "Start over" button to manually reset their round and cycle back through the same profiles.

## Changes

### API
- `src/app/api/profiles/route.ts`: after building the eligible candidate list, checks whether every candidate's `matching_queue.cycle` is `>= 1` (i.e. already skipped at least once since the last reset). If so, returns `{ profiles: [], roundComplete: true }` instead of falling through to the cycle/score sort — this is what actually makes the deck "run dry" instead of looping forever.
- `src/app/api/profiles/reset-round/route.ts` (new): `POST` endpoint that resets `cycle` to `0` on all of the authenticated viewer's `matching_queue` rows, using the existing RLS policy (`viewer_user_id = auth.jwt() ->> 'sub'`) so no service-role client is needed — same pattern as the existing `/api/skip` and `/api/profiles/seen` routes.

### Client
- `src/features/profile/useProfile.ts`: exposes `isFetching` from `useGetProfiles`'s underlying query so the UI can show a loading state during a manual refresh, and adds a new `useResetMatchingRound()` mutation hook that calls the reset endpoint and invalidates the `["profiles"]` query on success.
- `src/app/(school)/school/[slug]/dashboard/page.tsx`: updates the true-empty-deck copy (no active filters) to "No more co-founders to show right now" / "Check back later. More students from your program will be joining." and adds a "Start over" button below it, wired to `useResetMatchingRound()`. The button shows "Checking…" while the reset + refetch is in flight and surfaces a toast on failure. The filtered-empty state ("No matches for these filters") and the general (non-school) matching page are untouched.

## Testing
- `npx tsc --noEmit` passes with no errors.
- `npx eslint` passes on all changed/new files.
- Manually verified in dev: skipping through the full candidate pool now triggers the empty state (previously it looped indefinitely), and clicking "Start over" resets the round and brings the same profiles back from the top.

## Notes
- `roundComplete: true` is returned in the API response for potential future client-side use but isn't currently consumed by the UI — the empty `profiles` array alone drives the empty state.
