### PR TITLE
Ut director requests

### DIFF
--- a/src/app/(school)/school/[slug]/dashboard/page.tsx
+++ b/src/app/(school)/school/[slug]/dashboard/page.tsx
@@ -2,9 +2,20 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
-import { FaPaperPlane, FaLinkedin, FaGithub, FaTwitter, FaGlobe, FaCalendar } from "react-icons/fa6";
+import {
+  FaPaperPlane,
+  FaLinkedin,
+  FaGithub,
+  FaTwitter,
+  FaGlobe,
+  FaCalendar,
+} from "react-icons/fa6";
 import { MdSkipNext } from "react-icons/md";
-import { IoSearchOutline, IoCloseOutline, IoFilterOutline } from "react-icons/io5";
+import {
+  IoSearchOutline,
+  IoCloseOutline,
+  IoFilterOutline,
+} from "react-icons/io5";
 import { motion, AnimatePresence } from "motion/react";
 import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
@@ -12,15 +23,32 @@ import toast from "react-hot-toast";
 import HiringBadge from "@/components/HiringBadge";
 import CoFounderLinks from "@/features/cofounder/CoFounderLinks";
 import ProfileViewModal from "@/features/profile/ProfileViewModal";
-import { useGetProfiles, useSearchProfiles, useResetMatchingRound } from "@/features/profile/useProfile";
+import {
+  useGetProfiles,
+  useSearchProfiles,
+  useResetMatchingRound,
+} from "@/features/profile/useProfile";
 import { useSchool } from "@/features/school/components/SchoolContext";
-import { useToggleLike, useLikeStatus, useMutualLikes } from "@/features/likes/useLikes";
+import {
+  useToggleLike,
+  useLikeStatus,
+  useMutualLikes,
+} from "@/features/likes/useLikes";
 import { useSkipProfile } from "@/features/user-actions/useUserActions";
 import { trackEvent } from "@/lib/posthog-events";
 import { useProfileViewTracking } from "@/features/profile/useProfileViewTracking";
