### PR TITLE
Staging | Add cofounder invite startup details, matching round reset, and dashboard skeletons

### DIFF
--- a/src/app/(school)/school/[slug]/accept-policies/_actions.ts
+++ b/src/app/(school)/school/[slug]/accept-policies/_actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getRequiredConsents } from "@/features/legal/consent";
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
 
 type RecordConsentResult = { ok: true } | { ok: false; error: string };
 
@@ -20,7 +21,15 @@ export async function recordPolicyConsents(
     return { ok: false, error: "No logged-in user." };
   }
 
-  const organizationId = sessionClaims?.metadata?.organization_id ?? null;
+  // Prefer the session claim, but fall back to resolving the org from the slug.
+  // A just-signed-in user (e.g. an invited co-founder) can hit this action before
+  // Clerk's organization_id metadata has propagated onto their JWT — the slug is
+  // authoritative for which school's policies are being accepted, so it is both a
+  // safe and more robust source of org context.
+  const organizationId =
+    sessionClaims?.metadata?.organization_id ??
+    (await getOrganizationBySlug(slug))?.id ??
+    null;
   if (!organizationId) {
     return { ok: false, error: "No organization context for this user." };
   }

--- a/src/app/(school)/school/[slug]/admin/page.tsx
+++ b/src/app/(school)/school/[slug]/admin/page.tsx
@@ -699,7 +699,7 @@ export default function SchoolAdminPage() {
                           {[
                             "Match",
                             "Type Fit",
-                            "Startup",
+                            "Team",
                             "Date",
                             "Status",
                           ].map((h) => (
@@ -796,18 +796,44 @@ export default function SchoolAdminPage() {
                                 </div>
                               </td>
                               <td className="px-4 py-3">
-                                <div
-                                  className="font-medium"
-                                  style={{ color: "var(--ui-text)" }}
-                                >
-                                  {conn.person1.startup_name ?? "—"}
-                                </div>
-                                <div
-                                  className="text-xs"
-                                  style={{ color: "var(--ui-text-muted)" }}
-                                >
-                                  {conn.person2.startup_name ?? "—"}
-                                </div>
+                                {(() => {
+                                  const teamName =
+                                    conn.person1.startup_name ??
+                                    conn.person2.startup_name;
+                                  const teamWebsite =
+                                    conn.person1.startup_website ??
+                                    conn.person2.startup_website;
+                                  if (!teamName) {
+                                    return (
+                                      <span
+                                        style={{ color: "var(--ui-text-muted)" }}
+                                      >
+                                        —
+                                      </span>
+                                    );
+                                  }
+                                  if (teamWebsite) {
+                                    return (
+                                      <a
+                                        href={teamWebsite}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="font-medium hover:underline"
+                                        style={{ color: "var(--ui-text)" }}
+                                      >
+                                        {teamName}
+                                      </a>
+                                    );
+                                  }
+                                  return (
+                                    <div
+                                      className="font-medium"
+                                      style={{ color: "var(--ui-text)" }}
+                                    >
+                                      {teamName}
+                                    </div>
+                                  );
+                                })()}
                               </td>
                               <td
                                 className="px-4 py-3 text-xs"

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { trackEvent } from "@/lib/posthog-events";
 import { useProfileViewTracking } from "@/features/profile/useProfileViewTracking";
 import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/features/school/data/utSchoolsAndMajors";
 import FilterSidebar, { getFilterChipLabels } from "@/features/school/components/dashboard/FilterSidebar";
+import { SwipeCardSkeleton, SearchResultCardSkeleton } from "@/features/school/components/dashboard/ProfileCardSkeletons";
 import ReportProfileButton from "@/features/report/ReportProfileButton";
 import {
   type DashboardFilters,
@@ -410,6 +411,7 @@ export default function SchoolDashboardPage() {
         onChange={updateFilters}
         isOpen={filterDrawerOpen}
         onClose={() => setFilterDrawerOpen(false)}
+        isLoading={isLoadingProfiles}
       />
 
       {/* Search bar — only shown when open */}
@@ -441,6 +443,7 @@ export default function SchoolDashboardPage() {
           variant="sidebar"
           filters={filters}
           onChange={updateFilters}
+          isLoading={isLoadingProfiles}
         />
 
         <div className="mx-auto flex w-full min-w-0 max-w-2xl flex-1 flex-col min-h-0">
@@ -448,9 +451,11 @@ export default function SchoolDashboardPage() {
       {isSearchActive ? (
         <div>
           {isSearching && (
-            <p className="mb-4 text-center text-sm text-[var(--ui-text-muted)]">
-              Searching…
-            </p>
+            <div className="flex flex-col gap-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <SearchResultCardSkeleton key={i} />
+              ))}
+            </div>
           )}
           {!isSearching && searchResults && searchResults.length === 0 && (
             <div className="flex flex-col items-center gap-3 py-16 text-center">
@@ -500,9 +505,7 @@ export default function SchoolDashboardPage() {
       ) : (
         /* Swipe card */
         isLoadingProfiles ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
-            <p className="text-sm text-[var(--ui-text-muted)]">Loading profiles…</p>
-          </div>
+          <SwipeCardSkeleton />
         ) : !curProfile ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
             {filtersActive ? (

--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -12,7 +12,7 @@ import toast from "react-hot-toast";
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
 import ProfileViewModal from "@/features/profile/ProfileViewModal";
-import { useGetProfiles, useSearchProfiles } from "@/features/profile/useProfile";
+import { useGetProfiles, useSearchProfiles, useResetMatchingRound } from "@/features/profile/useProfile";
 import { useSchool } from "@/features/school/components/SchoolContext";
 import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/useLikes";
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
@@ -211,7 +211,12 @@ export default function SchoolDashboardPage() {
   const cardRef = useRef<HTMLDivElement>(null);
 
   const { schoolName, slug } = useSchool();
-  const { data: profiles, isLoading: isLoadingProfiles } = useGetProfiles(filters, slug);
+  const {
+    data: profiles,
+    isLoading: isLoadingProfiles,
+    isFetching: isFetchingProfiles,
+  } = useGetProfiles(filters, slug);
+  const resetRoundMutation = useResetMatchingRound();
 
   useEffect(() => {
     setFilters(loadDashboardFilters());
@@ -294,6 +299,14 @@ export default function SchoolDashboardPage() {
       queryClient.invalidateQueries({ queryKey: ["profiles"] });
     } catch {
       toast.error("Failed to skip profile");
+    }
+  };
+
+  const handleStartOver = async () => {
+    try {
+      await resetRoundMutation.mutateAsync();
+    } catch {
+      toast.error("Failed to refresh profiles");
     }
   };
 
@@ -530,8 +543,16 @@ export default function SchoolDashboardPage() {
                   No more co-founders to show right now
                 </p>
                 <p className="text-sm text-[var(--ui-text-muted)]">
-                  Check back later — more students from your program will be joining.
+                  Check back later. More students from your program will be joining.
                 </p>
+                <button
+                  type="button"
+                  onClick={handleStartOver}
+                  disabled={resetRoundMutation.isPending || isFetchingProfiles}
+                  className="mt-1 inline-flex items-center gap-2 rounded-full bg-[#BF5700] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-60 cursor-pointer"
+                >
+                  {resetRoundMutation.isPending || isFetchingProfiles ? "Checking…" : "Start over"}
+                </button>
               </>
             )}
           </div>

--- a/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/AcceptInviteClient.tsx
@@ -19,6 +19,8 @@ type Props = {
   inviterPfpUrl: string | null;
   inviteeRole: string | null;
   note: string | null;
+  startupName: string | null;
+  startupWebsite: string | null;
 };
 
 export default function AcceptInviteClient({
@@ -29,6 +31,8 @@ export default function AcceptInviteClient({
   inviterPfpUrl,
   inviteeRole,
   note,
+  startupName,
+  startupWebsite,
 }: Props) {
   const router = useRouter();
   const [accepting, setAccepting] = useState(false);
@@ -104,6 +108,30 @@ export default function AcceptInviteClient({
           )}
         </div>
 
+        {/* Proposed startup name/site — read-only, approved by accepting */}
+        {startupName && (
+          <div
+            className="mb-4 rounded-xl border border-[#e8e4dc] bg-[#faf8f4] px-4 py-3 space-y-1 text-center"
+          >
+            <p className="text-xs" style={{ color: "#5f7280" }}>
+              Your team will be named
+            </p>
+            <p className="text-base font-semibold" style={{ color: "#333f48" }}>
+              {startupName}
+            </p>
+            {startupWebsite && (
+              <a
+                href={startupWebsite}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-[#bf5700] hover:underline"
+              >
+                {startupWebsite}
+              </a>
+            )}
+          </div>
+        )}
+
         {/* Role assigned by inviter */}
         {(inviteeRole || note) && (
           <div
@@ -155,7 +183,10 @@ export default function AcceptInviteClient({
         )}
 
         <p className="mb-6 text-center text-sm" style={{ color: "#5f7280" }}>
-          Accepting will link your profiles as confirmed co-founders, visible on both your cards.
+          Accepting will link your profiles as confirmed co-founders, visible on both your cards
+          {startupName
+            ? `, and set your startup name to "${startupName}" on both profiles.`
+            : "."}
         </p>
 
         <div className="flex gap-3">

--- a/src/app/(school)/school/[slug]/invite/[token]/page.tsx
+++ b/src/app/(school)/school/[slug]/invite/[token]/page.tsx
@@ -24,7 +24,9 @@ export default async function InviteAcceptPage({
 
   const { data: invite } = await supabase
     .from("cofounder_invites")
-    .select("id, inviter_user_id, organization_id, status, expires_at, invitee_role, note")
+    .select(
+      "id, inviter_user_id, organization_id, status, expires_at, invitee_role, note, startup_name, startup_website",
+    )
     .eq("token", token)
     .single();
 
@@ -134,6 +136,8 @@ export default async function InviteAcceptPage({
       inviterPfpUrl={inviterProfile?.pfp_url ?? null}
       inviteeRole={invite.invitee_role ?? null}
       note={invite.note ?? null}
+      startupName={invite.startup_name ?? null}
+      startupWebsite={invite.startup_website ?? null}
     />
   );
 }

--- a/src/app/api/cofounder-invite/[token]/accept/route.ts
+++ b/src/app/api/cofounder-invite/[token]/accept/route.ts
@@ -27,7 +27,9 @@ export async function POST(
 
     const { data: invite, error: inviteErr } = await supabase
       .from("cofounder_invites")
-      .select("id, inviter_user_id, organization_id, invitee_email, status, expires_at")
+      .select(
+        "id, inviter_user_id, organization_id, invitee_email, status, expires_at, startup_name, startup_website",
+      )
       .eq("token", token)
       .single();
 
@@ -110,6 +112,20 @@ export async function POST(
     if (linkErr) {
       console.error("[cofounder-invite accept] link insert error:", linkErr);
       return NextResponse.json({ error: "Failed to create co-founder link" }, { status: 500 });
+    }
+
+    // Overwrite both profiles' startup identity with the agreed-on name/site
+    if (invite.startup_name) {
+      const { error: profileSyncErr } = await supabase
+        .from("profiles")
+        .update({
+          startup_name: invite.startup_name,
+          startup_website: invite.startup_website,
+        })
+        .in("user_id", [invite.inviter_user_id, userId]);
+      if (profileSyncErr) {
+        console.error("[cofounder-invite accept] profile sync error:", profileSyncErr);
+      }
     }
 
     await supabase

--- a/src/app/api/cofounder-invite/[token]/resend/route.ts
+++ b/src/app/api/cofounder-invite/[token]/resend/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
+import { sendCofounderInviteEmail } from "@/lib/email/emails/cofounderInvite";
+
+const RESEND_COOLDOWN_MS = 60 * 1000;
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { token } = await params;
+    const supabase = await createServerSupabaseClient();
+
+    const { data: invite, error: inviteErr } = await supabase
+      .from("cofounder_invites")
+      .select("id, inviter_user_id, organization_id, status, invitee_email, notified_at")
+      .eq("token", token)
+      .single();
+
+    if (inviteErr || !invite) {
+      return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+    }
+    if (invite.inviter_user_id !== userId) {
+      return NextResponse.json({ error: "Only the inviter can resend an invite" }, { status: 403 });
+    }
+    if (invite.status !== "pending") {
+      return NextResponse.json(
+        { error: `Invite is already ${invite.status}` },
+        { status: 409 },
+      );
+    }
+    if (
+      invite.notified_at &&
+      Date.now() - new Date(invite.notified_at).getTime() < RESEND_COOLDOWN_MS
+    ) {
+      return NextResponse.json(
+        { error: "Just sent. Wait a moment before resending." },
+        { status: 429 },
+      );
+    }
+
+    const { data: inviterProfile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("first_name, last_name")
+      .eq("user_id", userId)
+      .single();
+
+    if (profileErr || !inviterProfile) {
+      return NextResponse.json({ error: "Caller profile not found" }, { status: 404 });
+    }
+
+    const { data: org, error: orgErr } = await supabase
+      .from("organizations")
+      .select("slug")
+      .eq("id", invite.organization_id)
+      .single();
+
+    if (orgErr || !org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const inviterName =
+      [inviterProfile.first_name, inviterProfile.last_name]
+        .filter(Boolean)
+        .join(" ") || "Someone";
+
+    const emailResult = await sendCofounderInviteEmail({
+      to: invite.invitee_email,
+      inviterName,
+      slug: org.slug,
+      token,
+    });
+
+    if (!emailResult.ok) {
+      return NextResponse.json({ error: "Failed to send invite email" }, { status: 500 });
+    }
+
+    const { error: updateErr } = await supabase
+      .from("cofounder_invites")
+      .update({
+        notified_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .eq("id", invite.id)
+      .select("id")
+      .single();
+
+    if (updateErr) {
+      console.error("[cofounder-invite resend] update error:", updateErr);
+      return NextResponse.json({ error: "Failed to update invite" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[cofounder-invite resend] unhandled:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/cofounder-invite/[token]/revoke/route.ts
+++ b/src/app/api/cofounder-invite/[token]/revoke/route.ts
@@ -34,10 +34,17 @@ export async function POST(
       );
     }
 
-    await supabase
+    const { error: updateErr } = await supabase
       .from("cofounder_invites")
       .update({ status: "revoked", responded_at: new Date().toISOString() })
-      .eq("id", invite.id);
+      .eq("id", invite.id)
+      .select("id")
+      .single();
+
+    if (updateErr) {
+      console.error("[cofounder-invite revoke] update error:", updateErr);
+      return NextResponse.json({ error: "Failed to revoke invite" }, { status: 500 });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/cofounder-invite/route.ts
+++ b/src/app/api/cofounder-invite/route.ts
@@ -12,13 +12,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { inviteeEmail, inviteeRole, note } = await request.json();
+    const { inviteeEmail, startupName, startupWebsite, inviteeRole, note } =
+      await request.json();
     const normalizedEmail = (inviteeEmail ?? "").trim().toLowerCase();
+    const normalizedStartupName = (startupName ?? "").trim() || null;
+    const normalizedStartupWebsite = (startupWebsite ?? "").trim() || null;
     const normalizedRole = (inviteeRole ?? "").trim() || null;
     const normalizedNote = (note ?? "").trim() || null;
     if (!normalizedEmail) {
       return NextResponse.json(
         { error: "Missing inviteeEmail" },
+        { status: 400 },
+      );
+    }
+    if (!normalizedStartupName) {
+      return NextResponse.json(
+        { error: "Missing startupName" },
         { status: 400 },
       );
     }
@@ -147,6 +156,8 @@ export async function POST(request: NextRequest) {
         inviter_user_id: userId,
         organization_id: inviterProfile.organization_id,
         invitee_email: normalizedEmail,
+        startup_name: normalizedStartupName,
+        startup_website: normalizedStartupWebsite,
         invitee_role: normalizedRole,
         note: normalizedNote,
         invitee_user_id: inviteeUserId,
@@ -197,7 +208,7 @@ export async function GET() {
     const { data: invites, error: inviteErr } = await supabase
       .from("cofounder_invites")
       .select(
-        "id, token, invitee_email, invitee_role, note, status, created_at, expires_at",
+        "id, token, invitee_email, invitee_role, note, startup_name, startup_website, status, created_at, expires_at",
       )
       .eq("inviter_user_id", userId)
       .order("created_at", { ascending: false });

--- a/src/app/api/cofounder-invite/route.ts
+++ b/src/app/api/cofounder-invite/route.ts
@@ -131,17 +131,31 @@ export async function POST(request: NextRequest) {
     // Pending invite already exists check (via partial unique index)
     const { data: existingInvite } = await supabase
       .from("cofounder_invites")
-      .select("id")
+      .select("id, expires_at")
       .eq("inviter_user_id", userId)
       .eq("status", "pending")
       .ilike("invitee_email", normalizedEmail)
       .maybeSingle();
 
     if (existingInvite) {
-      return NextResponse.json(
-        { error: "A pending invite already exists for this email" },
-        { status: 409 },
-      );
+      if (new Date(existingInvite.expires_at) < new Date()) {
+        const { error: expireErr } = await supabase
+          .from("cofounder_invites")
+          .update({ status: "expired" })
+          .eq("id", existingInvite.id);
+        if (expireErr) {
+          console.error("[cofounder-invite] expire stale invite error:", expireErr);
+          return NextResponse.json(
+            { error: "Failed to create invite" },
+            { status: 500 },
+          );
+        }
+      } else {
+        return NextResponse.json(
+          { error: "A pending invite already exists for this email" },
+          { status: 409 },
+        );
+      }
     }
 
     const token = randomBytes(32).toString("hex");

--- a/src/app/api/profiles/reset-round/route.ts
+++ b/src/app/api/profiles/reset-round/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createServerSupabaseClient } from "@/lib/supabaseServer";
+
+export async function POST() {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = await createServerSupabaseClient();
+
+    const { error } = await supabase
+      .from("matching_queue")
+      .update({ cycle: 0, updated_at: new Date().toISOString() })
+      .eq("viewer_user_id", userId);
+
+    if (error) {
+      console.error("Error resetting matching queue:", error);
+      return NextResponse.json(
+        { error: "Failed to reset matching queue" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in reset-round API:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -240,6 +240,17 @@ export async function GET(req: NextRequest) {
       );
     }
 
+    // If every eligible candidate has already been skipped at least once since the
+    // last reset, the viewer has completed a full pass through the deck. Show the
+    // empty state instead of looping the same candidates in score order forever.
+    const roundComplete = enrichedFiltered.every(
+      (profile) => (queueMap.get(profile.user_id!)?.cycle ?? 0) >= 1,
+    );
+
+    if (roundComplete) {
+      return NextResponse.json({ profiles: [], currentUser, roundComplete: true });
+    }
+
     // Sort by: cycle asc (skipped profiles go to back) → score desc (best match first within same cycle)
     const sorted = enrichedFiltered
       .map((profile) => {

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,3 @@
+export default function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-[var(--ui-surface-active)] ${className}`} />;
+}

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -32,6 +32,8 @@ export default function CoFounderPanel({
   allowedDomains?: string[];
 }) {
   const [email, setEmail] = useState("");
+  const [startupName, setStartupName] = useState("");
+  const [startupWebsite, setStartupWebsite] = useState("");
   const [role, setRole] = useState("");
   const [note, setNote] = useState("");
   const { data, isLoading } = useCofounderManagement();
@@ -49,15 +51,20 @@ export default function CoFounderPanel({
   async function handleSend(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = email.trim().toLowerCase();
-    if (!trimmed) return;
+    const trimmedStartupName = startupName.trim();
+    if (!trimmed || !trimmedStartupName) return;
     try {
       await sendInvite.mutateAsync({
         inviteeEmail: trimmed,
+        startupName: trimmedStartupName,
+        startupWebsite: startupWebsite.trim() || undefined,
         inviteeRole: role || undefined,
         note: note.trim() || undefined,
       });
       toast.success(`Invite sent to ${trimmed}`);
       setEmail("");
+      setStartupName("");
+      setStartupWebsite("");
       setRole("");
       setNote("");
     } catch (err) {
@@ -156,6 +163,21 @@ export default function CoFounderPanel({
             className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
             required
           />
+          <input
+            type="text"
+            value={startupName}
+            onChange={(e) => setStartupName(e.target.value)}
+            placeholder="Startup or project name"
+            className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
+            required
+          />
+          <input
+            type="url"
+            value={startupWebsite}
+            onChange={(e) => setStartupWebsite(e.target.value)}
+            placeholder="https://yourstartup.com (optional)"
+            className="w-full rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder-[var(--ui-text-subtle)] focus:border-[var(--ui-border-strong)] focus:outline-none focus:ring-1 focus:ring-[var(--ui-border)]"
+          />
           <select
             value={role}
             onChange={(e) => setRole(e.target.value)}
@@ -177,7 +199,7 @@ export default function CoFounderPanel({
           />
           <button
             type="submit"
-            disabled={sendInvite.isPending || !email.trim()}
+            disabled={sendInvite.isPending || !email.trim() || !startupName.trim()}
             className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--ui-btn-bg)] px-4 py-2 text-sm font-medium text-[var(--ui-btn-text)] transition hover:bg-[#a34800] disabled:opacity-50"
           >
             <FaUserPlus className="h-3.5 w-3.5" />

--- a/src/features/cofounder/CoFounderPanel.tsx
+++ b/src/features/cofounder/CoFounderPanel.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import toast from "react-hot-toast";
 import Image from "next/image";
-import { FaUserPlus, FaTrash, FaUserMinus } from "react-icons/fa6";
+import { FaUserPlus, FaTrash, FaUserMinus, FaPaperPlane, FaRotateRight } from "react-icons/fa6";
 import {
   useCofounderManagement,
   useSendCofounderInvite,
   useRevokeCofounderInvite,
+  useResendCofounderInvite,
   useUnlinkCofounder,
+  type CofounderInvite,
 } from "./hooks";
 import { formatAllowedDomainsForCopy } from "@/features/school/auth/email-domain";
 
@@ -25,6 +27,13 @@ const ROLE_OPTIONS = [
   { value: "non-technical", label: "Non-technical founder" },
 ];
 
+function effectiveStatus(invite: CofounderInvite): CofounderInvite["status"] {
+  if (invite.status === "pending" && new Date(invite.expires_at) < new Date()) {
+    return "expired";
+  }
+  return invite.status;
+}
+
 export default function CoFounderPanel({
   allowedDomains = [],
 }: {
@@ -36,13 +45,15 @@ export default function CoFounderPanel({
   const [startupWebsite, setStartupWebsite] = useState("");
   const [role, setRole] = useState("");
   const [note, setNote] = useState("");
+  const formRef = useRef<HTMLFormElement>(null);
   const { data, isLoading } = useCofounderManagement();
   const sendInvite = useSendCofounderInvite();
   const revokeInvite = useRevokeCofounderInvite();
+  const resendInvite = useResendCofounderInvite();
   const unlink = useUnlinkCofounder();
 
-  const pendingInvites = (data?.invites ?? []).filter((i) => i.status === "pending");
-  const pastInvites = (data?.invites ?? []).filter((i) => i.status !== "pending");
+  const pendingInvites = (data?.invites ?? []).filter((i) => effectiveStatus(i) === "pending");
+  const pastInvites = (data?.invites ?? []).filter((i) => effectiveStatus(i) !== "pending");
   const links = data?.links ?? [];
 
   const emailPlaceholder = `cofounder@${allowedDomains[0] ?? "utexas.edu"}`;
@@ -79,6 +90,39 @@ export default function CoFounderPanel({
       toast.success("Invite revoked");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to revoke");
+    }
+  }
+
+  async function handleResend(token: string) {
+    try {
+      await resendInvite.mutateAsync(token);
+      toast.success("Invite re-sent");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to resend invite");
+    }
+  }
+
+  async function handleReinvite(invite: CofounderInvite) {
+    if (!invite.startup_name) {
+      setEmail(invite.invitee_email);
+      setStartupWebsite(invite.startup_website ?? "");
+      setRole(invite.invitee_role ?? "");
+      setNote(invite.note ?? "");
+      formRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      toast("Add the startup name to re-send this invite", { icon: "✏️" });
+      return;
+    }
+    try {
+      await sendInvite.mutateAsync({
+        inviteeEmail: invite.invitee_email,
+        startupName: invite.startup_name,
+        startupWebsite: invite.startup_website ?? undefined,
+        inviteeRole: invite.invitee_role ?? undefined,
+        note: invite.note ?? undefined,
+      });
+      toast.success(`Invite re-sent to ${invite.invitee_email}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to re-invite");
     }
   }
 
@@ -154,7 +198,7 @@ export default function CoFounderPanel({
           Enter their school email address — they&apos;ll receive a link to accept.
           {allowedDomainsCopy && ` Must be a ${allowedDomainsCopy} email.`}
         </p>
-        <form onSubmit={handleSend} className="space-y-2">
+        <form ref={formRef} onSubmit={handleSend} className="space-y-2">
           <input
             type="email"
             value={email}
@@ -223,15 +267,26 @@ export default function CoFounderPanel({
                   Expires {new Date(invite.expires_at).toLocaleDateString()}
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() => handleRevoke(invite.token)}
-                disabled={revokeInvite.isPending}
-                className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-red-500/30 hover:text-red-500 disabled:opacity-50"
-              >
-                <FaTrash className="h-3 w-3" />
-                Revoke
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleResend(invite.token)}
+                  disabled={resendInvite.isPending}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)] disabled:opacity-50"
+                >
+                  <FaPaperPlane className="h-3 w-3" />
+                  Resend
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(invite.token)}
+                  disabled={revokeInvite.isPending}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-red-500/30 hover:text-red-500 disabled:opacity-50"
+                >
+                  <FaTrash className="h-3 w-3" />
+                  Revoke
+                </button>
+              </div>
             </div>
           ))}
         </div>
@@ -241,17 +296,34 @@ export default function CoFounderPanel({
       {pastInvites.length > 0 && (
         <div className="space-y-2">
           <label className={labelClass}>Past invites</label>
-          {pastInvites.map((invite) => (
-            <div
-              key={invite.id}
-              className="flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] px-4 py-3 opacity-60"
-            >
-              <p className="truncate text-sm text-[var(--ui-text)]">{invite.invitee_email}</p>
-              <span className="text-xs text-[var(--ui-text-subtle)]">
-                {STATUS_LABELS[invite.status] ?? invite.status}
-              </span>
-            </div>
-          ))}
+          {pastInvites.map((invite) => {
+            const status = effectiveStatus(invite);
+            const canReinvite = status === "revoked" || status === "declined" || status === "expired";
+            return (
+              <div
+                key={invite.id}
+                className="flex items-center justify-between gap-3 rounded-xl border border-[var(--ui-border)] px-4 py-3 opacity-60"
+              >
+                <p className="truncate text-sm text-[var(--ui-text)]">{invite.invitee_email}</p>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-[var(--ui-text-subtle)]">
+                    {STATUS_LABELS[status] ?? status}
+                  </span>
+                  {canReinvite && (
+                    <button
+                      type="button"
+                      onClick={() => handleReinvite(invite)}
+                      disabled={sendInvite.isPending}
+                      className="flex items-center gap-1.5 rounded-lg border border-[var(--ui-border)] px-3 py-1.5 text-xs text-[var(--ui-text-muted)] transition hover:border-[var(--ui-border-strong)] hover:text-[var(--ui-text)] disabled:opacity-50"
+                    >
+                      <FaRotateRight className="h-3 w-3" />
+                      Re-invite
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/src/features/cofounder/hooks.ts
+++ b/src/features/cofounder/hooks.ts
@@ -9,6 +9,8 @@ export type CofounderInvite = {
   invitee_email: string;
   invitee_role: string | null;
   note: string | null;
+  startup_name: string | null;
+  startup_website: string | null;
   status: "pending" | "accepted" | "declined" | "revoked" | "expired";
   created_at: string;
   expires_at: string;
@@ -35,17 +37,27 @@ export function useSendCofounderInvite() {
   return useMutation({
     mutationFn: async ({
       inviteeEmail,
+      startupName,
+      startupWebsite,
       inviteeRole,
       note,
     }: {
       inviteeEmail: string;
+      startupName: string;
+      startupWebsite?: string;
       inviteeRole?: string;
       note?: string;
     }) => {
       const res = await fetch("/api/cofounder-invite", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ inviteeEmail, inviteeRole, note }),
+        body: JSON.stringify({
+          inviteeEmail,
+          startupName,
+          startupWebsite,
+          inviteeRole,
+          note,
+        }),
       });
       if (!res.ok) {
         const data = await res.json();

--- a/src/features/cofounder/hooks.ts
+++ b/src/features/cofounder/hooks.ts
@@ -86,6 +86,22 @@ export function useRevokeCofounderInvite() {
   });
 }
 
+export function useResendCofounderInvite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const res = await fetch(`/api/cofounder-invite/${token}/resend`, { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Failed to resend invite");
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cofounder-management"] });
+    },
+  });
+}
+
 export function useUnlinkCofounder() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -16,6 +16,7 @@ export function useGetProfiles(filters?: DashboardFilters, orgSlug?: string) {
   const {
     data: profiles,
     isLoading,
+    isFetching,
     error,
   } = useQuery({
     queryKey: ["profiles", filters, orgSlug],
@@ -60,7 +61,38 @@ export function useGetProfiles(filters?: DashboardFilters, orgSlug?: string) {
     retry: 1,
   });
 
-  return { data: profiles, isLoading, error };
+  return { data: profiles, isLoading, isFetching, error };
+}
+
+// Resets the viewer's matching_queue cycle counters to 0, so candidates
+// they've already cycled through this round reappear from the top.
+export function useResetMatchingRound() {
+  const { session } = useSession();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const token = await session?.getToken();
+      if (!token) throw new Error("No authentication token");
+
+      const response = await fetch("/api/profiles/reset-round", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to reset matching round");
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
 }
 
 export function useUserProfile() {

--- a/src/features/school/components/dashboard/FilterSidebar.tsx
+++ b/src/features/school/components/dashboard/FilterSidebar.tsx
@@ -14,6 +14,7 @@ import {
   EMPTY_DASHBOARD_FILTERS,
   hasActiveFilters,
 } from "@/features/school/data/dashboardFilters";
+import Skeleton from "@/components/ui/Skeleton";
 
 type SelectOption = { value: string; label: string };
 
@@ -124,6 +125,8 @@ type FilterSidebarProps = {
   variant?: "sidebar" | "drawer";
   /** Desktop sidebar height — should match the profile card */
   panelHeightClass?: string;
+  /** Show a skeleton in place of the real filter controls while profile data is loading */
+  isLoading?: boolean;
 };
 
 const INTENT_OPTIONS = [
@@ -285,6 +288,53 @@ function FilterPanel({
   );
 }
 
+function FilterPanelSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
+        <Skeleton className="h-5 w-16" />
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+        {/* School department */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+
+        {/* Industry / interest */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-32" />
+          <div className="flex flex-wrap gap-1">
+            <Skeleton className="h-5 w-12" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-5 w-14" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-5 w-12" />
+          </div>
+        </div>
+
+        {/* Graduation year */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+
+        {/* Intent */}
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-4 w-16" />
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-9 w-full rounded-xl" />
+            <Skeleton className="h-9 w-full rounded-xl" />
+            <Skeleton className="h-9 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function FilterSidebar({
   filters,
   onChange,
@@ -292,6 +342,7 @@ export default function FilterSidebar({
   onClose,
   variant = "sidebar",
   panelHeightClass = "",
+  isLoading = false,
 }: FilterSidebarProps) {
   useEffect(() => {
     if (variant !== "drawer" || !isOpen) return;
@@ -307,7 +358,11 @@ export default function FilterSidebar({
       <aside
         className={`hidden w-64 shrink-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)] p-4 lg:flex ${panelHeightClass}`}
       >
-        <FilterPanel filters={filters} onChange={onChange} scrollable={true} />
+        {isLoading ? (
+          <FilterPanelSkeleton />
+        ) : (
+          <FilterPanel filters={filters} onChange={onChange} scrollable={true} />
+        )}
       </aside>
     );
   }
@@ -332,13 +387,17 @@ export default function FilterSidebar({
             transition={{ type: "spring", damping: 28, stiffness: 320 }}
             className="fixed left-0 top-0 z-50 flex h-full w-[85vw] max-w-sm flex-col overflow-x-hidden border-r border-[var(--ui-border)] bg-[var(--ui-popover-bg,var(--org-bg,#ffffff))] p-4 shadow-xl"
           >
-            <FilterPanel
-              filters={filters}
-              onChange={onChange}
-              onClose={onClose}
-              showClose
-              scrollable
-            />
+            {isLoading ? (
+              <FilterPanelSkeleton />
+            ) : (
+              <FilterPanel
+                filters={filters}
+                onChange={onChange}
+                onClose={onClose}
+                showClose
+                scrollable
+              />
+            )}
           </motion.aside>
         </>
       )}

--- a/src/features/school/components/dashboard/ProfileCardSkeletons.tsx
+++ b/src/features/school/components/dashboard/ProfileCardSkeletons.tsx
@@ -1,0 +1,77 @@
+import Skeleton from "@/components/ui/Skeleton";
+
+export function SwipeCardSkeleton() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]">
+      <div className="flex-1 overflow-y-auto p-5">
+        {/* Avatar + Name row */}
+        <div className="mb-4 flex items-start gap-3">
+          <Skeleton className="h-16 w-16 flex-shrink-0 rounded-full" />
+          <div className="flex flex-1 min-w-0 flex-col gap-1">
+            <Skeleton className="h-7 w-40" />
+            <Skeleton className="h-5 w-24" />
+          </div>
+          <div className="flex flex-shrink-0 flex-col items-end gap-1.5">
+            <Skeleton className="h-6 w-16" />
+            <Skeleton className="h-6 w-16" />
+          </div>
+        </div>
+
+        {/* About box */}
+        <div className="mb-4 flex flex-col gap-2 rounded-lg border border-[var(--ui-border)] p-3">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-2/3" />
+        </div>
+
+        {/* Tag row */}
+        <div className="mb-1 flex flex-wrap gap-1.5">
+          <Skeleton className="h-6 w-16" />
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-14" />
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-border)] px-5 py-4">
+        <Skeleton className="h-11 w-11 flex-shrink-0 rounded-full" />
+        <Skeleton className="h-11 w-28 flex-shrink-0 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+export function SearchResultCardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]">
+      <div className="p-4">
+        {/* Avatar + name row */}
+        <div className="mb-3 flex items-center gap-3">
+          <Skeleton className="h-12 w-12 flex-shrink-0 rounded-full" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+
+        {/* Bio snippet */}
+        <div className="mb-3 flex flex-col gap-1">
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-6 w-3/4" />
+        </div>
+
+        {/* Sector tags */}
+        <div className="flex flex-wrap gap-1.5">
+          <Skeleton className="h-5 w-14" />
+          <Skeleton className="h-5 w-16" />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-3 border-t border-[var(--ui-border)] px-4 py-3">
+        <Skeleton className="h-10 w-24 flex-shrink-0 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/school/services/matchConnections.ts
+++ b/src/features/school/services/matchConnections.ts
@@ -9,6 +9,7 @@ export type MatchPerson = {
   title: string | null;
   is_technical: boolean | null;
   startup_name: string | null;
+  startup_website: string | null;
   email?: string | null;
 };
 
@@ -40,7 +41,9 @@ export async function getMatchConnections(
   // 1. Fetch all active org profiles
   const { data: profiles, error: profilesError } = await supabase
     .from("profiles")
-    .select("user_id, first_name, last_name, title, is_technical, startup_name")
+    .select(
+      "user_id, first_name, last_name, title, is_technical, startup_name, startup_website",
+    )
     .eq("organization_id", orgId)
     .is("deleted_at", null);
 
@@ -86,6 +89,7 @@ export async function getMatchConnections(
       title: p.title,
       is_technical: p.is_technical,
       startup_name: p.startup_name,
+      startup_website: p.startup_website,
     };
   };
 
@@ -189,6 +193,7 @@ export async function getMatchConnections(
         title: null,
         is_technical: null,
         startup_name: null,
+        startup_website: null,
         email: invite.invitee_email as string,
       };
     }

--- a/supabase/migrations/20260716000000_add_startup_fields_to_cofounder_invites.sql
+++ b/supabase/migrations/20260716000000_add_startup_fields_to_cofounder_invites.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_name TEXT NULL;
+ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;


### PR DESCRIPTION
## Summary
This PR merges `staging` into `main`, bundling five feature/fix commits: co-founder invites now carry a proposed startup name and website that get applied to both profiles on acceptance, invite management gains resend/re-invite flows and fixes for revoke/expiry, a race condition where newly-invited users hit "No organization context" is fixed, the matching queue gains a manual "Start over" reset once a viewer exhausts a round, and the school dashboard adds skeleton loaders in place of bare "Loading…" text. A new migration adds `startup_name`/`startup_website` to `cofounder_invites` and `startup_website` to `profiles`.

## Changes

### Co-founder invites — startup identity
- `src/app/api/cofounder-invite/route.ts`: `POST` now requires and stores `startupName`/`startupWebsite` on the invite (`startupName` is a hard 400 if missing); `GET` selects the new columns so the panel can render them.
- `src/app/api/cofounder-invite/[token]/accept/route.ts`: on acceptance, overwrites `startup_name`/`startup_website` on **both** the inviter's and invitee's `profiles` rows with the agreed-on values from the invite, keeping identity in sync post-link.
- `src/app/(school)/school/[slug]/invite/[token]/page.tsx` and `AcceptInviteClient.tsx`: invite page now fetches and displays the proposed startup name/website (read-only) and updates the acceptance copy to mention the startup name will be set on both profiles.
- `src/features/cofounder/CoFounderPanel.tsx` / `hooks.ts`: invite form adds required "Startup or project name" and optional website inputs; `useSendCofounderInvite` and `CofounderInvite` type carry the new fields through.
- `src/features/school/services/matchConnections.ts` and `src/app/(school)/school/[slug]/admin/page.tsx`: `MatchPerson` now carries `startup_website`; the admin matches table's "Startup" column is renamed "Team" and renders the team name as a clickable link to the startup website when present (falls back to plain text or `—`).

### Co-founder invites — resend, revoke, and expiry handling
- `src/app/api/cofounder-invite/[token]/resend/route.ts` (new): lets the original inviter resend a still-pending invite, enforcing a 60s cooldown via `notified_at` and pushing `expires_at` out another 14 days on success. Reuses `sendCofounderInviteEmail`.
- `src/features/cofounder/CoFounderPanel.tsx`: adds an `effectiveStatus()` helper that treats a `pending` invite whose `expires_at` has passed as `expired` client-side (server status isn't flipped until the next send attempt), so stale invites correctly move to "Past invites" with an "Expired" label. Adds a "Resend" button on pending invites and a "Re-invite" button on revoked/declined/expired ones — re-invite pre-fills the form and reuses `sendInvite` if the original invite had a startup name, otherwise prompts the user to fill it in.
- `src/app/api/cofounder-invite/route.ts`: when a new invite is requested for an email with an existing *pending* invite whose `expires_at` has already lapsed, the stale row is flipped to `expired` before creating the new one, instead of unconditionally blocking with a 409.
- `src/app/api/cofounder-invite/[token]/revoke/route.ts`: revoke's `update()` now checks `error`/`select().single()` and returns a 500 on failure instead of silently swallowing DB errors.

### Organization context race fix
- `src/app/(school)/school/[slug]/accept-policies/_actions.ts`: `recordPolicyConsents` falls back to `getOrganizationBySlug(slug)` when `sessionClaims?.metadata?.organization_id` is absent, fixing a race where a just-accepted invitee hits the policy-consent action before Clerk's org metadata has propagated onto their JWT. The slug is treated as an equally authoritative source of org context.

### Matching round reset
- `src/app/api/profiles/reset-round/route.ts` (new): authenticated `POST` that zeroes the caller's `matching_queue.cycle` counters, letting previously-skipped candidates reappear.
- `src/app/api/profiles/route.ts`: `GET` now detects when every eligible candidate has `cycle >= 1` (i.e., the viewer has already cycled through the full deck) and short-circuits with `{ profiles: [], roundComplete: true }` instead of looping the same candidates in score order indefinitely.
- `src/features/profile/useProfile.ts`: adds `useResetMatchingRound()` mutation hook (invalidates the `profiles` query on success) and exposes `isFetching` from `useGetProfiles` so the UI can distinguish "no more profiles" from "still refetching."
- `src/app/(school)/school/[slug]/dashboard/page.tsx`: adds a "Start over" button on the exhausted-deck empty state that calls the reset mutation; disabled and shows "Checking…" while pending or refetching.

### Dashboard loading states
- `src/components/ui/Skeleton.tsx` (new): shared `animate-pulse` skeleton primitive.
- `src/features/school/components/dashboard/ProfileCardSkeletons.tsx` (new): `SwipeCardSkeleton` and `SearchResultCardSkeleton`, matching the layout of the real swipe card and search result card.
- `src/features/school/components/dashboard/FilterSidebar.tsx`: adds `FilterPanelSkeleton` and an `isLoading` prop, rendered in place of the real filter controls (both sidebar and drawer variants) while profiles are loading.
- `src/app/(school)/school/[slug]/dashboard/page.tsx`: swaps the "Loading profiles…" / "Searching…" text states for `SwipeCardSkeleton` and repeated `SearchResultCardSkeleton`s, and passes `isLoading={isLoadingProfiles}` down to `FilterSidebar`.

## Migration / Config
- New migration `supabase/migrations/20260716000000_add_startup_fields_to_cofounder_invites.sql`:
  - `ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_name TEXT NULL;`
  - `ALTER TABLE cofounder_invites ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;`
  - `ALTER TABLE profiles ADD COLUMN IF NOT EXISTS startup_website TEXT NULL;`
  - Must be applied before deploying, since `/api/cofounder-invite` (POST/GET), the accept route, and `matchConnections.ts` all read/write these columns.

## Notes
- The invite POST route now hard-requires `startupName`; any existing client/integration calling this endpoint without it will get a 400.
- `effectiveStatus()` in `CoFounderPanel.tsx` is a client-side-only expiry check — the underlying `cofounder_invites.status` row stays `pending` until the next send attempt (resend or re-invite) touches it, so any other consumer of invite status (emails, admin views) won't see "expired" until then.
