### PR TITLE
UT-45 | Admin List Access Fix

### DIFF
--- a/src/app/(school)/school/[slug]/sso-complete/page.tsx
+++ b/src/app/(school)/school/[slug]/sso-complete/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
-import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
+import { isSchoolSignInEligible } from "@/features/school/auth/org-admin";
 import SessionRefreshRedirect from "@/features/school/components/auth/SessionRefreshRedirect";
 import AutoRetry from "@/features/school/components/auth/AutoRetry";
 import SignOutRedirect from "@/features/school/components/auth/SignOutOnMount";
@@ -64,7 +64,7 @@ export default async function SSOCompletePage({
     return <SignOutRedirect redirectUrl={signInUrl} />;
   }
 
-  if (!isEmailDomainAllowed(primaryEmail, org!.allowed_email_domains)) {
+  if (!isSchoolSignInEligible(primaryEmail, org!.allowed_email_domains)) {
     await revokeSession();
     const params = new URLSearchParams({
       mismatch: "1",

--- a/src/features/school/auth/org-admin.ts
+++ b/src/features/school/auth/org-admin.ts
@@ -1,6 +1,7 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
+import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
 
 function supabaseAdmin() {
   return createClient(
@@ -34,6 +35,21 @@ export function getEnvAdminEmails(): string[] {
     process.env.ADMIN_EMAILS?.split(",")
       .map((e) => e.trim().toLowerCase())
       .filter(Boolean) ?? []
+  );
+}
+
+/**
+ * Sign-in eligibility for a school portal: allowed when the email's domain is on
+ * the org allowlist OR the email is a configured global admin. Global admins
+ * override the domain block so support/staff can access any school portal.
+ */
+export function isSchoolSignInEligible(
+  email: string,
+  allowedDomains: string[],
+): boolean {
+  return (
+    getEnvAdminEmails().includes(email.trim().toLowerCase()) ||
+    isEmailDomainAllowed(email, allowedDomains)
   );
 }
 

--- a/src/features/school/auth/school-auth.ts
+++ b/src/features/school/auth/school-auth.ts
@@ -3,14 +3,25 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { createClient } from "@supabase/supabase-js";
 import { getOrganizationBySlug } from "@/features/school/data/organizations";
-import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
-import { getEnvAdminEmails } from "@/features/school/auth/org-admin";
+import {
+  getEnvAdminEmails,
+  isSchoolSignInEligible,
+} from "@/features/school/auth/org-admin";
 
 export type ExistingUserInfo = {
   exists: boolean;
   hasPassword: boolean;
   oauthProviders: string[];
 };
+
+/**
+ * Whether an email is on the global platform-admin allowlist (ADMIN_EMAILS).
+ * Lets the client sign-in forms honor the admin override to the domain block
+ * without exposing the allowlist itself.
+ */
+export async function isGlobalAdminEmail(email: string): Promise<boolean> {
+  return getEnvAdminEmails().includes(email.trim().toLowerCase());
+}
 
 export async function checkExistingUser(
   email: string,
@@ -59,8 +70,7 @@ export async function assignSchoolOrg(
   const email = primary?.emailAddress;
   if (!email) return { error: "No email on account." };
 
-  const isGlobalAdmin = getEnvAdminEmails().includes(email.toLowerCase());
-  if (!isGlobalAdmin && !isEmailDomainAllowed(email, org.allowed_email_domains)) {
+  if (!isSchoolSignInEligible(email, org.allowed_email_domains)) {
     return {
       error: `This account's email is not eligible for ${org.name}.`,
     };

--- a/src/features/school/components/auth/SchoolResetPassword.tsx
+++ b/src/features/school/components/auth/SchoolResetPassword.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/features/school/auth/email-domain";
 import {
   checkExistingUser,
+  isGlobalAdminEmail,
   type ExistingUserInfo,
 } from "@/features/school/auth/school-auth";
 import { completeSchoolSignIn } from "./complete-school-signin";
@@ -104,7 +105,10 @@ export default function SchoolResetPassword({
     if (!isLoaded) return;
     setError(null);
 
-    if (!isEmailDomainAllowed(email, allowedDomains)) {
+    if (
+      !isEmailDomainAllowed(email, allowedDomains) &&
+      !(await isGlobalAdminEmail(email))
+    ) {
       setError(
         `This portal is for ${schoolName}. Sign in at mamuncofoundr.com instead, or use a ${allowedCopy} email.`,
       );

--- a/src/features/school/components/auth/SchoolSignIn.tsx
+++ b/src/features/school/components/auth/SchoolSignIn.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/features/school/auth/email-domain";
 import {
   checkExistingUser,
+  isGlobalAdminEmail,
   type ExistingUserInfo,
 } from "@/features/school/auth/school-auth";
 import { completeSchoolSignIn } from "./complete-school-signin";
@@ -89,7 +90,10 @@ export default function SchoolSignIn({
     if (!isLoaded) return;
     setError(null);
 
-    if (!isEmailDomainAllowed(email, allowedDomains)) {
+    if (
+      !isEmailDomainAllowed(email, allowedDomains) &&
+      !(await isGlobalAdminEmail(email))
+    ) {
       setError(
         `This portal is for ${schoolName}. Sign in at mamuncofoundr.com instead, or use a ${allowedCopy} email.`,
       );

--- a/src/features/school/components/auth/SchoolSignUp.tsx
+++ b/src/features/school/components/auth/SchoolSignUp.tsx
@@ -11,6 +11,7 @@ import {
 import {
   assignSchoolOrg,
   checkExistingUser,
+  isGlobalAdminEmail,
   type ExistingUserInfo,
 } from "@/features/school/auth/school-auth";
 import GoogleOAuthButton from "./GoogleOAuthButton";
@@ -71,7 +72,10 @@ export default function SchoolSignUp({
     if (!isLoaded) return;
     setError(null);
 
-    if (!isEmailDomainAllowed(email, allowedDomains)) {
+    if (
+      !isEmailDomainAllowed(email, allowedDomains) &&
+      !(await isGlobalAdminEmail(email))
+    ) {
       setError(
         `Sign-up at ${schoolName} requires a ${allowedCopy} email address.`,
       );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ import {
   getRequiredTermsVersion,
   isConsentSatisfied,
 } from "@/features/legal/consent";
-import { isEmailDomainAllowed } from "@/features/school/auth/email-domain";
+import { isSchoolSignInEligible } from "@/features/school/auth/org-admin";
 import { getOrgConfig } from "@/features/school/registry/registry";
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding(.*)"]);
@@ -267,7 +267,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
       // Fast path: already assigned to this org via Clerk metadata → skip Clerk API call.
       if (claimOrgId !== org.id) {
         const email = await getVerifiedPrimaryEmail(userId);
-        if (!email || !isEmailDomainAllowed(email, org.allowed_email_domains)) {
+        if (!email || !isSchoolSignInEligible(email, org.allowed_email_domains)) {
           const notAuthorizedUrl = new URL(`/school/${pathSlug}/not-authorized`, req.url);
           if (pathname !== notAuthorizedUrl.pathname) {
             return NextResponse.redirect(notAuthorizedUrl);


### PR DESCRIPTION
## Summary
The global platform-admin allowlist (`ADMIN_EMAILS`) was supposed to let listed emails sign into any school portal even when their email domain isn't in the org's `allowed_email_domains`, but the override never worked. It was only wired into `assignSchoolOrg` and the admin-route access checks, while every gate that actually decides sign-in eligibility checked the raw domain and never consulted the admin list — so an off-domain admin was stopped before control ever reached the one function that honored the override, making that override effectively dead code. This PR introduces a single shared eligibility helper and routes all sign-in gates (middleware, Google OAuth completion, and the three client auth forms) through it, so admins can sign in while the normal domain gate stays intact for everyone else.

## Changes

### Auth core
- Add `isSchoolSignInEligible(email, allowedDomains)` in `src/features/school/auth/org-admin.ts` as the single source of truth for portal sign-in: eligible when the email is a configured global admin (`getEnvAdminEmails`) **or** its domain is on the org allowlist (`isEmailDomainAllowed`). This mirrors the override logic that previously lived inline in `assignSchoolOrg`.
- Refactor `assignSchoolOrg` in `src/features/school/auth/school-auth.ts` to call the shared helper instead of its own `isGlobalAdmin || isEmailDomainAllowed` check, so all server gates share one definition.
- Add `isGlobalAdminEmail(email)` server action in `school-auth.ts`. Because the `"use client"` forms can't read the `ADMIN_EMAILS` env var, this exposes only a boolean admin check to the client without leaking the allowlist itself.

### Server gates
- `src/middleware.ts`: the school membership/email-domain gate now calls `isSchoolSignInEligible` instead of `isEmailDomainAllowed`. This is what stops an admin from being redirected to `/school/<slug>/not-authorized`. `getEnvAdminEmails` is a pure `process.env` read, so it stays edge-safe.
- `src/app/(school)/school/[slug]/sso-complete/page.tsx`: the Google OAuth completion gate uses the same helper, so an admin's session is no longer revoked and bounced with `mismatch=1` — it now assigns the org and redirects into the portal.

### Client auth forms
- `SchoolSignIn.tsx`, `SchoolSignUp.tsx`, and `SchoolResetPassword.tsx`: each submit handler's domain block now short-circuits through `await isGlobalAdminEmail(email)` before erroring, so an admin isn't blocked before `signIn.create` / `signUp.create`. The success paths already route through `assignSchoolOrg` / `completeSchoolSignIn`, which honor the override, so no further client changes were needed.
- The extra server round-trip only fires on the off-domain submit path; a normal domain user hits the fast local check and a blocked non-admin still gets the immediate, specific error banner ("use a @utexas.edu email") as before. The debounced `checkExistingUser` effects stay domain-gated since they only drive UX hints, not the block.

## Migration / Config
- No new env vars or migrations. Relies on the existing `ADMIN_EMAILS` (comma-separated) env var. Ensure the deploy environment actually has it set and redeploy/restart so the value is loaded.

## Testing
- `npx tsc --noEmit` passes (exit 0) and `next lint` reports no warnings or errors on all seven changed files.
- End-to-end sign-in flows were not driven (they require a live Clerk session and a real admin account). Manual verification steps: with an `ADMIN_EMAILS` entry, confirm the admin completes both password and Google sign-in at `/school/ut` and lands on the dashboard/onboarding rather than `/not-authorized`; confirm a non-admin off-domain email is still blocked at every gate; confirm a normal `@utexas.edu` user signs in unchanged.

## Notes
- Scope is limited to the env-var global-admin override (`getEnvAdminEmails`). The per-org DB `settings.admin_emails` list remains a separate concept used only for admin-route access, not sign-in eligibility; extending sign-in to off-domain DB admins is a possible follow-up.