-import { getSchoolFullName, getDegreeAbbreviation, SECTOR_INTEREST_LABELS } from "@/features/school/data/utSchoolsAndMajors";
-import FilterSidebar, { getFilterChipLabels } from "@/features/school/components/dashboard/FilterSidebar";
-import { SwipeCardSkeleton, SearchResultCardSkeleton } from "@/features/school/components/dashboard/ProfileCardSkeletons";
+import {
+  getSchoolFullName,
+  getDegreeAbbreviation,
+  SECTOR_INTEREST_LABELS,
+} from "@/features/school/data/utSchoolsAndMajors";
+import FilterSidebar, {
+  getFilterChipLabels,
+} from "@/features/school/components/dashboard/FilterSidebar";
+import {
+  SwipeCardSkeleton,
+  SearchResultCardSkeleton,
+} from "@/features/school/components/dashboard/ProfileCardSkeletons";
 import ReportProfileButton from "@/features/report/ReportProfileButton";
 import {
   type DashboardFilters,
@@ -76,7 +104,7 @@ function SearchResultCard({
       <button
         type="button"
         onClick={() => onViewProfile(profile)}
-        className="w-full p-4 text-left hover:bg-[var(--ui-surface-active)] transition cursor-pointer"
+        className="w-full cursor-pointer p-4 text-left transition hover:bg-[var(--ui-surface-active)]"
       >
         {/* Avatar + name row */}
         <div className="mb-3 flex items-center gap-3">
@@ -112,7 +140,22 @@ function SearchResultCard({
               )}
               {profile.isTechnical && (
                 <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2 py-0.5 text-[10px] font-medium text-[#a34800]">
-                  {profile.isTechnical === "yes" ? "Technical" : "Non-technical"}
+                  {profile.isTechnical === "yes"
+                    ? "Technical"
+                    : "Non-technical"}
+                </span>
+              )}
+              {(profile.intent === "join_me" ||
+                profile.intent === "seeking_to_join") && (
+                <span className="inline-flex items-center rounded-md bg-[#bf5700] px-2 py-0.5 text-[10px] font-semibold text-white">
+                  {profile.intent === "join_me"
+                    ? "Seeking a cofounder"
+                    : "Seeking a startup to join"}
+                </span>
+              )}
+              {profile.intent === "no_preference" && (
+                <span className="inline-flex items-center rounded-md bg-[#bf5700] px-2 py-0.5 text-[10px] font-semibold text-white">
+                  Open to either: Seeking a cofounder or joining a startup
                 </span>
               )}
             </div>
@@ -133,29 +176,36 @@ function SearchResultCard({
 
         {profile.user_id && (
           <div className="mb-3" onClick={(e) => e.stopPropagation()}>
-            <CoFounderLinks userId={profile.user_id} onClickCofounder={onViewProfileById} />
+            <CoFounderLinks
+              userId={profile.user_id}
+              onClickCofounder={onViewProfileById}
+            />
           </div>
         )}
 
         {/* Sector tags (max 3) */}
         {profile.utSectorInterests && profile.utSectorInterests.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {profile.utSectorInterests.slice(0, 3).map((interest: string, i: number) => (
-              <span
-                key={interest}
-                className="rounded-md px-2 py-0.5 text-xs font-medium"
-                style={
-                  i === 0
-                    ? { backgroundColor: "#bf5700", color: "#fff" }
-                    : {
-                        backgroundColor: "var(--ui-surface-active)",
-                        color: "var(--ui-text-muted)",
-                      }
-                }
-              >
-                {SECTOR_INTEREST_LABELS[interest as keyof typeof SECTOR_INTEREST_LABELS] || interest}
-              </span>
-            ))}
+            {profile.utSectorInterests
+              .slice(0, 3)
+              .map((interest: string, i: number) => (
+                <span
+                  key={interest}
+                  className="rounded-md px-2 py-0.5 text-xs font-medium"
+                  style={
+                    i === 0
+                      ? { backgroundColor: "#bf5700", color: "#fff" }
+                      : {
+                          backgroundColor: "var(--ui-surface-active)",
+                          color: "var(--ui-text-muted)",
+                        }
+                  }
+                >
+                  {SECTOR_INTEREST_LABELS[
+                    interest as keyof typeof SECTOR_INTEREST_LABELS
+                  ] || interest}
+                </span>
+              ))}
           </div>
         )}
       </button>
@@ -165,7 +215,7 @@ function SearchResultCard({
         <button
           onClick={handleLike}
           disabled={isLikeLoading}
-          className={`flex h-10 px-3 flex-shrink-0 items-center justify-center gap-2 rounded-full transition cursor-pointer text-sm font-medium ${
+          className={`flex h-10 flex-shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full px-3 text-sm font-medium transition ${
             likeStatus?.isLiked
               ? "bg-pink-500 text-white"
               : "bg-[#BF5700] text-white hover:bg-[#a34800]"
@@ -190,10 +240,14 @@ export default function SchoolDashboardPage() {
       return !prev;
     });
   };
-  const [filters, setFilters] = useState<DashboardFilters>(EMPTY_DASHBOARD_FILTERS);
+  const [filters, setFilters] = useState<DashboardFilters>(
+    EMPTY_DASHBOARD_FILTERS,
+  );
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [viewingUserId, setViewingUserId] = useState<string | null>(null);
-  const [viewingProfile, setViewingProfile] = useState<OnboardingData | null>(null);
+  const [viewingProfile, setViewingProfile] = useState<OnboardingData | null>(
+    null,
+  );
 
   const openProfile = (profile: OnboardingData) => {
     setViewingProfile(profile);
@@ -226,7 +280,13 @@ export default function SchoolDashboardPage() {
     setFilters(next);
     saveDashboardFilters(next);
   };
-  const { data: searchResults, isFetching: isSearching, inferred, emptyReason, dismissFilter } = useSearchProfiles(searchQuery, filters, slug);
+  const {
+    data: searchResults,
+    isFetching: isSearching,
+    inferred,
+    emptyReason,
+    dismissFilter,
+  } = useSearchProfiles(searchQuery, filters, slug);
 
   // Relax a single binding filter from the empty-results state. Inferred filters
   // are dismissed (Mode B re-search); user filters are cleared from the sidebar.
@@ -235,7 +295,10 @@ export default function SchoolDashboardPage() {
       s.dismissKeys.forEach((key) => dismissFilter(key));
       return;
     }
-    const next: DashboardFilters = { ...filters, sectors: [...filters.sectors] };
+    const next: DashboardFilters = {
+      ...filters,
+      sectors: [...filters.sectors],
+    };
     if (s.dimension === "sectors") next.sectors = [];
     else next[s.dimension] = null;
     updateFilters(next);
@@ -274,12 +337,14 @@ export default function SchoolDashboardPage() {
           }).catch((err) => console.error("Failed to mark as seen:", err));
         }
       },
-      { threshold: 0.5 }
+      { threshold: 0.5 },
     );
 
     const node = cardRef.current;
     if (node) observer.observe(node);
-    return () => { if (node) observer.unobserve(node); };
+    return () => {
+      if (node) observer.unobserve(node);
+    };
   }, [curProfile?.user_id, curProfile?.isNew, isSearchActive]);
 
   const handleLike = async () => {
@@ -295,7 +360,9 @@ export default function SchoolDashboardPage() {
   const handleSkip = async () => {
     if (!curProfile?.user_id) return;
     try {
-      await skipProfileMutation.mutateAsync({ skippedProfileId: curProfile.user_id });
+      await skipProfileMutation.mutateAsync({
+        skippedProfileId: curProfile.user_id,
+      });
       queryClient.invalidateQueries({ queryKey: ["profiles"] });
     } catch {
       toast.error("Failed to skip profile");
@@ -314,7 +381,7 @@ export default function SchoolDashboardPage() {
     <div className="mb-4 flex items-center justify-between">
       <div className="w-8" />
       <div className="text-center">
-        <p className="text-xs font-semibold uppercase tracking-widest">
+        <p className="text-xs font-semibold tracking-widest uppercase">
           <span className="text-[#4d7c0f]">Mamun</span>
           <span className="text-[var(--ui-text-muted)]"> &times; </span>
           <span className="text-[#a34800]">{schoolName}</span>
@@ -326,14 +393,14 @@ export default function SchoolDashboardPage() {
       <div className="flex items-center gap-1">
         <button
           onClick={() => setFilterDrawerOpen(true)}
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] hover:bg-[#ffe8d6] transition cursor-pointer lg:hidden"
+          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] transition hover:bg-[#ffe8d6] lg:hidden"
           aria-label="Open filters"
         >
           <IoFilterOutline className="h-4 w-4" />
         </button>
         <button
           onClick={toggleSearch}
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] hover:bg-[#ffe8d6] transition cursor-pointer"
+          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-[#fff6f0] text-[#BF5700] transition hover:bg-[#ffe8d6]"
           aria-expanded={searchOpen}
           aria-label={searchOpen ? "Close search" : "Open search"}
         >
@@ -349,11 +416,13 @@ export default function SchoolDashboardPage() {
 
   // ── Helpers for swipe card ──
   const isOnline = curProfile?.last_active_at
-    ? new Date().getTime() - new Date(curProfile.last_active_at).getTime() < 5 * 60 * 1000
+    ? new Date().getTime() - new Date(curProfile.last_active_at).getTime() <
+      5 * 60 * 1000
     : false;
 
   const initials = curProfile
-    ? (curProfile.firstName?.[0] ?? "").toUpperCase() + (curProfile.lastName?.[0] ?? "").toUpperCase()
+    ? (curProfile.firstName?.[0] ?? "").toUpperCase() +
+      (curProfile.lastName?.[0] ?? "").toUpperCase()
     : "";
 
   const degreeAbbrev =
@@ -369,11 +438,10 @@ export default function SchoolDashboardPage() {
     ? getSchoolFullName(curProfile.utCollege)
     : undefined;
 
-
   const activeFilterChipsRow =
     filtersActive && !isSearchActive ? (
       <div className="mb-4">
-        <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+        <p className="mb-2 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
           Active filters
         </p>
         <div className="flex flex-wrap gap-1.5">
@@ -382,7 +450,7 @@ export default function SchoolDashboardPage() {
               key={chip.key}
               type="button"
               onClick={() => updateFilters(chip.onRemove())}
-              className="inline-flex items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white cursor-pointer hover:bg-[#a34800]"
+              className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-medium text-white hover:bg-[#a34800]"
             >
               {chip.label}
               <span aria-hidden>&times;</span>
@@ -392,30 +460,40 @@ export default function SchoolDashboardPage() {
       </div>
     ) : null;
 
-  const inferredFilterChipsRow = isSearchActive && inferred && inferred.filters && Object.keys(inferred.filters).length > 0 ? (
-    <div className="mb-3">
-      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
-        ✨ Understood as
-      </p>
-      <div className="flex flex-wrap gap-1.5">
-        {getFilterChipLabels(normalizeDashboardFilters(inferred.filters)).map((chip) => (
-          <button
-            key={chip.key}
-            type="button"
-            onClick={() => dismissFilter(chip.dismissKey)}
-            className="inline-flex items-center gap-1 rounded-md bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-800 cursor-pointer hover:bg-blue-200 transition"
-          >
-            {chip.label}
-            <span aria-hidden>&times;</span>
-          </button>
-        ))}
+  const inferredFilterChipsRow =
+    isSearchActive &&
+    inferred &&
+    inferred.filters &&
+    Object.keys(inferred.filters).length > 0 ? (
+      <div className="mb-3">
+        <p className="mb-2 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+          ✨ Understood as
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {getFilterChipLabels(normalizeDashboardFilters(inferred.filters)).map(
+            (chip) => (
+              <button
+                key={chip.key}
+                type="button"
+                onClick={() => dismissFilter(chip.dismissKey)}
+                className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-800 transition hover:bg-blue-200"
+              >
+                {chip.label}
+                <span aria-hidden>&times;</span>
+              </button>
+            ),
+          )}
+        </div>
       </div>
-    </div>
-  ) : null;
+    ) : null;
 
   return (
-    <div className="mx-auto flex flex-1 min-h-0 max-w-5xl flex-col px-4 pt-6 pb-8">
-      <ProfileViewModal profile={viewingProfile} userId={viewingUserId} onClose={closeProfile} />
+    <div className="mx-auto flex min-h-0 max-w-5xl flex-1 flex-col px-4 pt-6 pb-8">
+      <ProfileViewModal
+        profile={viewingProfile}
+        userId={viewingUserId}
+        onClose={closeProfile}
+      />
       {brandingHeader}
 
       <FilterSidebar
@@ -437,11 +515,11 @@ export default function SchoolDashboardPage() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by skill, major, industry…"
-            className="flex-1 bg-transparent text-sm text-[#3d1a00] placeholder:text-[#a34800] outline-none"
+            className="flex-1 bg-transparent text-sm text-[#3d1a00] outline-none placeholder:text-[#a34800]"
           />
           <button
             onClick={toggleSearch}
-            className="flex-shrink-0 text-[#BF5700] hover:text-[#8a3d00] cursor-pointer"
+            className="flex-shrink-0 cursor-pointer text-[#BF5700] hover:text-[#8a3d00]"
           >
             <IoCloseOutline className="h-4 w-4" />
           </button>
@@ -451,7 +529,7 @@ export default function SchoolDashboardPage() {
       {activeFilterChipsRow}
       {inferredFilterChipsRow}
 
-      <div className="flex flex-1 min-h-0 items-stretch gap-6">
+      <div className="flex min-h-0 flex-1 items-stretch gap-6">
         <FilterSidebar
           variant="sidebar"
           filters={filters}
@@ -459,338 +537,434 @@ export default function SchoolDashboardPage() {
           isLoading={isLoadingProfiles}
         />
 
-        <div className="mx-auto flex w-full min-w-0 max-w-2xl flex-1 flex-col min-h-0">
-      {/* Search results */}
-      {isSearchActive ? (
-        <div>
-          {isSearching && (
-            <div className="flex flex-col gap-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <SearchResultCardSkeleton key={i} />
-              ))}
-            </div>
-          )}
-          {!isSearching && searchResults && searchResults.length === 0 && (
-            <div className="flex flex-col items-center gap-3 py-16 text-center">
-              <p className="text-base font-semibold text-[var(--ui-text)]">No exact matches</p>
-              {emptyReason && emptyReason.relaxations.length > 0 ? (
-                <>
-                  <p className="text-sm text-[var(--ui-text-muted)]">
-                    Nobody fits all of your criteria. Relax one to see more:
-                  </p>
-                  <div className="mt-1 flex w-full max-w-xs flex-col items-stretch gap-2">
-                    {emptyReason.relaxations.map((s) => (
-                      <button
-                        key={s.dimension}
-                        type="button"
-                        onClick={() => handleRelax(s)}
-                        className="flex items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#a34800] transition hover:bg-[#ffe8d6] cursor-pointer"
-                      >
-                        <span className="font-medium">Drop &ldquo;{s.label}&rdquo;</span>
-                        <span className="flex-shrink-0 rounded-full bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
-                          +{s.countIfRelaxed}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </>
-              ) : (
-                <p className="text-sm text-[var(--ui-text-muted)]">
-                  Try different keywords — skills, majors, industries, or city names work well.
-                </p>
-              )}
-              <button
-                onClick={() => setSearchQuery("")}
-                className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
-              >
-                Clear search
-              </button>
-            </div>
-          )}
-          {searchResults && searchResults.length > 0 && (
-            <div className="flex flex-col gap-3">
-              {searchResults.map((profile) => (
-                <SearchResultCard key={profile.user_id} profile={profile} onViewProfile={openProfile} onViewProfileById={openProfileById} />
-              ))}
-            </div>
-          )}
-        </div>
-      ) : (
-        /* Swipe card */
-        isLoadingProfiles ? (
-          <SwipeCardSkeleton />
-        ) : !curProfile ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
-            {filtersActive ? (
-              <>
-                <p className="text-xl font-semibold text-[var(--ui-text)]">
-                  No matches for these filters
-                </p>
-                <p className="text-sm text-[var(--ui-text-muted)]">
-                  Try adjusting your filters or clear them to see more co-founders.
-                </p>
-                <button
-                  type="button"
-                  onClick={() => updateFilters(EMPTY_DASHBOARD_FILTERS)}
-                  className="mt-1 text-sm font-medium text-[#a34800] hover:underline cursor-pointer"
-                >
-                  Clear filters
-                </button>
-              </>
-            ) : (
-              <>
-                <p className="text-xl font-semibold text-[var(--ui-text)]">
-                  No more co-founders to show right now
-                </p>
-                <p className="text-sm text-[var(--ui-text-muted)]">
-                  Check back later. More students from your program will be joining.
-                </p>
-                <button
-                  type="button"
-                  onClick={handleStartOver}
-                  disabled={resetRoundMutation.isPending || isFetchingProfiles}
-                  className="mt-1 inline-flex items-center gap-2 rounded-full bg-[#BF5700] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-60 cursor-pointer"
-                >
-                  {resetRoundMutation.isPending || isFetchingProfiles ? "Checking…" : "Start over"}
-                </button>
-              </>
-            )}
-          </div>
-        ) : (
-          <AnimatePresence mode="wait">
-            <motion.div
-              ref={cardRef}
-              key={curProfile.user_id}
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -16 }}
-              transition={{ duration: 0.25 }}
-              className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]"
-            >
-              {/* Card header with avatar, name, badges */}
-              <div className="flex-1 overflow-y-auto p-5">
-                {/* Avatar + Name row */}
-                <div className="mb-4 flex items-start gap-3">
-                  <div className="relative flex-shrink-0">
-                    {curProfile.pfp_url ? (
-                      <Image
-                        src={curProfile.pfp_url}
-                        alt={`${curProfile.firstName} ${curProfile.lastName}`}
-                        width={64}
-                        height={64}
-                        className="h-16 w-16 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-lg font-bold text-[var(--ui-text)]">
-                        {initials}
-                      </div>
-                    )}
-                    <div
-                      className={`absolute bottom-0 right-0 h-4 w-4 rounded-full border-2 border-[var(--ui-surface)] ${
-                        isOnline ? "bg-green-500" : "bg-red-500"
-                      }`}
-                    />
-                  </div>
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <h2 className="text-lg font-bold text-[var(--ui-text)]">
-                        {curProfile.firstName} {curProfile.lastName}
-                      </h2>
-                      {curProfile.isNew && (
-                        <span className="inline-flex rounded-md bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
-                          New
-                        </span>
-                      )}
-                    </div>
-                    {degreeAbbrev && yearSuffix && (
-                      <div className="text-sm font-medium text-[var(--ui-text-muted)]">
-                        {degreeAbbrev} {yearSuffix}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
-                    {curProfile.utStatus && (
-                      <span
-                        className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ${
-                          curProfile.utStatus === "student"
-                            ? "bg-emerald-100 text-emerald-800"
-                            : "bg-purple-100 text-purple-800"
-                        }`}
-                      >
-                        {curProfile.utStatus === "student" ? "Student" : "Alumni"}
-                      </span>
-                    )}
-                    {curProfile.archetype && (
-                      <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
-                        {curProfile.archetype === "the_scaler"
-                          ? "The Scaler"
-                          : curProfile.archetype === "the_steward"
-                            ? "The Steward"
-                            : "The Architect"}
-                      </span>
-                    )}
-                    <ReportProfileButton
-                      reportedUserId={curProfile.user_id ?? ""}
-                      reportedName={`${curProfile.firstName ?? ""} ${curProfile.lastName ?? ""}`.trim()}
-                    />
-                  </div>
+        <div className="mx-auto flex min-h-0 w-full max-w-2xl min-w-0 flex-1 flex-col">
+          {/* Search results */}
+          {isSearchActive ? (
+            <div>
+              {isSearching && (
+                <div className="flex flex-col gap-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <SearchResultCardSkeleton key={i} />
+                  ))}
                 </div>
-
-                {curProfile.isTechnical && (
-                  <div className="mb-3 inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
-                    {curProfile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
-                  </div>
-                )}
-
-                {schoolFullName && curProfile.utMajor && (
-                  <div className="mb-3 text-xs text-[var(--ui-text-muted)]">
-                    {schoolFullName} — {curProfile.utMajor}
-                  </div>
-                )}
-
-                {curProfile.is_hiring && <HiringBadge />}
-
-                {curProfile.user_id && (
-                  <div className="mb-3">
-                    <CoFounderLinks userId={curProfile.user_id} onClickCofounder={setViewingUserId} />
-                  </div>
-                )}
-
-                {curProfile.personalIntro && (
-                  <div className="mb-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface-active)] p-3">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
-                      About
-                    </p>
-                    <p className="text-sm leading-relaxed text-[var(--ui-text)]">
-                      {curProfile.personalIntro}
-                    </p>
-                  </div>
-                )}
-
-                {curProfile.utSectorInterests && curProfile.utSectorInterests.length > 0 && (
-                  <div className="mb-4">
-                    <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
-                      Category Interests
-                    </p>
-                    <div className="flex flex-wrap gap-1.5">
-                      {curProfile.utSectorInterests.map((interest: string, i: number) => (
-                        <span
-                          key={interest}
-                          className="rounded-md px-2.5 py-1 text-xs font-medium"
-                          style={
-                            i < 2
-                              ? { backgroundColor: "#bf5700", color: "#fff" }
-                              : {
-                                  backgroundColor: "var(--ui-surface-active)",
-                                  color: "var(--ui-text-muted)",
-                                }
-                          }
-                        >
-                          {SECTOR_INTEREST_LABELS[interest as keyof typeof SECTOR_INTEREST_LABELS] || interest}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {curProfile.education && (
-                  <div className="mb-4">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">Education</p>
-                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">{curProfile.education}</p>
-                  </div>
-                )}
-
-                {curProfile.experience && (
-                  <div className="mb-4">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">Experience</p>
-                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">{curProfile.experience}</p>
-                  </div>
-                )}
-
-                {curProfile.accomplishments && (
-                  <div className="mb-4">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">Accomplishments</p>
-                    <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">{curProfile.accomplishments}</p>
-                  </div>
-                )}
-
-                {curProfile.hasStartup === "yes" && curProfile.startupName && (
-                  <div className="mb-4">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">Startup</p>
-                    <p className="font-medium text-[var(--ui-text)]">{curProfile.startupName}</p>
-                    {curProfile.startupDescription && (
-                      <p className="mt-0.5 text-sm leading-relaxed text-[var(--ui-text-muted)]">{curProfile.startupDescription}</p>
-                    )}
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {curProfile.startupTimeSpent && (
-                        <span className="rounded-md bg-orange-100 px-2.5 py-1 text-xs text-orange-800 font-medium">{curProfile.startupTimeSpent}</span>
-                      )}
-                      {curProfile.startupFunding && (
-                        <span className="rounded-md bg-orange-100 px-2.5 py-1 text-xs text-orange-800 font-medium">{curProfile.startupFunding}</span>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {(() => {
-                  const links = [
-                    curProfile.linkedin && { href: curProfile.linkedin, icon: <FaLinkedin className="h-3.5 w-3.5" />, label: "LinkedIn" },
-                    curProfile.twitter && { href: curProfile.twitter, icon: <FaTwitter className="h-3.5 w-3.5" />, label: "Twitter / X" },
-                    curProfile.git && { href: curProfile.git, icon: <FaGithub className="h-3.5 w-3.5" />, label: "GitHub" },
-                    curProfile.personalWebsite && { href: curProfile.personalWebsite, icon: <FaGlobe className="h-3.5 w-3.5" />, label: "Website" },
-                    curProfile.schedulingUrl && { href: curProfile.schedulingUrl, icon: <FaCalendar className="h-3.5 w-3.5" />, label: "Schedule a call" },
-                  ].filter(Boolean) as { href: string; icon: React.ReactNode; label: string }[];
-                  return links.length > 0 ? (
-                    <div className="mb-1">
-                      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">Connect</p>
-                      <div className="flex flex-wrap gap-2">
-                        {links.map(({ href, icon, label }) => (
-                          <a
-                            key={label}
-                            href={href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#a34800]"
+              )}
+              {!isSearching && searchResults && searchResults.length === 0 && (
+                <div className="flex flex-col items-center gap-3 py-16 text-center">
+                  <p className="text-base font-semibold text-[var(--ui-text)]">
+                    No exact matches
+                  </p>
+                  {emptyReason && emptyReason.relaxations.length > 0 ? (
+                    <>
+                      <p className="text-sm text-[var(--ui-text-muted)]">
+                        Nobody fits all of your criteria. Relax one to see more:
+                      </p>
+                      <div className="mt-1 flex w-full max-w-xs flex-col items-stretch gap-2">
+                        {emptyReason.relaxations.map((s) => (
+                          <button
+                            key={s.dimension}
+                            type="button"
+                            onClick={() => handleRelax(s)}
+                            className="flex cursor-pointer items-center justify-between gap-2 rounded-lg border border-[#bf5700]/30 bg-[#fff6f0] px-3 py-2 text-sm text-[#a34800] transition hover:bg-[#ffe8d6]"
                           >
-                            {icon}
-                            {label}
-                          </a>
+                            <span className="font-medium">
+                              Drop &ldquo;{s.label}&rdquo;
+                            </span>
+                            <span className="flex-shrink-0 rounded-full bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
+                              +{s.countIfRelaxed}
+                            </span>
+                          </button>
                         ))}
                       </div>
+                    </>
+                  ) : (
+                    <p className="text-sm text-[var(--ui-text-muted)]">
+                      Try different keywords — skills, majors, industries, or
+                      city names work well.
+                    </p>
+                  )}
+                  <button
+                    onClick={() => setSearchQuery("")}
+                    className="mt-1 cursor-pointer text-sm font-medium text-[#a34800] hover:underline"
+                  >
+                    Clear search
+                  </button>
+                </div>
+              )}
+              {searchResults && searchResults.length > 0 && (
+                <div className="flex flex-col gap-3">
+                  {searchResults.map((profile) => (
+                    <SearchResultCard
+                      key={profile.user_id}
+                      profile={profile}
+                      onViewProfile={openProfile}
+                      onViewProfileById={openProfileById}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : /* Swipe card */
+          isLoadingProfiles ? (
+            <SwipeCardSkeleton />
+          ) : !curProfile ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+              {filtersActive ? (
+                <>
+                  <p className="text-xl font-semibold text-[var(--ui-text)]">
+                    No matches for these filters
+                  </p>
+                  <p className="text-sm text-[var(--ui-text-muted)]">
+                    Try adjusting your filters or clear them to see more
+                    co-founders.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => updateFilters(EMPTY_DASHBOARD_FILTERS)}
+                    className="mt-1 cursor-pointer text-sm font-medium text-[#a34800] hover:underline"
+                  >
+                    Clear filters
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="text-xl font-semibold text-[var(--ui-text)]">
+                    No more co-founders to show right now
+                  </p>
+                  <p className="text-sm text-[var(--ui-text-muted)]">
+                    Check back later. More students from your program will be
+                    joining.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleStartOver}
+                    disabled={
+                      resetRoundMutation.isPending || isFetchingProfiles
+                    }
+                    className="mt-1 inline-flex cursor-pointer items-center gap-2 rounded-full bg-[#BF5700] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#a34800] disabled:opacity-60"
+                  >
+                    {resetRoundMutation.isPending || isFetchingProfiles
+                      ? "Checking…"
+                      : "Start over"}
+                  </button>
+                </>
+              )}
+            </div>
+          ) : (
+            <AnimatePresence mode="wait">
+              <motion.div
+                ref={cardRef}
+                key={curProfile.user_id}
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -16 }}
+                transition={{ duration: 0.25 }}
+                className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]"
+              >
+                {/* Card header with avatar, name, badges */}
+                <div className="flex-1 overflow-y-auto p-5">
+                  {/* Avatar + Name row */}
+                  <div className="mb-4 flex items-start gap-3">
+                    <div className="relative flex-shrink-0">
+                      {curProfile.pfp_url ? (
+                        <Image
+                          src={curProfile.pfp_url}
+                          alt={`${curProfile.firstName} ${curProfile.lastName}`}
+                          width={64}
+                          height={64}
+                          className="h-16 w-16 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--ui-surface-active)] text-lg font-bold text-[var(--ui-text)]">
+                          {initials}
+                        </div>
+                      )}
+                      <div
+                        className={`absolute right-0 bottom-0 h-4 w-4 rounded-full border-2 border-[var(--ui-surface)] ${
+                          isOnline ? "bg-green-500" : "bg-red-500"
+                        }`}
+                      />
                     </div>
-                  ) : null;
-                })()}
-              </div>
 
-              {/* Action buttons */}
-              <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-border)] px-5 py-4">
-                <button
-                  onClick={handleSkip}
-                  disabled={skipProfileMutation.isPending}
-                  className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-[#BF5700] bg-[#fff6f0] text-[#BF5700] transition hover:bg-[#ffe8d6] cursor-pointer"
-                >
-                  <MdSkipNext className="h-5 w-5" />
-                </button>
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 flex items-center gap-2">
+                        <h2 className="text-lg font-bold text-[var(--ui-text)]">
+                          {curProfile.firstName} {curProfile.lastName}
+                        </h2>
+                        {curProfile.isNew && (
+                          <span className="inline-flex rounded-md bg-[#bf5700] px-2 py-0.5 text-xs font-semibold text-white">
+                            New
+                          </span>
+                        )}
+                      </div>
+                      {degreeAbbrev && yearSuffix && (
+                        <div className="text-sm font-medium text-[var(--ui-text-muted)]">
+                          {degreeAbbrev} {yearSuffix}
+                        </div>
+                      )}
+                    </div>
 
-                <button
-                  onClick={handleLike}
-                  disabled={isLikeLoading}
-                  className={`flex h-11 px-4 flex-shrink-0 items-center justify-center gap-2 rounded-full transition cursor-pointer font-medium ${
-                    likeStatus?.isLiked
-                      ? "bg-pink-500 text-white"
-                      : "bg-[#BF5700] text-white hover:bg-[#a34800]"
-                  }`}
-                >
-                  <FaPaperPlane className="h-4 w-4" />
-                  <span className="text-sm">Send invite</span>
-                </button>
-              </div>
-            </motion.div>
-          </AnimatePresence>
-        )
-      )}
+                    <div className="flex flex-shrink-0 flex-col items-end gap-1.5">
+                      {curProfile.utStatus && (
+                        <span
+                          className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ${
+                            curProfile.utStatus === "student"
+                              ? "bg-emerald-100 text-emerald-800"
+                              : "bg-purple-100 text-purple-800"
+                          }`}
+                        >
+                          {curProfile.utStatus === "student"
+                            ? "Student"
+                            : "Alumni"}
+                        </span>
+                      )}
+                      {curProfile.archetype && (
+                        <span className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
+                          {curProfile.archetype === "the_scaler"
+                            ? "The Scaler"
+                            : curProfile.archetype === "the_steward"
+                              ? "The Steward"
+                              : "The Architect"}
+                        </span>
+                      )}
+                      <ReportProfileButton
+                        reportedUserId={curProfile.user_id ?? ""}
+                        reportedName={`${curProfile.firstName ?? ""} ${curProfile.lastName ?? ""}`.trim()}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    {(curProfile.intent === "join_me" ||
+                      curProfile.intent === "seeking_to_join") && (
+                      <div className="inline-flex items-center rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-semibold text-white">
+                        {curProfile.intent === "join_me"
+                          ? "Seeking a cofounder"
+                          : "Seeking a startup to join"}
+                      </div>
+                    )}
+
+                    {curProfile.intent === "no_preference" && (
+                      <div className="inline-flex items-center rounded-md bg-[#bf5700] px-2.5 py-1 text-xs font-semibold text-white">
+                        Open to either: Seeking a cofounder or joining a startup
+                      </div>
+                    )}
+
+                    {curProfile.isTechnical && (
+                      <div className="inline-flex items-center rounded-md border border-[#bf5700] px-2.5 py-1 text-xs font-medium text-[#a34800]">
+                        {curProfile.isTechnical === "yes"
+                          ? "Technical founder"
+                          : "Non-technical founder"}
+                      </div>
+                    )}
+                  </div>
+
+                  {schoolFullName && curProfile.utMajor && (
+                    <div className="mb-3 text-xs text-[var(--ui-text-muted)]">
+                      {schoolFullName} — {curProfile.utMajor}
+                    </div>
+                  )}
+
+                  {curProfile.is_hiring && <HiringBadge />}
+
+                  {curProfile.user_id && (
+                    <div className="mb-3">
+                      <CoFounderLinks
+                        userId={curProfile.user_id}
+                        onClickCofounder={setViewingUserId}
+                      />
+                    </div>
+                  )}
+
+                  {curProfile.personalIntro && (
+                    <div className="mb-4 rounded-lg border border-[var(--ui-border)] bg-[var(--ui-surface-active)] p-3">
+                      <p className="mb-1 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                        About
+                      </p>
+                      <p className="text-sm leading-relaxed text-[var(--ui-text)]">
+                        {curProfile.personalIntro}
+                      </p>
+                    </div>
+                  )}
+
+                  {curProfile.utSectorInterests &&
+                    curProfile.utSectorInterests.length > 0 && (
+                      <div className="mb-4">
+                        <p className="mb-2 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                          Category Interests
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {curProfile.utSectorInterests.map(
+                            (interest: string, i: number) => (
+                              <span
+                                key={interest}
+                                className="rounded-md px-2.5 py-1 text-xs font-medium"
+                                style={
+                                  i < 2
+                                    ? {
+                                        backgroundColor: "#bf5700",
+                                        color: "#fff",
+                                      }
+                                    : {
+                                        backgroundColor:
+                                          "var(--ui-surface-active)",
+                                        color: "var(--ui-text-muted)",
+                                      }
+                                }
+                              >
+                                {SECTOR_INTEREST_LABELS[
+                                  interest as keyof typeof SECTOR_INTEREST_LABELS
+                                ] || interest}
+                              </span>
+                            ),
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                  {curProfile.education && (
+                    <div className="mb-4">
+                      <p className="mb-1 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                        Education
+                      </p>
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
+                        {curProfile.education}
+                      </p>
+                    </div>
+                  )}
+
+                  {curProfile.experience && (
+                    <div className="mb-4">
+                      <p className="mb-1 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                        Experience
+                      </p>
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
+                        {curProfile.experience}
+                      </p>
+                    </div>
+                  )}
+
+                  {curProfile.accomplishments && (
+                    <div className="mb-4">
+                      <p className="mb-1 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                        Accomplishments
+                      </p>
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
+                        {curProfile.accomplishments}
+                      </p>
+                    </div>
+                  )}
+
+                  {curProfile.hasStartup === "yes" &&
+                    curProfile.startupName && (
+                      <div className="mb-4">
+                        <p className="mb-1 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                          Startup
+                        </p>
+                        <p className="font-medium text-[var(--ui-text)]">
+                          {curProfile.startupName}
+                        </p>
+                        {curProfile.startupDescription && (
+                          <p className="mt-0.5 text-sm leading-relaxed text-[var(--ui-text-muted)]">
+                            {curProfile.startupDescription}
+                          </p>
+                        )}
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {curProfile.startupTimeSpent && (
+                            <span className="rounded-md bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-800">
+                              {curProfile.startupTimeSpent}
+                            </span>
+                          )}
+                          {curProfile.startupFunding && (
+                            <span className="rounded-md bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-800">
+                              {curProfile.startupFunding}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                  {(() => {
+                    const links = [
+                      curProfile.linkedin && {
+                        href: curProfile.linkedin,
+                        icon: <FaLinkedin className="h-3.5 w-3.5" />,
+                        label: "LinkedIn",
+                      },
+                      curProfile.twitter && {
+                        href: curProfile.twitter,
+                        icon: <FaTwitter className="h-3.5 w-3.5" />,
+                        label: "Twitter / X",
+                      },
+                      curProfile.git && {
+                        href: curProfile.git,
+                        icon: <FaGithub className="h-3.5 w-3.5" />,
+                        label: "GitHub",
+                      },
+                      curProfile.personalWebsite && {
+                        href: curProfile.personalWebsite,
+                        icon: <FaGlobe className="h-3.5 w-3.5" />,
+                        label: "Website",
+                      },
+                      curProfile.schedulingUrl && {
+                        href: curProfile.schedulingUrl,
+                        icon: <FaCalendar className="h-3.5 w-3.5" />,
+                        label: "Schedule a call",
+                      },
+                    ].filter(Boolean) as {
+                      href: string;
+                      icon: React.ReactNode;
+                      label: string;
+                    }[];
+                    return links.length > 0 ? (
+                      <div className="mb-1">
+                        <p className="mb-2 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
+                          Connect
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {links.map(({ href, icon, label }) => (
+                            <a
+                              key={label}
+                              href={href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center gap-1.5 rounded-full border border-[var(--ui-border)] px-3 py-1.5 text-xs font-medium text-[var(--ui-text-muted)] transition hover:border-[#bf5700] hover:text-[#a34800]"
+                            >
+                              {icon}
+                              {label}
+                            </a>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null;
+                  })()}
+                </div>
+
+                {/* Action buttons */}
+                <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-border)] px-5 py-4">
+                  <button
+                    onClick={handleSkip}
+                    disabled={skipProfileMutation.isPending}
+                    className="flex h-11 w-11 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border border-[#BF5700] bg-[#fff6f0] text-[#BF5700] transition hover:bg-[#ffe8d6]"
+                  >
+                    <MdSkipNext className="h-5 w-5" />
+                  </button>
+
+                  <button
+                    onClick={handleLike}
+                    disabled={isLikeLoading}
+                    className={`flex h-11 flex-shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full px-4 font-medium transition ${
+                      likeStatus?.isLiked
+                        ? "bg-pink-500 text-white"
+                        : "bg-[#BF5700] text-white hover:bg-[#a34800]"
+                    }`}
+                  >
+                    <FaPaperPlane className="h-4 w-4" />
+                    <span className="text-sm">Send invite</span>
+                  </button>
+                </div>
+              </motion.div>
+            </AnimatePresence>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/(school)/school/[slug]/founder-archetypes/page.tsx
+++ b/src/app/(school)/school/[slug]/founder-archetypes/page.tsx
@@ -1,0 +1,264 @@
+import React from "react";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { getOrganizationBySlug } from "@/features/school/data/organizations";
+import { getOrgConfig } from "@/features/school/registry/registry";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const org = await getOrganizationBySlug(slug);
+  const cfg = getOrgConfig(slug);
+  const wordmark = cfg?.branding.wordmark ?? org?.name ?? "School Portal";
+  return {
+    title: `Founder Archetypes | ${wordmark} Co-Foundr`,
+    description:
+      "Understand the three founder archetypes: The Scaler, The Steward, and The Architect. Find your founding style.",
+  };
+}
+
+const ARCHETYPES = [
+  {
+    id: "the_scaler",
+    name: "The Scaler",
+    subtitle: "AI-First Hypergrowth",
+    description:
+      "Wins markets through speed, algorithmic efficiency, and bold bets on exponential growth. Every decision optimizes for scale.",
+    index: "01",
+    dimensions: [
+      {
+        label: "Primary Goal",
+        title: "Market Dominance",
+        body: "To win the market through speed and technical efficiency.",
+      },
+      {
+        label: "Core Value",
+        title: "Speed Over Perfection",
+        body: "Testing, breaking things, and iterating weekly to find product-market fit.",
+      },
+      {
+        label: "Operational Moat",
+        title: "Algorithmic Advantage",
+        body: "Using proprietary data and AI agents to scale without adding headcount.",
+      },
+      {
+        label: "Success Metric",
+        title: "WoW Growth",
+        body: "10–15% week-over-week revenue or user growth is the non-negotiable benchmark.",
+      },
+      {
+        label: "Risk Tolerance",
+        title: "High Ambition",
+        body: "Taking bold, experimental bets with a high tolerance for failure if the payoff is massive.",
+      },
+      {
+        label: "User Philosophy",
+        title: "Users as Data",
+        body: "Users provide the signals needed to pivot the product toward peak efficiency.",
+      },
+    ],
+  },
+  {
+    id: "the_steward",
+    name: "The Steward",
+    subtitle: "Ethical / Values-Driven",
+    description:
+      "Builds sustainable businesses grounded in moral integrity, community trust, and long-term impact. Every partnership must align with values.",
+    index: "02",
+    dimensions: [
+      {
+        label: "Primary Goal",
+        title: "Legacy & Impact",
+        body: "To build a sustainable business that reflects core moral and ethical values.",
+      },
+      {
+        label: "Core Value",
+        title: "Integrity Over Speed",
+        body: "Ensuring every partnership and transaction aligns with moral standards.",
+      },
+      {
+        label: "Operational Moat",
+        title: "Trust & Community",
+        body: "Relying on deep relational networks and a shared standard of conduct across partners.",
+      },
+      {
+        label: "Success Metric",
+        title: "Social & Community ROI",
+        body: "Measuring success by community well-being and adherence to ethical guardrails.",
+      },
+      {
+        label: "Risk Tolerance",
+        title: "Calculated Caution",
+        body: "Favoring proven, sustainable practices that protect the reputation of the community.",
+      },
+      {
+        label: "User Philosophy",
+        title: "Users as Partners",
+        body: "Users are members of a collective ecosystem built on mutual benefit.",
+      },
+    ],
+  },
+  {
+    id: "the_architect",
+    name: "The Architect",
+    subtitle: "Ecosystem-Driven",
+    description:
+      "Builds the infrastructure and platforms where other businesses live. Success is measured by the total value generated across the ecosystem.",
+    index: "03",
+    dimensions: [
+      {
+        label: "Primary Goal",
+        title: "Infrastructure",
+        body: 'To become the "operating system" or the environment where other businesses live.',
+      },
+      {
+        label: "Core Value",
+        title: "Interdependence",
+        body: "Believing that the success of the platform depends on the success of its third-party members.",
+      },
+      {
+        label: "Operational Moat",
+        title: "Network Effects",
+        body: "Every new participant makes the system more valuable for everyone else (e.g., Salesforce, Microsoft, or a global payments network).",
+      },
+      {
+        label: "Success Metric",
+        title: "Total Ecosystem Value",
+        body: "Measuring success by how much commerce or value is generated on the platform, not just by it.",
+      },
+      {
+        label: "Risk Tolerance",
+        title: "Complex Stability",
+        body: "A willingness to trade short-term rapid growth for long-term structural dominance and reliability.",
+      },
+      {
+        label: "User Philosophy",
+        title: "Users as Co-Creators",
+        body: "Users aren't just consumers or data points; they are developers, sellers, and partners.",
+      },
+    ],
+  },
+] as const;
+
+export default async function SchoolFounderArchetypesPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const [{ sessionClaims }, org] = await Promise.all([
+    auth(),
+    getOrganizationBySlug(slug),
+  ]);
+  const cfg = getOrgConfig(slug);
+
+  if (!org || !cfg) notFound();
+
+  const wordmark = cfg.branding.wordmark ?? org.name;
+
+  // Per-org onboarding flag keyed by org UUID, with the same legacy fallback the
+  // middleware uses for users who onboarded before the per-context split.
+  const schoolOnboarding = sessionClaims?.metadata?.schoolOnboarding;
+  const schoolDone =
+    schoolOnboarding?.[org.id] === true ||
+    (sessionClaims?.metadata?.onboardingComplete === true &&
+      sessionClaims?.metadata?.organization_id === org.id);
+
+  return (
+    <div className="flex-1">
+      {/* Hero */}
+      <section className="border-b border-[var(--ui-border)] px-6 py-20 md:py-28">
+        <div className="mx-auto max-w-4xl">
+          <p className="mb-4 text-xs font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
+            {wordmark} Co-Foundr
+          </p>
+          <h1 className="mb-5 text-4xl font-bold leading-tight text-[var(--ui-text)] md:text-5xl lg:text-6xl">
+            Founder Archetypes
+          </h1>
+          <p className="max-w-2xl text-base leading-relaxed text-[var(--ui-text-muted)] md:text-lg">
+            Every founder approaches building differently. These three archetypes
+            capture distinct philosophies, from hypergrowth to values-led to
+            ecosystem-first. Understanding yours helps you find the right
+            co-founder.
+          </p>
+          {!schoolDone && (
+            <Link
+              href={`/school/${slug}/onboarding`}
+              className="mt-8 inline-flex items-center gap-2 rounded-xl border border-[var(--ui-border-strong)] px-5 py-2.5 text-sm font-medium text-[var(--ui-text-muted)] transition-all duration-200 hover:border-[var(--ui-text-muted)] hover:text-[var(--ui-text)]"
+            >
+              ← Back to onboarding
+            </Link>
+          )}
+        </div>
+      </section>
+
+      {/* Archetype cards */}
+      <section className="px-6 py-16 md:py-20">
+        <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 lg:grid-cols-3">
+          {ARCHETYPES.map((archetype) => (
+            <article
+              key={archetype.id}
+              className="flex flex-col overflow-hidden rounded-2xl border border-[var(--ui-border)] bg-[var(--ui-surface)]"
+            >
+              {/* Card header */}
+              <div className="border-b border-[var(--ui-border)] p-7">
+                <div className="mb-4 flex items-start justify-between">
+                  <span className="text-xs font-medium tracking-widest text-[var(--ui-text-subtle)] uppercase">
+                    {archetype.index}
+                  </span>
+                </div>
+                <h2 className="mb-1 text-2xl font-bold text-[var(--ui-text)]">
+                  {archetype.name}
+                </h2>
+                <p className="mb-4 text-sm font-medium text-[var(--ui-text-muted)]">
+                  {archetype.subtitle}
+                </p>
+                <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
+                  {archetype.description}
+                </p>
+              </div>
+
+              {/* Dimensions */}
+              <div className="flex flex-1 flex-col divide-y divide-[var(--ui-border)] p-7 pt-0">
+                {archetype.dimensions.map((dim) => (
+                  <div key={dim.label} className="py-4 first:pt-6">
+                    <p className="mb-0.5 text-[10px] font-semibold tracking-widest text-[var(--ui-text-subtle)] uppercase">
+                      {dim.label}
+                    </p>
+                    <p className="mb-1 text-sm font-semibold text-[var(--ui-text)]">
+                      {dim.title}
+                    </p>
+                    <p className="text-xs leading-relaxed text-[var(--ui-text-muted)]">
+                      {dim.body}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Footer CTA — only shown before school onboarding is complete */}
+      {!schoolDone && (
+        <section className="border-t border-[var(--ui-border)] px-6 py-16 text-center">
+          <p className="mb-2 text-sm text-[var(--ui-text-muted)]">
+            Ready to set your archetype?
+          </p>
+          <Link
+            href={`/school/${slug}/onboarding`}
+            className="inline-flex items-center gap-2 rounded-xl bg-[var(--ui-btn-bg)] px-6 py-3 text-sm font-semibold text-[var(--ui-btn-text)] transition-all duration-200 hover:opacity-90"
+          >
+            Continue onboarding →
+          </Link>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/(school)/school/[slug]/profile/page.tsx
+++ b/src/app/(school)/school/[slug]/profile/page.tsx
@@ -422,7 +422,7 @@ export default function SchoolProfilePage({ params }: { params: Promise<{ slug: 
               <div className="flex items-center justify-between">
                 <label className={labelClass}>Founder Archetype *</label>
                 <a
-                  href="/founder-archetypes"
+                  href={`/school/${slug}/founder-archetypes`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-[var(--ui-text-subtle)] underline-offset-2 hover:text-[var(--ui-text-muted)] hover:underline"

--- a/src/app/api/profile/[userId]/route.ts
+++ b/src/app/api/profile/[userId]/route.ts
@@ -188,8 +188,32 @@ export async function GET(
 
     const mappedProfile = mapProfileToOnboardingData(data);
 
+    // Merge UT/school-specific fields (utStatus, utMajor, intent, etc.) so the
+    // profile view modal shows the same badges here as it does when the caller
+    // already has an enriched profile object (e.g. from /api/profiles).
+    const { data: schoolRows } = await supabase
+      .from("school_profiles")
+      .select("school_status, graduation_year, college, degree_type, major, sector_interests, intent")
+      .eq("user_id", userId)
+      .limit(1);
+
+    const schoolRow = schoolRows?.[0];
+
+    const enrichedProfile = schoolRow
+      ? {
+          ...mappedProfile,
+          utStatus: schoolRow.school_status,
+          gradYear: schoolRow.graduation_year,
+          utCollege: schoolRow.college,
+          utDegreeType: schoolRow.degree_type,
+          utMajor: schoolRow.major,
+          utSectorInterests: schoolRow.sector_interests,
+          intent: schoolRow.intent,
+        }
+      : mappedProfile;
+
     return NextResponse.json({
-      profile: mappedProfile,
+      profile: enrichedProfile,
     });
   } catch (error) {
     console.error("Error in profile by user ID API:", error);

--- a/src/app/api/profiles/search/route.ts
+++ b/src/app/api/profiles/search/route.ts
@@ -263,7 +263,7 @@ async function enrichWithSchoolData(
   const { data: schoolEnrichRows } = await supabase
     .from("school_profiles")
     .select(
-      "user_id, school_status, graduation_year, college, degree_type, major, sector_interests",
+      "user_id, school_status, graduation_year, college, degree_type, major, sector_interests, intent",
     )
     .eq("organization_id", orgId)
     .in("user_id", candidateIds);
@@ -278,6 +278,7 @@ async function enrichWithSchoolData(
         utDegreeType: row.degree_type,
         utMajor: row.major,
         utSectorInterests: row.sector_interests,
+        intent: row.intent,
       },
     ]) ?? [],
   );

--- a/src/features/profile/ProfileViewModal.tsx
+++ b/src/features/profile/ProfileViewModal.tsx
@@ -34,22 +34,33 @@ interface ProfileViewModalProps {
   onClose: () => void;
 }
 
-export default function ProfileViewModal({ profile: profileProp, userId, onClose }: ProfileViewModalProps) {
+export default function ProfileViewModal({
+  profile: profileProp,
+  userId,
+  onClose,
+}: ProfileViewModalProps) {
   // Internal navigation: when user clicks a linked cofounder, we navigate to their profile.
   // navUserId overrides the props while set; clearing it returns to the root profile.
   const [navUserId, setNavUserId] = useState<string | null>(null);
 
   // Reset internal nav whenever the root target changes (modal opened for a new person)
   const rootId = profileProp?.user_id ?? userId ?? null;
-  useEffect(() => { setNavUserId(null); }, [rootId]);
+  useEffect(() => {
+    setNavUserId(null);
+  }, [rootId]);
 
   const targetId = navUserId ?? rootId;
   const isNavigated = !!navUserId;
 
   // Only fetch when we don't have the profile directly (or we've navigated away)
   const shouldFetch = isNavigated || (!profileProp && !!targetId);
-  const { data: fetchedProfile, isLoading } = useProfileByUserId(targetId ?? "", shouldFetch && !!targetId);
-  const profile = isNavigated ? (fetchedProfile ?? null) : (profileProp ?? fetchedProfile ?? null);
+  const { data: fetchedProfile, isLoading } = useProfileByUserId(
+    targetId ?? "",
+    shouldFetch && !!targetId,
+  );
+  const profile = isNavigated
+    ? (fetchedProfile ?? null)
+    : (profileProp ?? fetchedProfile ?? null);
 
   const { toggleLike, isLoading: isLikeLoading } = useToggleLike();
   const { data: likeStatus } = useLikeStatus(targetId ?? "");
@@ -69,7 +80,8 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
   if (!targetId) return null;
 
   const initials = profile
-    ? (profile.firstName?.[0] ?? "").toUpperCase() + (profile.lastName?.[0] ?? "").toUpperCase()
+    ? (profile.firstName?.[0] ?? "").toUpperCase() +
+      (profile.lastName?.[0] ?? "").toUpperCase()
     : "";
 
   const degreeAbbrev =
@@ -86,17 +98,42 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
     : undefined;
 
   const isOnline = profile?.last_active_at
-    ? new Date().getTime() - new Date(profile.last_active_at).getTime() < 5 * 60 * 1000
+    ? new Date().getTime() - new Date(profile.last_active_at).getTime() <
+      5 * 60 * 1000
     : false;
 
   const socialLinks = profile
-    ? [
-        profile.linkedin && { href: profile.linkedin, icon: <FaLinkedin className="h-4 w-4" />, label: "LinkedIn" },
-        profile.twitter && { href: profile.twitter, icon: <FaTwitter className="h-4 w-4" />, label: "Twitter / X" },
-        profile.git && { href: profile.git, icon: <FaGithub className="h-4 w-4" />, label: "GitHub" },
-        profile.personalWebsite && { href: profile.personalWebsite, icon: <FaGlobe className="h-4 w-4" />, label: "Website" },
-        profile.schedulingUrl && { href: profile.schedulingUrl, icon: <FaCalendar className="h-4 w-4" />, label: "Schedule a call" },
-      ].filter(Boolean) as { href: string; icon: React.ReactNode; label: string }[]
+    ? ([
+        profile.linkedin && {
+          href: profile.linkedin,
+          icon: <FaLinkedin className="h-4 w-4" />,
+          label: "LinkedIn",
+        },
+        profile.twitter && {
+          href: profile.twitter,
+          icon: <FaTwitter className="h-4 w-4" />,
+          label: "Twitter / X",
+        },
+        profile.git && {
+          href: profile.git,
+          icon: <FaGithub className="h-4 w-4" />,
+          label: "GitHub",
+        },
+        profile.personalWebsite && {
+          href: profile.personalWebsite,
+          icon: <FaGlobe className="h-4 w-4" />,
+          label: "Website",
+        },
+        profile.schedulingUrl && {
+          href: profile.schedulingUrl,
+          icon: <FaCalendar className="h-4 w-4" />,
+          label: "Schedule a call",
+        },
+      ].filter(Boolean) as {
+        href: string;
+        icon: React.ReactNode;
+        label: string;
+      }[])
     : [];
 
   const showLoading = isLoading && shouldFetch;
@@ -116,7 +153,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 40 }}
             transition={{ type: "spring", damping: 25, stiffness: 300 }}
-            className="flex h-[92vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] shadow-2xl sm:rounded-2xl sm:h-[85vh]"
+            className="flex h-[92vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-[var(--ui-border)] bg-[var(--ui-popover-bg)] shadow-2xl sm:h-[85vh] sm:rounded-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Sticky header */}
@@ -135,7 +172,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                   {isNavigated && (
                     <button
                       onClick={() => setNavUserId(null)}
-                      className="mt-1 flex-shrink-0 rounded-full p-2 text-[var(--ui-text-muted)] transition hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)] cursor-pointer"
+                      className="mt-1 flex-shrink-0 cursor-pointer rounded-full p-2 text-[var(--ui-text-muted)] transition hover:bg-[var(--ui-surface-active)] hover:text-[var(--ui-text)]"
                       title="Back"
                     >
                       <FaArrowLeft className="h-4 w-4" />
@@ -157,7 +194,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                       </div>
                     )}
                     <div
-                      className={`absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ${isOnline ? "bg-green-500" : "bg-gray-300"}`}
+                      className={`absolute right-0.5 bottom-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ${isOnline ? "bg-green-500" : "bg-gray-300"}`}
                     />
                   </div>
 
@@ -178,7 +215,9 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                     <div className="flex flex-wrap gap-1.5">
                       {profile.utStatus && (
                         <span className="inline-flex items-center rounded-md border border-[var(--ui-border-strong)] px-2 py-0.5 text-xs font-medium text-[var(--ui-text-muted)]">
-                          {profile.utStatus === "student" ? "Student" : "Alumni"}
+                          {profile.utStatus === "student"
+                            ? "Student"
+                            : "Alumni"}
                         </span>
                       )}
                       {profile.archetype && (
@@ -192,21 +231,44 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                       )}
                       {profile.isTechnical && (
                         <span className="inline-flex items-center rounded-md border border-[var(--org-primary)] px-2 py-0.5 text-xs font-medium text-[var(--org-primary)]">
-                          {profile.isTechnical === "yes" ? "Technical founder" : "Non-technical founder"}
+                          {profile.isTechnical === "yes"
+                            ? "Technical founder"
+                            : "Non-technical founder"}
+                        </span>
+                      )}
+                      {(profile.intent === "join_me" ||
+                        profile.intent === "seeking_to_join") && (
+                        <span className="inline-flex items-center rounded-md bg-[var(--org-primary)] px-2 py-0.5 text-xs font-semibold text-white">
+                          {profile.intent === "join_me"
+                            ? "Seeking a cofounder"
+                            : "Seeking a startup to join"}
+                        </span>
+                      )}
+                      {profile.intent === "no_preference" && (
+                        <span className="inline-flex items-center rounded-md bg-[var(--org-primary)] px-2 py-0.5 text-xs font-semibold text-white">
+                          Open to either: Seeking a cofounder or joining a
+                          startup
                         </span>
                       )}
                     </div>
 
                     {(degreeAbbrev || schoolFullName) && (
                       <p className="mt-1.5 text-xs text-[var(--ui-text-muted)]">
-                        {degreeAbbrev && yearSuffix ? `${degreeAbbrev} ${yearSuffix}` : degreeAbbrev ?? ""}
-                        {schoolFullName && profile.utMajor ? ` · ${schoolFullName} — ${profile.utMajor}` : ""}
+                        {degreeAbbrev && yearSuffix
+                          ? `${degreeAbbrev} ${yearSuffix}`
+                          : (degreeAbbrev ?? "")}
+                        {schoolFullName && profile.utMajor
+                          ? ` · ${schoolFullName} — ${profile.utMajor}`
+                          : ""}
                       </p>
                     )}
 
                     {targetId && (
                       <div className="mt-2">
-                        <CoFounderLinks userId={targetId} onClickCofounder={setNavUserId} />
+                        <CoFounderLinks
+                          userId={targetId}
+                          onClickCofounder={setNavUserId}
+                        />
                       </div>
                     )}
                   </div>
@@ -217,7 +279,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                   />
                   <button
                     onClick={onClose}
-                    className="flex-shrink-0 rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                    className="flex-shrink-0 cursor-pointer rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
                   >
                     <FaTimes className="h-4 w-4" />
                   </button>
@@ -237,29 +299,40 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                     </Section>
                   )}
 
-                  {profile.utSectorInterests && profile.utSectorInterests.length > 0 && (
-                    <Section title="Sector Interests">
-                      <div className="flex flex-wrap gap-1.5">
-                        {profile.utSectorInterests.map((interest: string, i: number) => (
-                          <span
-                            key={interest}
-                            className="rounded-md px-2.5 py-1 text-xs font-medium"
-                            style={
-                              i < 2
-                                ? { backgroundColor: "var(--org-primary)", color: "#fff" }
-                                : { backgroundColor: "#f3f4f6", color: "#6b7280" }
-                            }
-                          >
-                            {SECTOR_INTEREST_LABELS[interest as keyof typeof SECTOR_INTEREST_LABELS] || interest}
-                          </span>
-                        ))}
-                      </div>
-                    </Section>
-                  )}
+                  {profile.utSectorInterests &&
+                    profile.utSectorInterests.length > 0 && (
+                      <Section title="Sector Interests">
+                        <div className="flex flex-wrap gap-1.5">
+                          {profile.utSectorInterests.map(
+                            (interest: string, i: number) => (
+                              <span
+                                key={interest}
+                                className="rounded-md px-2.5 py-1 text-xs font-medium"
+                                style={
+                                  i < 2
+                                    ? {
+                                        backgroundColor: "var(--org-primary)",
+                                        color: "#fff",
+                                      }
+                                    : {
+                                        backgroundColor: "#f3f4f6",
+                                        color: "#6b7280",
+                                      }
+                                }
+                              >
+                                {SECTOR_INTEREST_LABELS[
+                                  interest as keyof typeof SECTOR_INTEREST_LABELS
+                                ] || interest}
+                              </span>
+                            ),
+                          )}
+                        </div>
+                      </Section>
+                    )}
 
                   {profile.education && (
                     <Section title="Education">
-                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
                         {profile.education}
                       </p>
                     </Section>
@@ -267,7 +340,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
 
                   {profile.experience && (
                     <Section title="Experience">
-                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
                         {profile.experience}
                       </p>
                     </Section>
@@ -275,7 +348,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
 
                   {profile.accomplishments && (
                     <Section title="Accomplishments">
-                      <p className="whitespace-pre-line text-sm leading-relaxed text-[var(--ui-text)]">
+                      <p className="text-sm leading-relaxed whitespace-pre-line text-[var(--ui-text)]">
                         {profile.accomplishments}
                       </p>
                     </Section>
@@ -283,7 +356,9 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
 
                   {profile.hasStartup === "yes" && profile.startupName && (
                     <Section title="Startup">
-                      <p className="mb-1 font-medium text-[var(--ui-text)]">{profile.startupName}</p>
+                      <p className="mb-1 font-medium text-[var(--ui-text)]">
+                        {profile.startupName}
+                      </p>
                       {profile.startupDescription && (
                         <p className="text-sm leading-relaxed text-[var(--ui-text-muted)]">
                           {profile.startupDescription}
@@ -332,7 +407,7 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
                 <button
                   onClick={handleInvite}
                   disabled={isLikeLoading}
-                  className={`flex w-full items-center justify-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 cursor-pointer ${
+                  className={`flex w-full cursor-pointer items-center justify-center gap-2 rounded-full px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 ${
                     likeStatus?.isLiked
                       ? "bg-pink-500 text-white hover:bg-pink-600"
                       : "bg-[var(--org-primary)] text-white hover:bg-[#a34800]"
@@ -350,10 +425,16 @@ export default function ProfileViewModal({ profile: profileProp, userId, onClose
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <div>
-      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--ui-text-muted)]">
+      <p className="mb-2 text-[10px] font-semibold tracking-wider text-[var(--ui-text-muted)] uppercase">
         {title}
       </p>
       {children}

--- a/src/features/school/components/dashboard/FilterSidebar.tsx
+++ b/src/features/school/components/dashboard/FilterSidebar.tsx
@@ -131,8 +131,8 @@ type FilterSidebarProps = {
 
 const INTENT_OPTIONS = [
   { value: null, label: "Any" },
-  { value: "join_me" as const, label: "Join me" },
-  { value: "seeking_to_join" as const, label: "Seeking to join" },
+  { value: "join_me" as const, label: "Seeking a cofounder" },
+  { value: "seeking_to_join" as const, label: "Seeking a startup to join" },
 ];
 
 function FilterPanel({
@@ -451,14 +451,14 @@ export function getFilterChipLabels(filters: DashboardFilters): FilterChipLabel[
     chips.push({
       key: "intent-join_me",
       dismissKey: "intent",
-      label: "Join me",
+      label: "Seeking a cofounder",
       onRemove: () => ({ ...filters, intent: null }),
     });
   } else if (filters.intent === "seeking_to_join") {
     chips.push({
       key: "intent-seeking",
       dismissKey: "intent",
-      label: "Seeking to join",
+      label: "Seeking a startup to join",
       onRemove: () => ({ ...filters, intent: null }),
     });
   }

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -11,12 +11,12 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
       </Link>
 
       <nav className="flex flex-wrap items-center justify-center gap-3 sm:gap-5">
-        <a
-          href="#departments"
+        <Link
+          href={`/school/${slug}/sign-in?redirect=${encodeURIComponent(`/school/${slug}/dashboard`)}`}
           className="border-b border-white/40 pb-0.5 text-xs sm:text-sm font-medium text-white whitespace-nowrap"
         >
           Find your co-foundr
-        </a>
+        </Link>
         <Link
           href={`/school/${slug}/contact-us`}
           className="text-xs sm:text-sm font-medium text-white transition-[font-weight] duration-300 hover:font-semibold whitespace-nowrap"

--- a/src/features/school/components/landing/PublicSchoolHeader.tsx
+++ b/src/features/school/components/landing/PublicSchoolHeader.tsx
@@ -6,7 +6,7 @@ export default function PublicSchoolHeader({ slug }: { slug: string }) {
       className="flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-0 px-4 sm:px-6 py-3 sm:py-4"
       style={{ backgroundColor: "#bf5700" }}
     >
-      <Link href="/" className="text-xs sm:text-sm font-semibold text-white text-center sm:text-left">
+      <Link href={`/school/${slug}`} className="text-xs sm:text-sm font-semibold text-white text-center sm:text-left">
         University of Texas Co-Foundr
       </Link>
 

--- a/src/features/school/onboarding/components/UTAboutYouForm.tsx
+++ b/src/features/school/onboarding/components/UTAboutYouForm.tsx
@@ -6,6 +6,7 @@ import FormInput from "@/components/ui/FormInput";
 import LocationSelector from "@/components/ui/LocationSelector";
 import { useStepEntry, useErrorShake } from "@/hooks/useOnboardingAnimation";
 import UTSchoolFields from "@/features/school/onboarding/components/UTSchoolFields";
+import { useSchool } from "@/features/school/components/SchoolContext";
 
 type UTAboutYouData = {
   firstName: string;
@@ -64,6 +65,7 @@ function UTAboutYouForm({
 }) {
   const fieldsRef = useStepEntry();
   const { formRef, triggerShake } = useErrorShake();
+  const { slug } = useSchool();
 
   const {
     register,
@@ -223,7 +225,7 @@ function UTAboutYouForm({
               </p>
             </div>
             <a
-              href="/founder-archetypes"
+              href={`/school/${slug}/founder-archetypes`}
               target="_blank"
               rel="noopener noreferrer"
               className="shrink-0 mt-0.5 text-xs text-[var(--ui-text-subtle)] underline-offset-2 transition-colors duration-150 hover:text-[var(--ui-text-muted)] hover:underline"

--- a/src/features/school/onboarding/components/UTInterestsForm.tsx
+++ b/src/features/school/onboarding/components/UTInterestsForm.tsx
@@ -110,8 +110,6 @@ const INTEREST_DOMAINS = [
       "Human Augmentation",
       "Metaverse",
       "Smart Cities",
-      "Halal Tech",
-      "Islamic Fintech",
     ],
   },
 ] as const;

--- a/src/lib/searchQueryParser.ts
+++ b/src/lib/searchQueryParser.ts
@@ -11,7 +11,7 @@ export type ParsedQuery = {
 };
 
 const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
-const GROQ_MODEL = "llama-3.3-70b-versatile";
+const GROQ_MODEL = "openai/gpt-oss-20b";
 const GROQ_TIMEOUT_MS = 1500;
 const CACHE_MAX = 1000;
 const CACHE_TTL_MS = 60 * 60 * 1000;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,6 +28,7 @@ const isPublicRoute = createRouteMatcher([
   "/school/:slug/privacy-policy",
   "/school/:slug/terms-and-conditions",
   "/school/:slug/contact-us",
+  "/school/:slug/founder-archetypes",
   "/school/:slug/not-authorized",
   "/school/:slug/sign-up(.*)",
   "/school/:slug/sign-in(.*)",


### PR DESCRIPTION
## Summary
This PR ships a batch of UT-specific director requests: a new public "Founder Archetypes" explainer page, an "intent" badge (seeking a cofounder / seeking to join a startup / open to either) surfaced across the dashboard swipe card, search results, and profile modal, several onboarding/copy fixes, and a couple of small infra tweaks (semantic search model swap, sidebar link fix). Most of the `dashboard/page.tsx` and `ProfileViewModal.tsx` diff is Prettier-driven reformatting (multi-line JSX/import wrapping) rather than logic changes — the functional changes are called out below.

## Changes

### Founder Archetypes page
- Add a new public, per-school route `src/app/(school)/school/[slug]/founder-archetypes/page.tsx` describing the three founder archetypes (The Scaler, The Steward, The Architect) with per-dimension breakdowns (primary goal, core value, moat, success metric, risk tolerance, user philosophy). Server component that resolves org/branding via `getOrganizationBySlug`/`getOrgConfig` and 404s if either is missing.
- Conditionally shows a "Back to onboarding" / "Continue onboarding" CTA only when the signed-in user hasn't completed school onboarding for that org, checked via Clerk `sessionClaims.metadata.schoolOnboarding[org.id]` with a fallback to the legacy pre-per-context `onboardingComplete` flag.
- Register `/school/:slug/founder-archetypes` as a public route in `src/middleware.ts` so it's reachable pre-auth.
- Repoint the "Founder Archetype" info links in `src/app/(school)/school/[slug]/profile/page.tsx` and `UTAboutYouForm.tsx` from a hardcoded `/founder-archetypes` to the per-school `/school/${slug}/founder-archetypes`, since the old global route no longer exists in this flow.

### Intent badges (dashboard, search, profile modal)
- Surface the profile's `intent` field (`join_me`, `seeking_to_join`, `no_preference`) as a badge in three places: the dashboard swipe card and `SearchResultCard` (`src/app/(school)/school/[slug]/dashboard/page.tsx`), and `ProfileViewModal.tsx`. Labels: "Seeking a cofounder", "Seeking a startup to join", and "Open to either: Seeking a cofounder or joining a startup".
- Relabel the existing `FilterSidebar` intent filter options and chip labels from "Join me" / "Seeking to join" to the same "Seeking a cofounder" / "Seeking a startup to join" copy for consistency (`src/features/school/components/dashboard/FilterSidebar.tsx`).
- Wire `intent` through the two profile-fetch paths so the badge has data to render: `enrichWithSchoolData` in `src/app/api/profiles/search/route.ts` now selects and maps `intent` from `school_profiles`, and `src/app/api/profile/[userId]/route.ts` (single-profile GET) now does an additional `school_profiles` lookup to merge `utStatus`, `utMajor`, `intent`, etc. onto the mapped profile — previously that endpoint returned only the base profile without school-specific enrichment, so the modal fell back to fetching via `useProfileByUserId` without these badges.

### Onboarding / copy
- Drop "Halal Tech" and "Islamic Fintech" as interest options in `UTInterestsForm.tsx` (matches the separate `0e16b1f` "Remove Islamic + Halal Fintech options from UT site" commit on this branch).
- Fix `PublicSchoolHeader.tsx`: the site title now links to `/school/${slug}` instead of `/` (previously routed off the per-school context), and "Find your co-foundr" now points to `/school/${slug}/sign-in?redirect=.../dashboard` instead of a dead `#departments` anchor.

### Infra
- Swap the Groq semantic search model in `src/lib/searchQueryParser.ts` from `llama-3.3-70b-versatile` to `openai/gpt-oss-20b`.

## Testing
- Not stated in the diff — recommend manually exercising: viewing the founder-archetypes page signed-out and signed-in (pre/post onboarding), confirming intent badges render correctly for all three intent values across dashboard/search/modal, and re-running a semantic dashboard search to confirm the new Groq model still parses queries within the 1.5s timeout.

## Notes
- The bulk of the diff in `dashboard/page.tsx` and `ProfileViewModal.tsx` is Prettier reformatting (line-wrapping imports/JSX, `flex-shrink-0` → reordered utility classes, etc.) with no behavior change — worth a quick skim rather than a line-by-line review.
- `/founder-archetypes` (global, non-school-prefixed) is not defined in this diff; if it exists elsewhere it's now orphaned from these two entry points.
