### PR TITLE
Fix revoke and resend broken cofounder invite

### DIFF
--- a/src/app/api/cofounder-invite/[token]/resend/route.ts
+++ b/src/app/api/cofounder-invite/[token]/resend/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
+import { sendCofounderInviteEmail } from "@/lib/email/emails/cofounderInvite";
+
+const RESEND_COOLDOWN_MS = 60 * 1000;
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { token } = await params;
+    const supabase = await createServerSupabaseClient();
+
+    const { data: invite, error: inviteErr } = await supabase
+      .from("cofounder_invites")
+      .select("id, inviter_user_id, organization_id, status, invitee_email, notified_at")
+      .eq("token", token)
+      .single();
+
+    if (inviteErr || !invite) {
+      return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+    }
+    if (invite.inviter_user_id !== userId) {
+      return NextResponse.json({ error: "Only the inviter can resend an invite" }, { status: 403 });
+    }
+    if (invite.status !== "pending") {
+      return NextResponse.json(
+        { error: `Invite is already ${invite.status}` },
+        { status: 409 },
+      );
+    }
+    if (
+      invite.notified_at &&
+      Date.now() - new Date(invite.notified_at).getTime() < RESEND_COOLDOWN_MS
+    ) {
+      return NextResponse.json(
+        { error: "Just sent. Wait a moment before resending." },
+        { status: 429 },
+      );
+    }
+
+    const { data: inviterProfile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("first_name, last_name")
+      .eq("user_id", userId)
+      .single();
+
+    if (profileErr || !inviterProfile) {
+      return NextResponse.json({ error: "Caller profile not found" }, { status: 404 });
+    }
+
+    const { data: org, error: orgErr } = await supabase
+      .from("organizations")
+      .select("slug")
+      .eq("id", invite.organization_id)
+      .single();
+
+    if (orgErr || !org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const inviterName =
+      [inviterProfile.first_name, inviterProfile.last_name]
+        .filter(Boolean)
+        .join(" ") || "Someone";
+
+    const emailResult = await sendCofounderInviteEmail({
+      to: invite.invitee_email,
+      inviterName,
+      slug: org.slug,
+      token,
+    });
+
+    if (!emailResult.ok) {
+      return NextResponse.json({ error: "Failed to send invite email" }, { status: 500 });
+    }
+
+    const { error: updateErr } = await supabase
+      .from("cofounder_invites")
+      .update({
+        notified_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .eq("id", invite.id)
+      .select("id")
+      .single();
+
+    if (updateErr) {
+      console.error("[cofounder-invite resend] update error:", updateErr);
+      return NextResponse.json({ error: "Failed to update invite" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[cofounder-invite resend] unhandled:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/cofounder-invite/[token]/revoke/route.ts
+++ b/src/app/api/cofounder-invite/[token]/revoke/route.ts
@@ -34,10 +34,17 @@ export async function POST(
       );
     }
 
-    await supabase
+    const { error: updateErr } = await supabase
       .from("cofounder_invites")
       .update({ status: "revoked", responded_at: new Date().toISOString() })
-      .eq("id", invite.id);
+      .eq("id", invite.id)
+      .select("id")
+      .single();
+
+    if (updateErr) {
+      console.error("[cofounder-invite revoke] update error:", updateErr);
+      return NextResponse.json({ error: "Failed to revoke invite" }, { status: 500 });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/cofounder-invite/route.ts
+++ b/src/app/api/cofounder-invite/route.ts
@@ -131,17 +131,31 @@ export async function POST(request: NextRequest) {
     // Pending invite already exists check (via partial unique index)
     const { data: existingInvite } = await supabase
       .from("cofounder_invites")
-      .select("id")
+      .select("id, expires_at")
       .eq("inviter_user_id", userId)
       .eq("status", "pending")
       .ilike("invitee_email", normalizedEmail)
       .maybeSingle();
 
     if (existingInvite) {
-      return NextResponse.json(
-        { error: "A pending invite already exists for this email" },
-        { status: 409 },
-      );
+      if (new Date(existingInvite.expires_at) < new Date()) {
+        const { error: expireErr } = await supabase
+          .from("cofounder_invites")
+          .update({ status: "expired" })
+          .eq("id", existingInvite.id);
+        if (expireErr) {
+          console.error("[cofounder-invite] expire stale invite error:", expireErr);
+          return NextResponse.json(
+            { error: "Failed to create invite" },
+            { status: 500 },
+          );
+        }
+      } else {
+        return NextResponse.json(
+          { error: "A pending invite already exists for this email" },
+          { status: 409 },
+        );
+      }
     }
 
     const token = randomBytes(32).toString("hex");

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import toast from "react-hot-toast";
 import Image from "next/image";
-import { FaUserPlus, FaTrash, FaUserMinus } from "react-icons/fa6";
+import { FaUserPlus, FaTrash, FaUserMinus, FaPaperPlane, FaRotateRight } from "react-icons/fa6";
 import {
   useCofounderManagement,
   useSendCofounderInvite,
   useRevokeCofounderInvite,
+  useResendCofounderInvite,
   useUnlinkCofounder,
+  type CofounderInvite,
 } from "./hooks";
 import { formatAllowedDomainsForCopy } from "@/features/school/auth/email-domain";
 
@@ -25,6 +27,13 @@ const ROLE_OPTIONS = [
   { value: "non-technical", label: "Non-technical founder" },
 ];
 
+function effectiveStatus(invite: CofounderInvite): CofounderInvite["status"] {
+  if (invite.status === "pending" && new Date(invite.expires_at) < new Date()) {
+    return "expired";
+  }
+  return invite.status;
+}
+
 export default function CoFounderPanel({
   allowedDomains = [],
 }: {
@@ -36,13 +45,15 @@ export default function CoFounderPanel({
   const [startupWebsite, setStartupWebsite] = useState("");
   const [role, setRole] = useState("");
   const [note, setNote] = useState("");
+  const formRef = useRef<HTMLFormElement>(null);
   const { data, isLoading } = useCofounderManagement();
   const sendInvite = useSendCofounderInvite();
   const revokeInvite = useRevokeCofounderInvite();
+  const resendInvite = useResendCofounderInvite();
   const unlink = useUnlinkCofounder();
 
-  const pendingInvites = (data?.invites ?? []).filter((i) => i.status === "pending");
-  const pastInvites = (data?.invites ?? []).filter((i) => i.status !== "pending");
+  const pendingInvites = (data?.invites ?? []).filter((i) => effectiveStatus(i) === "pending");
+  const pastInvites = (data?.invites ?? []).filter((i) => effectiveStatus(i) !== "pending");
   const links = data?.links ?? [];
 
   const emailPlaceholder = `cofounder@${allowedDomains[0] ?? "utexas.edu"}`;
@@ -79,6 +90,39 @@ export default function CoFounderPanel({
       toast.success("Invite revoked");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to revoke");
+    }
+  }
+
+  async function handleResend(token: string) {
+    try {
+      await resendInvite.mutateAsync(token);
+      toast.success("Invite re-sent");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to resend invite");
+    }
+  }
+
+  async function handleReinvite(invite: CofounderInvite) {
+    if (!invite.startup_name) {
+      setEmail(invite.invitee_email);
+      setStartupWebsite(invite.startup_website ?? "");
+      setRole(invite.invitee_role ?? "");
+      setNote(invite.note ?? "");
+      formRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      toast("Add the startup name to re-send this invite", { icon: "✏️" });
+      return;
+    }
+    try {
+      await sendInvite.mutateAsync({
+        inviteeEmail: invite.invitee_email,
+        startupName: invite.startup_name,
+        startupWebsite: invite.startup_website ?? undefined,
+        inviteeRole: invite.invitee_role ?? undefined,
+        note: invite.note ?? undefined,
+      });
+      toast.success(`Invite re-sent to ${invite.invitee_email}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to re-invite");
     }
   }
 
@@ -154,7 +198,7 @@ export default function CoFounderPanel({
           Enter their school email address — they&apos;ll receive a link to accept.
           {allowedDomainsCopy && ` Must be a ${allowedDomainsCopy} email.`}
         </p>
-        <form onSubmit={handleSend} className="space-y-2">
+        <form ref={formRef} onSubmit={handleSend} className="space-y-2">
           <input
             type="email"
             value={email}
@@ -223,15 +267,26 @@ export default function CoFounderPanel({
                   Expires {new Date(invite.expires_at).toLocaleDateString()}
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() => handleRevoke(invite.token)}
-                disabled={revokeInvite.isPending}
-                className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-red-500/30 hover:text-red-500 disabled:opacity-50"
-              >
-                <FaTrash className="h-3 w-3" />
-                Revoke
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleResend(invite.token)}
+                  disabled={resendInvite.isPending}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)] disabled:opacity-50"
+                >
+                  <FaPaperPlane className="h-3 w-3" />
+                  Resend
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(invite.token)}
+                  disabled={revokeInvite.isPending}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-red-500/30 hover:text-red-500 disabled:opacity-50"
+                >
+                  <FaTrash className="h-3 w-3" />
+                  Revoke
+                </button>
+              </div>
             </div>
           ))}
         </div>
@@ -241,17 +296,34 @@ export default function CoFounderPanel({
       {pastInvites.length > 0 && (
         <div className="space-y-2">
           <label className={labelClass}>Past invites</label>
-          {pastInvites.map((invite) => (
-            <div
-              key={invite.id}
-              className="flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] px-4 py-3 opacity-60"
-            >
-              <p className="truncate text-sm text-[var(--ui-text)]">{invite.invitee_email}</p>
-              <span className="text-xs text-[var(--ui-text-subtle)]">
-                {STATUS_LABELS[invite.status] ?? invite.status}
-              </span>
-            </div>
-          ))}
+          {pastInvites.map((invite) => {
+            const status = effectiveStatus(invite);
+            const canReinvite = status === "revoked" || status === "declined" || status === "expired";
+            return (
+              <div
+                key={invite.id}
+                className="flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] px-4 py-3 opacity-60"
+              >
+                <p className="truncate text-sm text-[var(--ui-text)]">{invite.invitee_email}</p>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-[var(--ui-text-subtle)]">
+                    {STATUS_LABELS[status] ?? status}
+                  </span>
+                  {canReinvite && (
+                    <button
+                      type="button"
+                      onClick={() => handleReinvite(invite)}
+                      disabled={sendInvite.isPending}
+                      className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)] disabled:opacity-50"
+                    >
+                      <FaRotateRight className="h-3 w-3" />
+                      Re-invite
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/src/features/cofounder/hooks.ts
+++ b/src/features/cofounder/hooks.ts
@@ -86,6 +86,22 @@ export function useRevokeCofounderInvite() {
   });
 }
 
+export function useResendCofounderInvite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const res = await fetch(`/api/cofounder-invite/${token}/resend`, { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Failed to resend invite");
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cofounder-management"] });
+    },
+  });
+}
+
 export function useUnlinkCofounder() {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Summary
Fixes co-founder invites becoming a dead end once revoked: users could not resend an invite to the same email nor undo a revoke. Adds a **Resend** action for pending invites and a **Re-invite** action for revoked/declined/expired invites, and closes a related gap where expired invites stayed `pending` forever and silently blocked re-inviting that email. Also hardens the revoke endpoint, which previously reported success even when its update affected zero rows.

## Changes

### API
- `src/app/api/cofounder-invite/route.ts`: the pending-duplicate check now inspects `expires_at` on the blocking invite. If it's already past expiry, the row is flipped to `status: "expired"` before the new invite is created instead of unconditionally 409ing — this was the actual mechanism causing "can't re-invite this email," since nothing else ever swept expired invites out of `pending`.
- `src/app/api/cofounder-invite/[token]/resend/route.ts` (new): re-sends the invite email on the **same token** (so a previously-received link keeps working) via the existing `sendCofounderInviteEmail`, extends `expires_at` by 14 days, and bumps `notified_at`. Guards: inviter-only, invite must still be `pending`, and a 60s cooldown keyed off `notified_at` to prevent spam-clicking (429 on violation).
- `src/app/api/cofounder-invite/[token]/revoke/route.ts`: the revoke `update()` previously discarded its error and always returned `{ success: true }`. Now captures `updateErr` and confirms a row was actually affected via `.select("id").single()`, returning 500 on failure instead of silently no-oping.

### Client
- `src/features/cofounder/CoFounderPanel.tsx`:
  - Adds a `Resend` button (paper-plane icon) next to `Revoke` on pending invites, wired to the new endpoint.
  - Adds a `Re-invite` button on past invites with status `revoked`, `declined`, or `expired`. It reuses the existing `useSendCofounderInvite` mutation with the invite's stored `startup_name`/`startup_website`/`invitee_role`/`note` rather than adding a new endpoint, since creating a fresh invite (new token, new 14-day expiry) is safer than resurrecting the original — an un-revoked row would carry its original `expires_at`, which may already be in the past.
  - Handles legacy rows where `startup_name` is null (nullable column added after `cofounder_invites` existed, but required by the create endpoint): instead of firing a doomed request, `handleReinvite` prefills the send form with the invite's other fields and scrolls it into view so the user only needs to add the missing startup name.
  - Adds an `effectiveStatus()` helper so invites that are still `status: "pending"` in the DB but past `expires_at` are displayed and filtered as expired client-side too, keeping the "Pending invites" section from showing stale entries with already-past expiry dates.
- `src/features/cofounder/hooks.ts`: adds `useResendCofounderInvite`, mirroring the shape of the existing `useRevokeCofounderInvite` (mutate by token, invalidate `["cofounder-management"]` on success).

## Testing
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- Not exercised end-to-end against a live DB (local Supabase required Docker, which was unavailable in this environment). Manual verification still needed: revoke → re-invite round trip, resend cooldown (429 on double-click), stale-pending-invite auto-expiry on next send attempt, and the legacy-row (`startup_name = null`) prefill path.
